### PR TITLE
metricbeat: fix modernize lint findings

### DIFF
--- a/metricbeat/module/beat/state/data.go
+++ b/metricbeat/module/beat/state/data.go
@@ -71,7 +71,7 @@ func eventMapping(r mb.ReporterV2, info beat.Info, content []byte, isXpack bool)
 		ModuleFields: mapstr.M{},
 	}
 
-	var data map[string]interface{}
+	var data map[string]any
 	err := json.Unmarshal(content, &data)
 	if err != nil {
 		return fmt.Errorf("failure parsing Beat's State API response: %w", err)
@@ -147,13 +147,13 @@ func eventMapping(r mb.ReporterV2, info beat.Info, content []byte, isXpack bool)
 	return nil
 }
 
-func getClusterUUID(state map[string]interface{}) string {
+func getClusterUUID(state map[string]any) string {
 	o, exists := state["outputs"]
 	if !exists {
 		return ""
 	}
 
-	outputs, ok := o.(map[string]interface{})
+	outputs, ok := o.(map[string]any)
 	if !ok {
 		return ""
 	}
@@ -163,7 +163,7 @@ func getClusterUUID(state map[string]interface{}) string {
 		return ""
 	}
 
-	elasticsearch, ok := e.(map[string]interface{})
+	elasticsearch, ok := e.(map[string]any)
 	if !ok {
 		return ""
 	}
@@ -181,13 +181,13 @@ func getClusterUUID(state map[string]interface{}) string {
 	return clusterUUID
 }
 
-func isOutputES(state map[string]interface{}) bool {
+func isOutputES(state map[string]any) bool {
 	o, exists := state["output"]
 	if !exists {
 		return false
 	}
 
-	output, ok := o.(map[string]interface{})
+	output, ok := o.(map[string]any)
 	if !ok {
 		return false
 	}
@@ -205,13 +205,13 @@ func isOutputES(state map[string]interface{}) bool {
 	return name == "elasticsearch"
 }
 
-func getMonitoringClusterUUID(state map[string]interface{}) string {
+func getMonitoringClusterUUID(state map[string]any) string {
 	m, exists := state["monitoring"]
 	if !exists {
 		return ""
 	}
 
-	monitoring, ok := m.(map[string]interface{})
+	monitoring, ok := m.(map[string]any)
 	if !ok {
 		return ""
 	}

--- a/metricbeat/module/beat/state/data_test.go
+++ b/metricbeat/module/beat/state/data_test.go
@@ -20,7 +20,7 @@
 package state
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -42,7 +42,7 @@ func TestEventMapping(t *testing.T) {
 	}
 
 	for _, f := range files {
-		input, err := ioutil.ReadFile(f)
+		input, err := os.ReadFile(f)
 		require.NoError(t, err)
 
 		reporter := &mbtest.CapturingReporterV2{}
@@ -62,7 +62,7 @@ func TestUuidFromEsOutput(t *testing.T) {
 		Beat: "testbeat",
 	}
 
-	input, err := ioutil.ReadFile("./_meta/test/uuid_es_output.json")
+	input, err := os.ReadFile("./_meta/test/uuid_es_output.json")
 	require.NoError(t, err)
 
 	err = eventMapping(reporter, info, input, true)
@@ -86,7 +86,7 @@ func TestNoEventIfEsOutputButNoUuidYet(t *testing.T) {
 		Beat: "testbeat",
 	}
 
-	input, err := ioutil.ReadFile("./_meta/test/uuid_es_output_pre_connect.json")
+	input, err := os.ReadFile("./_meta/test/uuid_es_output_pre_connect.json")
 	require.NoError(t, err)
 
 	err = eventMapping(reporter, info, input, true)
@@ -103,7 +103,7 @@ func TestUuidFromMonitoringConfig(t *testing.T) {
 		Beat: "testbeat",
 	}
 
-	input, err := ioutil.ReadFile("./_meta/test/uuid_monitoring_config.json")
+	input, err := os.ReadFile("./_meta/test/uuid_monitoring_config.json")
 	require.NoError(t, err)
 
 	err = eventMapping(reporter, info, input, true)
@@ -127,7 +127,7 @@ func TestNoUuidInMonitoringConfig(t *testing.T) {
 		Beat: "testbeat",
 	}
 
-	input, err := ioutil.ReadFile("./_meta/test/uuid_no_monitoring_config.json")
+	input, err := os.ReadFile("./_meta/test/uuid_no_monitoring_config.json")
 	require.NoError(t, err)
 
 	err = eventMapping(reporter, info, input, true)

--- a/metricbeat/module/beat/stats/data.go
+++ b/metricbeat/module/beat/stats/data.go
@@ -156,7 +156,7 @@ func eventMapping(r mb.ReporterV2, info beat.Info, clusterUUID string, content [
 		event.ModuleFields.Put("elasticsearch.cluster.id", clusterUUID)
 	}
 
-	var data map[string]interface{}
+	var data map[string]any
 	err := json.Unmarshal(content, &data)
 	if err != nil {
 		return fmt.Errorf("failure parsing Beat's Stats API response: %w", err)

--- a/metricbeat/module/beat/stats/data_test.go
+++ b/metricbeat/module/beat/stats/data_test.go
@@ -20,7 +20,8 @@
 package stats
 
 import (
-	"io/ioutil"
+	"os"
+
 	"path/filepath"
 	"testing"
 
@@ -44,7 +45,7 @@ func TestEventMapping(t *testing.T) {
 	clusterUUID := "foo"
 
 	for _, f := range files {
-		input, err := ioutil.ReadFile(f)
+		input, err := os.ReadFile(f)
 		require.NoError(t, err)
 
 		reporter := &mbtest.CapturingReporterV2{}

--- a/metricbeat/module/beat/testing.go
+++ b/metricbeat/module/beat/testing.go
@@ -18,8 +18,8 @@
 package beat
 
 // GetConfig for Metricbeat
-func GetConfig(metricset string, host string) map[string]interface{} {
-	return map[string]interface{}{
+func GetConfig(metricset string, host string) map[string]any {
+	return map[string]any{
 		"module":     ModuleName,
 		"metricsets": []string{metricset},
 		"hosts":      []string{host},

--- a/metricbeat/module/elasticsearch/ccr/ccr_test.go
+++ b/metricbeat/module/elasticsearch/ccr/ccr_test.go
@@ -18,7 +18,8 @@
 package ccr
 
 import (
-	"io/ioutil"
+	"os"
+
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -44,7 +45,7 @@ func createEsMuxer(esVersion, license string, ccrEnabled bool) *http.ServeMux {
 			http.NotFound(w, r)
 		}
 
-		input, _ := ioutil.ReadFile("./_meta/test/root.710.json")
+		input, _ := os.ReadFile("./_meta/test/root.710.json")
 		input = []byte(strings.Replace(string(input), "7.10.0", esVersion, -1))
 		w.Write(input)
 	}
@@ -112,8 +113,8 @@ func TestCCRNotAvailable(t *testing.T) {
 	}
 }
 
-func getConfig(host string) map[string]interface{} {
-	return map[string]interface{}{
+func getConfig(host string) map[string]any {
+	return map[string]any{
 		"module":     elasticsearch.ModuleName,
 		"metricsets": []string{"ccr"},
 		"hosts":      []string{host},

--- a/metricbeat/module/elasticsearch/ccr/data.go
+++ b/metricbeat/module/elasticsearch/ccr/data.go
@@ -126,10 +126,10 @@ var (
 )
 
 type response struct {
-	AutoFollowStats map[string]interface{} `json:"auto_follow_stats"`
+	AutoFollowStats map[string]any `json:"auto_follow_stats"`
 	FollowStats     struct {
 		Indices []struct {
-			Shards []map[string]interface{} `json:"shards"`
+			Shards []map[string]any `json:"shards"`
 		} `json:"indices"`
 	} `json:"follow_stats"`
 }

--- a/metricbeat/module/elasticsearch/ccr/data_test.go
+++ b/metricbeat/module/elasticsearch/ccr/data_test.go
@@ -20,9 +20,9 @@
 package ccr
 
 import (
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -41,7 +41,7 @@ func TestMapper(t *testing.T) {
 }
 
 func TestEmpty(t *testing.T) {
-	input, err := ioutil.ReadFile("./_meta/test/empty.700.json")
+	input, err := os.ReadFile("./_meta/test/empty.700.json")
 	require.NoError(t, err)
 
 	reporter := &mbtest.CapturingReporterV2{}
@@ -53,7 +53,7 @@ func TestEmpty(t *testing.T) {
 func TestData(t *testing.T) {
 	mux := createEsMuxer("7.6.0", "platinum", true)
 	mux.Handle("/_ccr/stats", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		input, _ := ioutil.ReadFile("./_meta/test/ccr_stats.700.json")
+		input, _ := os.ReadFile("./_meta/test/ccr_stats.700.json")
 		w.Write(input)
 	}))
 

--- a/metricbeat/module/elasticsearch/cluster_stats/data.go
+++ b/metricbeat/module/elasticsearch/cluster_stats/data.go
@@ -143,14 +143,14 @@ func computeNodesHash(clusterState mapstr.M) (int32, error) {
 		return 0, elastic.MakeErrorForMissingField("nodes", elastic.Elasticsearch)
 	}
 
-	nodes, ok := value.(map[string]interface{})
+	nodes, ok := value.(map[string]any)
 	if !ok {
 		return 0, fmt.Errorf("nodes is not a map")
 	}
 
 	var nodeEphemeralIDs []string
 	for _, value := range nodes {
-		nodeData, ok := value.(map[string]interface{})
+		nodeData, ok := value.(map[string]any)
 		if !ok {
 			return 0, fmt.Errorf("node data is not a map")
 		}
@@ -186,7 +186,7 @@ func apmIndicesExist(clusterState mapstr.M) (bool, error) {
 		return false, elastic.MakeErrorForMissingField("routing_table.indices", elastic.Elasticsearch)
 	}
 
-	indices, ok := value.(map[string]interface{})
+	indices, ok := value.(map[string]any)
 	if !ok {
 		return false, fmt.Errorf("routing table indices is not a map")
 	}
@@ -223,7 +223,7 @@ func eventMapping(
 	content []byte,
 	isXpack bool,
 	_ *logp.Logger) error {
-	var data map[string]interface{}
+	var data map[string]any
 	err := json.Unmarshal(content, &data)
 	if err != nil {
 		return fmt.Errorf("failure parsing Elasticsearch Cluster Stats API response: %w", err)
@@ -287,9 +287,9 @@ func eventMapping(
 	}
 	delete(clusterState, "routing_table") // We don't want to index the routing table in monitoring indices
 
-	stackStats := map[string]interface{}{
+	stackStats := map[string]any{
 		"xpack": usage,
-		"apm": map[string]interface{}{
+		"apm": map[string]any{
 			"found": isAPMFound,
 		},
 	}

--- a/metricbeat/module/elasticsearch/cluster_stats/data_test.go
+++ b/metricbeat/module/elasticsearch/cluster_stats/data_test.go
@@ -115,8 +115,8 @@ func TestData(t *testing.T) {
 		t.Fatal("write", err)
 	}
 }
-func getConfig(host string) map[string]interface{} {
-	return map[string]interface{}{
+func getConfig(host string) map[string]any {
+	return map[string]any{
 		"module":     elasticsearch.ModuleName,
 		"metricsets": []string{"cluster_stats"},
 		"hosts":      []string{host},

--- a/metricbeat/module/elasticsearch/elasticsearch.go
+++ b/metricbeat/module/elasticsearch/elasticsearch.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -150,7 +151,7 @@ func getNodeName(http *helper.HTTP, uri string) (string, error) {
 	}
 
 	nodesStruct := struct {
-		Nodes map[string]interface{} `json:"nodes"`
+		Nodes map[string]any `json:"nodes"`
 	}{}
 
 	err = json.Unmarshal(content, &nodesStruct)
@@ -261,7 +262,7 @@ func GetClusterState(http *helper.HTTP, resetURI string, metrics []string, filte
 		return nil, err
 	}
 
-	var clusterState map[string]interface{}
+	var clusterState map[string]any
 	err = json.Unmarshal(content, &clusterState)
 	return clusterState, err
 }
@@ -283,7 +284,7 @@ func GetIndexSettings(http *helper.HTTP, resetURI string, indexPattern string, f
 		return nil, err
 	}
 
-	var indicesSettings map[string]interface{}
+	var indicesSettings map[string]any
 	err = json.Unmarshal(content, &indicesSettings)
 	return indicesSettings, err
 }
@@ -313,19 +314,19 @@ func GetClusterSettings(http *helper.HTTP, resetURI string, includeDefaults bool
 		return nil, err
 	}
 
-	var clusterSettings map[string]interface{}
+	var clusterSettings map[string]any
 	err = json.Unmarshal(content, &clusterSettings)
 	return clusterSettings, err
 }
 
 // GetStackUsage returns stack usage information.
-func GetStackUsage(http *helper.HTTP, resetURI string) (map[string]interface{}, error) {
+func GetStackUsage(http *helper.HTTP, resetURI string) (map[string]any, error) {
 	content, err := fetchPath(http, resetURI, "_xpack/usage", "")
 	if err != nil {
 		return nil, err
 	}
 
-	var stackUsage map[string]interface{}
+	var stackUsage map[string]any
 	err = json.Unmarshal(content, &stackUsage)
 	return stackUsage, err
 }
@@ -454,13 +455,7 @@ func (c *_licenseCache) set(license *License, ttl time.Duration) {
 func (l *License) IsOneOf(candidateLicenses ...string) bool {
 	t := l.Type
 
-	for _, candidateLicense := range candidateLicenses {
-		if candidateLicense == t {
-			return true
-		}
-	}
-
-	return false
+	return slices.Contains(candidateLicenses, t)
 }
 
 // ToMapStr converts the license to a mapstr.M. This is necessary
@@ -514,7 +509,7 @@ func getSettingGroup(allSettings mapstr.M, groupKey string) (mapstr.M, error) {
 		return nil, fmt.Errorf("failure to extract %s settings: %w", groupKey, err)
 	}
 
-	v, ok := settings.(map[string]interface{})
+	v, ok := settings.(map[string]any)
 	if !ok {
 		return nil, fmt.Errorf("%s settings are not a map", groupKey)
 	}

--- a/metricbeat/module/elasticsearch/elasticsearch_integration_test.go
+++ b/metricbeat/module/elasticsearch/elasticsearch_integration_test.go
@@ -155,8 +155,8 @@ func TestGetAllIndices(t *testing.T) {
 }
 
 // GetConfig returns config for elasticsearch module
-func getConfigForMetricset(metricset string, host string) map[string]interface{} {
-	return map[string]interface{}{
+func getConfigForMetricset(metricset string, host string) map[string]any {
+	return map[string]any{
 		"module":                     elasticsearch.ModuleName,
 		"metricsets":                 []string{metricset},
 		"hosts":                      []string{host},
@@ -164,8 +164,8 @@ func getConfigForMetricset(metricset string, host string) map[string]interface{}
 	}
 }
 
-func getConfig(host string) map[string]interface{} {
-	return map[string]interface{}{
+func getConfig(host string) map[string]any {
+	return map[string]any{
 		"module":     elasticsearch.ModuleName,
 		"metricsets": metricSets,
 		"hosts":      []string{host},
@@ -386,7 +386,7 @@ func checkCCRStatsExists(host string) (bool, error) {
 
 	var data struct {
 		FollowStats struct {
-			Indices []map[string]interface{} `json:"indices"`
+			Indices []map[string]any `json:"indices"`
 		} `json:"follow_stats"`
 	}
 	err = json.Unmarshal(body, &data)

--- a/metricbeat/module/elasticsearch/enrich/data.go
+++ b/metricbeat/module/elasticsearch/enrich/data.go
@@ -64,8 +64,8 @@ var (
 )
 
 type response struct {
-	ExecutingPolicies []map[string]interface{} `json:"executing_policies"`
-	CoordinatorStats  []map[string]interface{} `json:"coordinator_stats"`
+	ExecutingPolicies []map[string]any `json:"executing_policies"`
+	CoordinatorStats  []map[string]any `json:"coordinator_stats"`
 }
 
 func eventsMapping(r mb.ReporterV2, info elasticsearch.Info, content []byte, isXpack bool) error {
@@ -130,7 +130,7 @@ func eventsMapping(r mb.ReporterV2, info elasticsearch.Info, content []byte, isX
 			continue
 		}
 
-		taskMapstr, ok := taskData.(map[string]interface{})
+		taskMapstr, ok := taskData.(map[string]any)
 		if !ok {
 			errs = append(errs, errors.New("error trying to convert interface of task data into a map"))
 			continue

--- a/metricbeat/module/elasticsearch/enrich/data_test.go
+++ b/metricbeat/module/elasticsearch/enrich/data_test.go
@@ -20,9 +20,9 @@
 package enrich
 
 import (
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -41,7 +41,7 @@ func TestMapper(t *testing.T) {
 }
 
 func TestEmpty(t *testing.T) {
-	input, err := ioutil.ReadFile("./_meta/test/empty.750.json")
+	input, err := os.ReadFile("./_meta/test/empty.750.json")
 	require.NoError(t, err)
 
 	reporter := &mbtest.CapturingReporterV2{}
@@ -76,13 +76,13 @@ func createEsMuxer(esVersion, license string, ccrEnabled bool) *http.ServeMux {
 
 	mux.Handle("/_xpack/usage", http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
-			input, _ := ioutil.ReadFile("./_meta/test/xpack-usage.710.json")
+			input, _ := os.ReadFile("./_meta/test/xpack-usage.710.json")
 			w.Write(input)
 		}))
 
 	mux.Handle("/_enrich/_stats", http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
-			input, _ := ioutil.ReadFile("./_meta/test/enrich_stats.750.json")
+			input, _ := os.ReadFile("./_meta/test/enrich_stats.750.json")
 			w.Write(input)
 		}))
 
@@ -100,8 +100,8 @@ func TestData(t *testing.T) {
 		t.Fatal("write", err)
 	}
 }
-func getConfig(host string) map[string]interface{} {
-	return map[string]interface{}{
+func getConfig(host string) map[string]any {
+	return map[string]any{
 		"module":     elasticsearch.ModuleName,
 		"metricsets": []string{"enrich"},
 		"hosts":      []string{host},

--- a/metricbeat/module/elasticsearch/index/data.go
+++ b/metricbeat/module/elasticsearch/index/data.go
@@ -309,7 +309,7 @@ func addIndexSettings(idx *Index, indicesSettings mapstr.M) error {
 		return fmt.Errorf("failed to get index settings for index %s: %w", idx.Index, err)
 	}
 
-	indexSettings, ok := indexSettingsValue.(map[string]interface{})
+	indexSettings, ok := indexSettingsValue.(map[string]any)
 	if !ok {
 		return fmt.Errorf("index settings is not a map for index: %s", idx.Index)
 	}
@@ -369,14 +369,14 @@ func getClusterStateMetricForIndex(clusterState mapstr.M, index, metricKey strin
 		return nil, fmt.Errorf("'"+fieldKey+"': %w", err)
 	}
 
-	metric, ok := value.(map[string]interface{})
+	metric, ok := value.(map[string]any)
 	if !ok {
 		return nil, elastic.MakeErrorForMissingField(fieldKey, elastic.Elasticsearch)
 	}
 	return mapstr.M(metric), nil
 }
 
-func getIndexStatus(shards map[string]interface{}) (string, error) {
+func getIndexStatus(shards map[string]any) (string, error) {
 	if len(shards) == 0 {
 		// No shards, index is red
 		return "red", nil
@@ -386,13 +386,13 @@ func getIndexStatus(shards map[string]interface{}) (string, error) {
 	areAllReplicasStarted := true
 
 	for indexName, indexShard := range shards {
-		is, ok := indexShard.([]interface{})
+		is, ok := indexShard.([]any)
 		if !ok {
 			return "", fmt.Errorf("shards is not an array")
 		}
 
 		for shardIdx, shard := range is {
-			s, ok := shard.(map[string]interface{})
+			s, ok := shard.(map[string]any)
 			if !ok {
 				return "", fmt.Errorf("%v.shards[%v] is not a map", indexName, shardIdx)
 			}
@@ -442,13 +442,13 @@ func getIndexShardStats(shards mapstr.M) (*shardStats, error) {
 	relocating := 0
 
 	for indexName, indexShard := range shards {
-		is, ok := indexShard.([]interface{})
+		is, ok := indexShard.([]any)
 		if !ok {
 			return nil, fmt.Errorf("shards is not an array")
 		}
 
 		for shardIdx, shard := range is {
-			s, ok := shard.(map[string]interface{})
+			s, ok := shard.(map[string]any)
 			if !ok {
 				return nil, fmt.Errorf("%v.shards[%v] is not a map", indexName, shardIdx)
 			}
@@ -507,13 +507,13 @@ func getIndexShardStats(shards mapstr.M) (*shardStats, error) {
 	}, nil
 }
 
-func getShardsFromRoutingTable(indexRoutingTable mapstr.M) (map[string]interface{}, error) {
+func getShardsFromRoutingTable(indexRoutingTable mapstr.M) (map[string]any, error) {
 	s, err := indexRoutingTable.GetValue("shards")
 	if err != nil {
 		return nil, err
 	}
 
-	shards, ok := s.(map[string]interface{})
+	shards, ok := s.(map[string]any)
 	if !ok {
 		return nil, elastic.MakeErrorForMissingField("shards", elastic.Elasticsearch)
 	}

--- a/metricbeat/module/elasticsearch/index/data_test.go
+++ b/metricbeat/module/elasticsearch/index/data_test.go
@@ -21,9 +21,9 @@ package index
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -79,7 +79,7 @@ func TestEmpty(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	input, err := ioutil.ReadFile("./_meta/test/empty.512.json")
+	input, err := os.ReadFile("./_meta/test/empty.512.json")
 	require.NoError(t, err)
 
 	reporter := &mbtest.CapturingReporterV2{}
@@ -96,16 +96,16 @@ func createEsMuxer(esVersion, license string, ccrEnabled bool) *http.ServeMux {
 	}
 	rootHandler := func(w http.ResponseWriter, r *http.Request) {
 		if strings.Contains(r.URL.Path, "_stats") {
-			input, _ := ioutil.ReadFile(fmt.Sprintf("./_meta/test/stats.%s.json", esVersion))
+			input, _ := os.ReadFile(fmt.Sprintf("./_meta/test/stats.%s.json", esVersion))
 			w.Write(input)
 			return
 		} else if r.URL.Path != "/" {
-			input, _ := ioutil.ReadFile(fmt.Sprintf("./_meta/test/settings.%s.json", esVersion))
+			input, _ := os.ReadFile(fmt.Sprintf("./_meta/test/settings.%s.json", esVersion))
 			w.Write(input)
 			return
 		}
 
-		input, _ := ioutil.ReadFile(fmt.Sprintf("./_meta/test/root.%s.json", esVersion))
+		input, _ := os.ReadFile(fmt.Sprintf("./_meta/test/root.%s.json", esVersion))
 		w.Write(input)
 
 	}
@@ -121,13 +121,13 @@ func createEsMuxer(esVersion, license string, ccrEnabled bool) *http.ServeMux {
 
 	mux.Handle("/_xpack/usage", http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
-			input, _ := ioutil.ReadFile(fmt.Sprintf("./_meta/test/xpack-usage.%s.json", esVersion))
+			input, _ := os.ReadFile(fmt.Sprintf("./_meta/test/xpack-usage.%s.json", esVersion))
 			w.Write(input)
 		}))
 
 	mux.Handle("/_cluster/state/routing_table", http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
-			input, _ := ioutil.ReadFile(fmt.Sprintf("./_meta/test/cluster_state.%s.json", esVersion))
+			input, _ := os.ReadFile(fmt.Sprintf("./_meta/test/cluster_state.%s.json", esVersion))
 			w.Write(input)
 		}))
 
@@ -147,8 +147,8 @@ func TestData(t *testing.T) {
 		t.Fatal("errors writing events to data.json file", err)
 	}
 }
-func getConfig(host string) map[string]interface{} {
-	return map[string]interface{}{
+func getConfig(host string) map[string]any {
+	return map[string]any{
 		"module":     elasticsearch.ModuleName,
 		"metricsets": []string{"index"},
 		"hosts":      []string{host},

--- a/metricbeat/module/elasticsearch/index/index_test.go
+++ b/metricbeat/module/elasticsearch/index/index_test.go
@@ -72,7 +72,7 @@ func TestGetServiceURIMultipleCalls(t *testing.T) {
 
 		var uri string
 		var err error
-		for i := uint(0); i < numCalls; i++ {
+		for range numCalls {
 			uri, err = getServicePath(*version.MustNew("8.0.0"))
 			if err != nil {
 				return false

--- a/metricbeat/module/elasticsearch/index_recovery/data.go
+++ b/metricbeat/module/elasticsearch/index_recovery/data.go
@@ -89,7 +89,7 @@ var (
 
 func eventsMapping(r mb.ReporterV2, info elasticsearch.Info, content []byte, isXpack bool) error {
 
-	var data map[string]map[string][]map[string]interface{}
+	var data map[string]map[string][]map[string]any
 
 	err := json.Unmarshal(content, &data)
 	if err != nil {

--- a/metricbeat/module/elasticsearch/index_recovery/data_test.go
+++ b/metricbeat/module/elasticsearch/index_recovery/data_test.go
@@ -20,9 +20,9 @@
 package index_recovery
 
 import (
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	mbtest "github.com/elastic/beats/v7/metricbeat/mb/testing"
@@ -46,7 +46,7 @@ func createEsMuxer(license string) *http.ServeMux {
 			http.NotFound(w, r)
 		}
 
-		input, _ := ioutil.ReadFile("./_meta/test/root.710.json")
+		input, _ := os.ReadFile("./_meta/test/root.710.json")
 		w.Write(input)
 	}
 	licenseHandler := func(w http.ResponseWriter, r *http.Request) {
@@ -60,7 +60,7 @@ func createEsMuxer(license string) *http.ServeMux {
 	mux.Handle("/_xpack/license", http.HandlerFunc(licenseHandler)) // for before 7.0
 	mux.Handle("/", http.HandlerFunc(rootHandler))
 	mux.Handle("/_recovery", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		content, _ := ioutil.ReadFile("./_meta/test/recovery.710.json")
+		content, _ := os.ReadFile("./_meta/test/recovery.710.json")
 		w.Write(content)
 	}))
 
@@ -79,8 +79,8 @@ func TestData(t *testing.T) {
 	}
 }
 
-func getConfig(host string) map[string]interface{} {
-	return map[string]interface{}{
+func getConfig(host string) map[string]any {
+	return map[string]any{
 		"module":                     elasticsearch.ModuleName,
 		"metricsets":                 []string{"index_recovery"},
 		"hosts":                      []string{host},

--- a/metricbeat/module/elasticsearch/index_summary/data.go
+++ b/metricbeat/module/elasticsearch/index_summary/data.go
@@ -31,7 +31,7 @@ import (
 )
 
 type nodeStatsWrapper struct {
-	Nodes map[string]interface{} `json:"nodes"`
+	Nodes map[string]any `json:"nodes"`
 }
 
 var nodeItemSchema = s.Schema{
@@ -161,8 +161,8 @@ func eventMapping(r mb.ReporterV2, info elasticsearch.Info, content []byte, isXP
 	return nil
 }
 
-func addNodeMetrics(rawNode interface{}, summary *IndexSummary) error {
-	nodeMap, ok := rawNode.(map[string]interface{})
+func addNodeMetrics(rawNode any, summary *IndexSummary) error {
+	nodeMap, ok := rawNode.(map[string]any)
 	if !ok {
 		return fmt.Errorf("node is not a map")
 	}
@@ -202,7 +202,7 @@ func addNodeMetrics(rawNode interface{}, summary *IndexSummary) error {
 }
 
 func getInt64(m mapstr.M, path ...string) (int64, error) {
-	current := interface{}(m)
+	current := any(m)
 	for _, key := range path {
 		mm, ok := current.(mapstr.M)
 		if !ok {
@@ -223,7 +223,7 @@ func getInt64(m mapstr.M, path ...string) (int64, error) {
 }
 
 func buildEvent(info *elasticsearch.Info, summary *IndexSummary, isXPack bool) mb.Event {
-	eventNew := map[string]interface{}{
+	eventNew := map[string]any{
 		"primaries": summary,
 		"total":     summary,
 	}

--- a/metricbeat/module/elasticsearch/index_summary/data_test.go
+++ b/metricbeat/module/elasticsearch/index_summary/data_test.go
@@ -202,8 +202,8 @@ func TestEmpty(t *testing.T) {
 	require.Equal(t, 0, len(reporter.GetEvents()))
 }
 
-func getConfig(host string) map[string]interface{} {
-	return map[string]interface{}{
+func getConfig(host string) map[string]any {
+	return map[string]any{
 		"module":                     elasticsearch.ModuleName,
 		"metricsets":                 []string{"index_summary"},
 		"hosts":                      []string{host},

--- a/metricbeat/module/elasticsearch/ingest_pipeline/data_test.go
+++ b/metricbeat/module/elasticsearch/ingest_pipeline/data_test.go
@@ -18,7 +18,7 @@
 package ingest_pipeline
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -36,7 +36,7 @@ func TestMapper(t *testing.T) {
 		ClusterName: "helloworld",
 	}
 
-	ingestData, err := ioutil.ReadFile("./_meta/test/stats.json")
+	ingestData, err := os.ReadFile("./_meta/test/stats.json")
 	require.NoError(t, err)
 
 	err = eventsMapping(reporter, info, ingestData, true, true)
@@ -92,7 +92,7 @@ func TestSampling(t *testing.T) {
 		ClusterName: "helloworld",
 	}
 
-	ingestData, err := ioutil.ReadFile("./_meta/test/stats.json")
+	ingestData, err := os.ReadFile("./_meta/test/stats.json")
 	require.NoError(t, err)
 
 	err = eventsMapping(reporter, info, ingestData, true, false) // set sampling to false
@@ -117,7 +117,7 @@ func TestSampling(t *testing.T) {
 	require.Equal(t, 0, len(processorEvents))
 }
 
-func requireMetricSetFields(t *testing.T, event mb.Event, fieldName string, expected interface{}) {
+func requireMetricSetFields(t *testing.T, event mb.Event, fieldName string, expected any) {
 	val, err := event.MetricSetFields.GetValue(fieldName)
 	require.NoError(t, err)
 	require.Equal(t, expected, val)

--- a/metricbeat/module/elasticsearch/metricset.go
+++ b/metricbeat/module/elasticsearch/metricset.go
@@ -197,7 +197,7 @@ func (m *MetricSet) GetMasterNodeID() (string, error) {
 	}
 
 	var response struct {
-		Nodes map[string]interface{} `json:"nodes"`
+		Nodes map[string]any `json:"nodes"`
 	}
 
 	if err := json.Unmarshal(content, &response); err != nil {

--- a/metricbeat/module/elasticsearch/ml_job/data.go
+++ b/metricbeat/module/elasticsearch/ml_job/data.go
@@ -49,7 +49,7 @@ var (
 )
 
 type jobsStruct struct {
-	Jobs []map[string]interface{} `json:"jobs"`
+	Jobs []map[string]any `json:"jobs"`
 }
 
 func eventsMapping(r mb.ReporterV2, info elasticsearch.Info, content []byte, isXpack bool) error {
@@ -82,7 +82,7 @@ func eventsMapping(r mb.ReporterV2, info elasticsearch.Info, content []byte, isX
 		event.ModuleFields.Put("cluster.id", info.ClusterID)
 
 		if node, exists := job["node"]; exists {
-			nodeHash, ok := node.(map[string]interface{})
+			nodeHash, ok := node.(map[string]any)
 			if !ok {
 				errs = append(errs, errors.New("job[node] is not a map"))
 				continue

--- a/metricbeat/module/elasticsearch/ml_job/data_test.go
+++ b/metricbeat/module/elasticsearch/ml_job/data_test.go
@@ -20,9 +20,9 @@
 package ml_job
 
 import (
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strconv"
 	"strings"
 	"testing"
@@ -50,7 +50,7 @@ func TestData(t *testing.T) {
 			http.NotFound(w, r)
 		}
 
-		input, _ := ioutil.ReadFile("./_meta/test/root.710.json")
+		input, _ := os.ReadFile("./_meta/test/root.710.json")
 		input = []byte(strings.Replace(string(input), "7.10.0", "7.10.0", -1))
 		w.Write(input)
 	}
@@ -70,7 +70,7 @@ func TestData(t *testing.T) {
 	mux.Handle("/_xpack", http.HandlerFunc(xpackHandler))
 
 	mux.Handle("/_ml/anomaly_detectors/_all/_stats", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		input, _ := ioutil.ReadFile("./_meta/test/ml.711.json")
+		input, _ := os.ReadFile("./_meta/test/ml.711.json")
 		w.Write(input)
 	}))
 

--- a/metricbeat/module/elasticsearch/ml_job/ml_job_test.go
+++ b/metricbeat/module/elasticsearch/ml_job/ml_job_test.go
@@ -18,7 +18,8 @@
 package ml_job
 
 import (
-	"io/ioutil"
+	"os"
+
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -45,7 +46,7 @@ func createEsMuxer(mlEnabled bool) *http.ServeMux {
 			http.NotFound(w, r)
 		}
 
-		input, _ := ioutil.ReadFile("./_meta/test/root.710.json")
+		input, _ := os.ReadFile("./_meta/test/root.710.json")
 		input = []byte(strings.Replace(string(input), "7.10.0", "7.10.0", -1))
 		w.Write(input)
 	}
@@ -106,8 +107,8 @@ func TestMLNotAvailable(t *testing.T) {
 	}
 }
 
-func getConfig(host string) map[string]interface{} {
-	return map[string]interface{}{
+func getConfig(host string) map[string]any {
+	return map[string]any{
 		"module":     elasticsearch.ModuleName,
 		"metricsets": []string{"ml_job"},
 		"hosts":      []string{host},

--- a/metricbeat/module/elasticsearch/node/data.go
+++ b/metricbeat/module/elasticsearch/node/data.go
@@ -64,8 +64,8 @@ var (
 
 func eventsMapping(r mb.ReporterV2, info elasticsearch.Info, content []byte, isXpack bool) error {
 	nodesStruct := struct {
-		ClusterName string                            `json:"cluster_name"`
-		Nodes       map[string]map[string]interface{} `json:"nodes"`
+		ClusterName string                    `json:"cluster_name"`
+		Nodes       map[string]map[string]any `json:"nodes"`
 	}{}
 
 	err := json.Unmarshal(content, &nodesStruct)

--- a/metricbeat/module/elasticsearch/node/data_test.go
+++ b/metricbeat/module/elasticsearch/node/data_test.go
@@ -20,7 +20,8 @@
 package node
 
 import (
-	"io/ioutil"
+	"os"
+
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -42,7 +43,7 @@ func TestGetMappings(t *testing.T) {
 func TestInvalid(t *testing.T) {
 	file := "./_meta/test/invalid.json"
 
-	content, err := ioutil.ReadFile(file)
+	content, err := os.ReadFile(file)
 	require.NoError(t, err)
 
 	reporter := &mbtest.CapturingReporterV2{}

--- a/metricbeat/module/elasticsearch/node/node_test.go
+++ b/metricbeat/module/elasticsearch/node/node_test.go
@@ -66,7 +66,7 @@ func TestFetch(t *testing.T) {
 			}))
 			defer server.Close()
 
-			config := map[string]interface{}{
+			config := map[string]any{
 				"module":     elasticsearch.ModuleName,
 				"metricsets": []string{"node"},
 				"hosts":      []string{server.URL},

--- a/metricbeat/module/elasticsearch/node_stats/data.go
+++ b/metricbeat/module/elasticsearch/node_stats/data.go
@@ -428,7 +428,7 @@ var (
 )
 
 type nodesStruct struct {
-	Nodes map[string]map[string]interface{} `json:"nodes"`
+	Nodes map[string]map[string]any `json:"nodes"`
 }
 
 func eventsMapping(r mb.ReporterV2, m elasticsearch.MetricSetAPI, info elasticsearch.Info, content []byte, isXpack bool) error {

--- a/metricbeat/module/elasticsearch/node_stats/data_test.go
+++ b/metricbeat/module/elasticsearch/node_stats/data_test.go
@@ -58,7 +58,7 @@ func (m mockModule) Config() mb.ModuleConfig {
 	}
 }
 
-func (m mockModule) UnpackConfig(to interface{}) error {
+func (m mockModule) UnpackConfig(to any) error {
 	return nil
 }
 

--- a/metricbeat/module/elasticsearch/pending_tasks/data.go
+++ b/metricbeat/module/elasticsearch/pending_tasks/data.go
@@ -41,7 +41,7 @@ var (
 
 func eventsMapping(r mb.ReporterV2, info elasticsearch.Info, content []byte, isXpack bool) error {
 	tasksStruct := struct {
-		Tasks []map[string]interface{} `json:"tasks"`
+		Tasks []map[string]any `json:"tasks"`
 	}{}
 
 	err := json.Unmarshal(content, &tasksStruct)

--- a/metricbeat/module/elasticsearch/pending_tasks/data_test.go
+++ b/metricbeat/module/elasticsearch/pending_tasks/data_test.go
@@ -20,7 +20,7 @@
 package pending_tasks
 
 import (
-	"io/ioutil"
+	"os"
 	"reflect"
 	"testing"
 	"time"
@@ -42,7 +42,7 @@ var info = elasticsearch.Info{
 
 func TestEmptyQueueShouldGiveNoError(t *testing.T) {
 	file := "./_meta/test/empty.json"
-	content, err := ioutil.ReadFile(file)
+	content, err := os.ReadFile(file)
 	require.NoError(t, err)
 
 	reporter := &mbtest.CapturingReporterV2{}
@@ -52,7 +52,7 @@ func TestEmptyQueueShouldGiveNoError(t *testing.T) {
 
 func TestNotEmptyQueueShouldGiveNoError(t *testing.T) {
 	file := "./_meta/test/tasks.622.json"
-	content, err := ioutil.ReadFile(file)
+	content, err := os.ReadFile(file)
 	require.NoError(t, err)
 
 	reporter := &mbtest.CapturingReporterV2{}
@@ -64,7 +64,7 @@ func TestNotEmptyQueueShouldGiveNoError(t *testing.T) {
 
 func TestEmptyQueueShouldGiveZeroEvent(t *testing.T) {
 	file := "./_meta/test/empty.json"
-	content, err := ioutil.ReadFile(file)
+	content, err := os.ReadFile(file)
 	require.NoError(t, err)
 
 	reporter := &mbtest.CapturingReporterV2{}
@@ -75,7 +75,7 @@ func TestEmptyQueueShouldGiveZeroEvent(t *testing.T) {
 
 func TestNotEmptyQueueShouldGiveSeveralEvents(t *testing.T) {
 	file := "./_meta/test/tasks.622.json"
-	content, err := ioutil.ReadFile(file)
+	content, err := os.ReadFile(file)
 	require.NoError(t, err)
 
 	reporter := &mbtest.CapturingReporterV2{}
@@ -86,7 +86,7 @@ func TestNotEmptyQueueShouldGiveSeveralEvents(t *testing.T) {
 
 func TestInvalidJsonForRequiredFieldShouldThrowError(t *testing.T) {
 	file := "./_meta/test/invalid_required_field.json"
-	content, err := ioutil.ReadFile(file)
+	content, err := os.ReadFile(file)
 	require.NoError(t, err)
 
 	reporter := &mbtest.CapturingReporterV2{}
@@ -96,7 +96,7 @@ func TestInvalidJsonForRequiredFieldShouldThrowError(t *testing.T) {
 
 func TestInvalidJsonForBadFormatShouldThrowError(t *testing.T) {
 	file := "./_meta/test/invalid_format.json"
-	content, err := ioutil.ReadFile(file)
+	content, err := os.ReadFile(file)
 	require.NoError(t, err)
 
 	reporter := &mbtest.CapturingReporterV2{}
@@ -198,7 +198,7 @@ func TestEventsMappedMatchToContentReceived(t *testing.T) {
 	}
 
 	for iter, testCase := range testCases {
-		content, err := ioutil.ReadFile(testCase.given)
+		content, err := os.ReadFile(testCase.given)
 		require.NoError(t, err)
 
 		reporter := &mbtest.CapturingReporterV2{}

--- a/metricbeat/module/elasticsearch/security_stats/data_test.go
+++ b/metricbeat/module/elasticsearch/security_stats/data_test.go
@@ -130,17 +130,17 @@ func TestMetricSetFieldsJSONShape(t *testing.T) {
 	raw, err := json.Marshal(events[0].MetricSetFields)
 	require.NoError(t, err)
 
-	var doc map[string]interface{}
+	var doc map[string]any
 	require.NoError(t, json.Unmarshal(raw, &doc))
 
-	want := map[string]interface{}{
-		"dls": map[string]interface{}{
-			"cache": map[string]interface{}{
-				"entries":   map[string]interface{}{"count": float64(1)},
-				"memory":    map[string]interface{}{"bytes": float64(2)},
-				"hits":      map[string]interface{}{"count": float64(3), "time": map[string]interface{}{"ms": float64(6)}},
-				"misses":    map[string]interface{}{"count": float64(4), "time": map[string]interface{}{"ms": float64(7)}},
-				"evictions": map[string]interface{}{"count": float64(5)},
+	want := map[string]any{
+		"dls": map[string]any{
+			"cache": map[string]any{
+				"entries":   map[string]any{"count": float64(1)},
+				"memory":    map[string]any{"bytes": float64(2)},
+				"hits":      map[string]any{"count": float64(3), "time": map[string]any{"ms": float64(6)}},
+				"misses":    map[string]any{"count": float64(4), "time": map[string]any{"ms": float64(7)}},
+				"evictions": map[string]any{"count": float64(5)},
 			},
 		},
 	}
@@ -161,7 +161,7 @@ func TestEventShapeWithEnrichment(t *testing.T) {
 	require.Equal(t, 1, len(events))
 	event := events[0]
 
-	for path, want := range map[string]interface{}{
+	for path, want := range map[string]any{
 		"cluster.id":   info.ClusterID,
 		"cluster.name": info.ClusterName,
 		"node.id":      nodeID,

--- a/metricbeat/module/elasticsearch/shard/data.go
+++ b/metricbeat/module/elasticsearch/shard/data.go
@@ -52,7 +52,7 @@ type stateStruct struct {
 	} `json:"nodes"`
 	RoutingTable struct {
 		Indices map[string]struct {
-			Shards map[string][]map[string]interface{} `json:"shards"`
+			Shards map[string][]map[string]any `json:"shards"`
 		} `json:"indices"`
 	} `json:"routing_table"`
 }

--- a/metricbeat/module/elasticsearch/shard/data_test.go
+++ b/metricbeat/module/elasticsearch/shard/data_test.go
@@ -18,9 +18,9 @@
 package shard
 
 import (
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -36,7 +36,7 @@ func TestStats(t *testing.T) {
 	require.NoError(t, err)
 
 	for _, f := range files {
-		input, err := ioutil.ReadFile(f)
+		input, err := os.ReadFile(f)
 		require.NoError(t, err)
 
 		reporter := &mbtest.CapturingReporterV2{}
@@ -58,7 +58,7 @@ func TestData(t *testing.T) {
 	}))
 	mux.Handle("/_cluster/state/version,nodes,master_node,routing_table", http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
-			input, _ := ioutil.ReadFile("./_meta/test/routing_table.710.json")
+			input, _ := os.ReadFile("./_meta/test/routing_table.710.json")
 			w.Write(input)
 		}))
 
@@ -70,8 +70,8 @@ func TestData(t *testing.T) {
 		t.Fatal("write", err)
 	}
 }
-func getConfig(host string) map[string]interface{} {
-	return map[string]interface{}{
+func getConfig(host string) map[string]any {
+	return map[string]any{
 		"module":     elasticsearch.ModuleName,
 		"metricsets": []string{"shard"},
 		"hosts":      []string{host},

--- a/metricbeat/module/elasticsearch/testing.go
+++ b/metricbeat/module/elasticsearch/testing.go
@@ -110,7 +110,7 @@ func TestMapperWithExpectedEvents(
 		actualBytes, err := json.Marshal(ev)
 		require.NoError(t, err)
 
-		var actual map[string]interface{}
+		var actual map[string]any
 		err = json.Unmarshal(actualBytes, &actual)
 		require.NoError(t, err)
 
@@ -137,13 +137,13 @@ func TestMapperExpectingError(
 	require.Equal(t, 0, len(events), "Number of events mismatch")
 }
 
-func loadExpectedEventsFromFiles(t *testing.T, files []string) []map[string]interface{} {
-	expected := make([]map[string]interface{}, 0, len(files))
+func loadExpectedEventsFromFiles(t *testing.T, files []string) []map[string]any {
+	expected := make([]map[string]any, 0, len(files))
 	for _, f := range files {
 		content, err := os.ReadFile(f)
 		require.NoError(t, err)
 
-		var ev map[string]interface{}
+		var ev map[string]any
 		err = json.Unmarshal(content, &ev)
 		require.NoError(t, err)
 

--- a/metricbeat/module/kibana/cluster_actions/data.go
+++ b/metricbeat/module/kibana/cluster_actions/data.go
@@ -43,9 +43,9 @@ var (
 )
 
 type response struct {
-	Actions     map[string]interface{} `json:"cluster_actions"`
-	Kibana      map[string]interface{} `json:"kibana"`
-	ClusterUuid string                 `json:"cluster_uuid"`
+	Actions     map[string]any `json:"cluster_actions"`
+	Kibana      map[string]any `json:"kibana"`
+	ClusterUuid string         `json:"cluster_uuid"`
 }
 
 func eventMapping(r mb.ReporterV2, content []byte, isXpack bool) error {

--- a/metricbeat/module/kibana/cluster_rules/data.go
+++ b/metricbeat/module/kibana/cluster_rules/data.go
@@ -43,9 +43,9 @@ var (
 )
 
 type response struct {
-	Rules       map[string]interface{} `json:"cluster_rules"`
-	Kibana      map[string]interface{} `json:"kibana"`
-	ClusterUuid string                 `json:"cluster_uuid"`
+	Rules       map[string]any `json:"cluster_rules"`
+	Kibana      map[string]any `json:"kibana"`
+	ClusterUuid string         `json:"cluster_uuid"`
 }
 
 func eventMapping(r mb.ReporterV2, content []byte, isXpack bool) error {

--- a/metricbeat/module/kibana/mtest/testing.go
+++ b/metricbeat/module/kibana/mtest/testing.go
@@ -18,8 +18,8 @@
 package mtest
 
 // GetConfig returns config for kibana module
-func GetConfig(metricset string, host string) map[string]interface{} {
-	config := map[string]interface{}{
+func GetConfig(metricset string, host string) map[string]any {
+	config := map[string]any{
 		"module":     "kibana",
 		"metricsets": []string{metricset},
 		"hosts":      []string{host},

--- a/metricbeat/module/kibana/node_actions/data.go
+++ b/metricbeat/module/kibana/node_actions/data.go
@@ -39,9 +39,9 @@ var (
 )
 
 type response struct {
-	Actions     map[string]interface{} `json:"node_actions"`
-	Kibana      map[string]interface{} `json:"kibana"`
-	ClusterUuid string                 `json:"cluster_uuid"`
+	Actions     map[string]any `json:"node_actions"`
+	Kibana      map[string]any `json:"kibana"`
+	ClusterUuid string         `json:"cluster_uuid"`
 }
 
 func eventMapping(r mb.ReporterV2, content []byte, isXpack bool) error {

--- a/metricbeat/module/kibana/node_rules/data.go
+++ b/metricbeat/module/kibana/node_rules/data.go
@@ -39,9 +39,9 @@ var (
 )
 
 type response struct {
-	Rules       map[string]interface{} `json:"node_rules"`
-	Kibana      map[string]interface{} `json:"kibana"`
-	ClusterUuid string                 `json:"cluster_uuid"`
+	Rules       map[string]any `json:"node_rules"`
+	Kibana      map[string]any `json:"kibana"`
+	ClusterUuid string         `json:"cluster_uuid"`
 }
 
 func eventMapping(r mb.ReporterV2, content []byte, isXpack bool) error {

--- a/metricbeat/module/kibana/stats/data.go
+++ b/metricbeat/module/kibana/stats/data.go
@@ -126,7 +126,7 @@ var (
 )
 
 func eventMapping(r mb.ReporterV2, content []byte, isXpack bool) error {
-	var data map[string]interface{}
+	var data map[string]any
 	err := json.Unmarshal(content, &data)
 	if err != nil {
 		return fmt.Errorf("failure parsing Kibana Stats API response: %w", err)
@@ -175,7 +175,7 @@ func eventMapping(r mb.ReporterV2, content []byte, isXpack bool) error {
 	event.Host = fmt.Sprintf("%v", serviceAddress)
 
 	// Set process PID
-	process, ok := data["process"].(map[string]interface{})
+	process, ok := data["process"].(map[string]any)
 	if !ok {
 		event.Error = elastic.MakeErrorForMissingField("process", elastic.Kibana)
 		return event.Error

--- a/metricbeat/module/kibana/stats/data_test.go
+++ b/metricbeat/module/kibana/stats/data_test.go
@@ -20,7 +20,8 @@
 package stats
 
 import (
-	"io/ioutil"
+	"os"
+
 	"path/filepath"
 	"testing"
 
@@ -35,7 +36,7 @@ func TestEventMapping(t *testing.T) {
 	require.NoError(t, err)
 
 	for _, f := range files {
-		input, err := ioutil.ReadFile(f)
+		input, err := os.ReadFile(f)
 		require.NoError(t, err)
 
 		reporter := &mbtest.CapturingReporterV2{}

--- a/metricbeat/module/kibana/status/data.go
+++ b/metricbeat/module/kibana/status/data.go
@@ -68,7 +68,7 @@ func eventMapping(r mb.ReporterV2, content []byte, isXpack bool) error {
 	event.RootFields = mapstr.M{}
 	event.RootFields.Put("service.name", kibana.ModuleName)
 
-	var data map[string]interface{}
+	var data map[string]any
 	err := json.Unmarshal(content, &data)
 	if err != nil {
 		return fmt.Errorf("failure parsing Kibana Status API response: %w", err)

--- a/metricbeat/module/kibana/status/data_test.go
+++ b/metricbeat/module/kibana/status/data_test.go
@@ -20,7 +20,8 @@
 package status
 
 import (
-	"io/ioutil"
+	"os"
+
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -30,7 +31,7 @@ import (
 
 func TestEventMapping(t *testing.T) {
 	f := "./_meta/test/input.json"
-	content, err := ioutil.ReadFile(f)
+	content, err := os.ReadFile(f)
 	require.NoError(t, err)
 
 	reporter := &mbtest.CapturingReporterV2{}

--- a/metricbeat/module/logstash/logstash.go
+++ b/metricbeat/module/logstash/logstash.go
@@ -55,8 +55,8 @@ type MetricSet struct {
 }
 
 type Graph struct {
-	Vertices []map[string]interface{} `json:"vertices"`
-	Edges    []map[string]interface{} `json:"edges"`
+	Vertices []map[string]any `json:"vertices"`
+	Edges    []map[string]any `json:"edges"`
 }
 
 type GraphContainer struct {
@@ -151,7 +151,7 @@ func (m *MetricSet) CheckPipelineGraphAPIsAvailable() error {
 // GetVertexClusterUUID returns the correct cluster UUID value for the given Elasticsearch
 // vertex from a Logstash pipeline. If the vertex has no cluster UUID associated with it,
 // the given override cluster UUID is returned.
-func GetVertexClusterUUID(vertex map[string]interface{}, overrideClusterUUID string) string {
+func GetVertexClusterUUID(vertex map[string]any, overrideClusterUUID string) string {
 	c, ok := vertex["cluster_uuid"]
 	if !ok {
 		return overrideClusterUUID

--- a/metricbeat/module/logstash/logstash_integration_test.go
+++ b/metricbeat/module/logstash/logstash_integration_test.go
@@ -21,7 +21,8 @@ package logstash_test
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
+
 	"net/http"
 	"testing"
 	"time"
@@ -80,16 +81,16 @@ func TestData(t *testing.T) {
 	}
 }
 
-func getConfig(metricSet string, host string) map[string]interface{} {
-	return map[string]interface{}{
+func getConfig(metricSet string, host string) map[string]any {
+	return map[string]any{
 		"module":     logstash.ModuleName,
 		"metricsets": []string{metricSet},
 		"hosts":      []string{host},
 	}
 }
 
-func getXPackConfig(host string) map[string]interface{} {
-	return map[string]interface{}{
+func getXPackConfig(host string) map[string]any {
+	return map[string]any{
 		"module":     logstash.ModuleName,
 		"metricsets": metricSets,
 		"hosts":      []string{host},
@@ -105,7 +106,7 @@ func getESClusterUUID(t *testing.T, host string) string {
 		ClusterUUID string `json:"cluster_uuid"`
 	}
 
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
 	json.Unmarshal(data, &body)
 

--- a/metricbeat/module/logstash/logstash_test.go
+++ b/metricbeat/module/logstash/logstash_test.go
@@ -32,19 +32,19 @@ import (
 
 func TestGetVertexClusterUUID(t *testing.T) {
 	tests := map[string]struct {
-		vertex              map[string]interface{}
+		vertex              map[string]any
 		overrideClusterUUID string
 		expectedClusterUUID string
 	}{
 		"vertex_and_override": {
-			map[string]interface{}{
+			map[string]any{
 				"cluster_uuid": "v",
 			},
 			"o",
 			"v",
 		},
 		"vertex_only": {
-			vertex: map[string]interface{}{
+			vertex: map[string]any{
 				"cluster_uuid": "v",
 			},
 			expectedClusterUUID: "v",
@@ -66,7 +66,7 @@ func TestGetVertexClusterUUID(t *testing.T) {
 }
 
 func TestXPackEnabledMetricSets(t *testing.T) {
-	config := map[string]interface{}{
+	config := map[string]any{
 		"module":        logstash.ModuleName,
 		"hosts":         []string{"foobar:9600"},
 		"xpack.enabled": true,

--- a/metricbeat/module/logstash/node/data.go
+++ b/metricbeat/module/logstash/node/data.go
@@ -81,7 +81,7 @@ func commonFieldsMapping(event *mb.Event, fields mapstr.M) error {
 }
 
 func eventMapping(r mb.ReporterV2, content []byte, pipelines []logstash.PipelineState, overrideClusterUUID string, isXpack bool) error {
-	var data map[string]interface{}
+	var data map[string]any
 	err := json.Unmarshal(content, &data)
 	if err != nil {
 		return fmt.Errorf("failure parsing Logstash Node API response: %w", err)

--- a/metricbeat/module/logstash/node/data_test.go
+++ b/metricbeat/module/logstash/node/data_test.go
@@ -21,7 +21,8 @@ package node
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
+
 	"path/filepath"
 	"testing"
 
@@ -38,10 +39,10 @@ func TestEventMapping(t *testing.T) {
 	require.NoError(t, err)
 
 	for _, f := range files {
-		input, err := ioutil.ReadFile(f)
+		input, err := os.ReadFile(f)
 		require.NoError(t, err)
 
-		var data map[string]interface{}
+		var data map[string]any
 		err = json.Unmarshal(input, &data)
 		require.NoError(t, err)
 
@@ -63,7 +64,7 @@ func TestMakeClusterToPipelinesMap(t *testing.T) {
 					ID: "test_pipeline",
 					Graph: &logstash.GraphContainer{
 						Graph: &logstash.Graph{
-							Vertices: []map[string]interface{}{
+							Vertices: []map[string]any{
 								{
 									"id": "vertex_1",
 								},
@@ -85,7 +86,7 @@ func TestMakeClusterToPipelinesMap(t *testing.T) {
 						ID: "test_pipeline",
 						Graph: &logstash.GraphContainer{
 							Graph: &logstash.Graph{
-								Vertices: []map[string]interface{}{
+								Vertices: []map[string]any{
 									{
 										"id": "vertex_1",
 									},
@@ -108,7 +109,7 @@ func TestMakeClusterToPipelinesMap(t *testing.T) {
 					ID: "test_pipeline",
 					Graph: &logstash.GraphContainer{
 						Graph: &logstash.Graph{
-							Vertices: []map[string]interface{}{
+							Vertices: []map[string]any{
 								{
 									"id":           "vertex_1",
 									"cluster_uuid": "es_1",
@@ -131,7 +132,7 @@ func TestMakeClusterToPipelinesMap(t *testing.T) {
 						ID: "test_pipeline",
 						Graph: &logstash.GraphContainer{
 							Graph: &logstash.Graph{
-								Vertices: []map[string]interface{}{
+								Vertices: []map[string]any{
 									{
 										"id":           "vertex_1",
 										"cluster_uuid": "es_1",
@@ -155,7 +156,7 @@ func TestMakeClusterToPipelinesMap(t *testing.T) {
 					ID: "test_pipeline_1",
 					Graph: &logstash.GraphContainer{
 						Graph: &logstash.Graph{
-							Vertices: []map[string]interface{}{
+							Vertices: []map[string]any{
 								{
 									"id":           "vertex_1_1",
 									"cluster_uuid": "es_1",
@@ -174,7 +175,7 @@ func TestMakeClusterToPipelinesMap(t *testing.T) {
 					ID: "test_pipeline_2",
 					Graph: &logstash.GraphContainer{
 						Graph: &logstash.Graph{
-							Vertices: []map[string]interface{}{
+							Vertices: []map[string]any{
 								{
 									"id": "vertex_2_1",
 								},
@@ -196,7 +197,7 @@ func TestMakeClusterToPipelinesMap(t *testing.T) {
 						ID: "test_pipeline_1",
 						Graph: &logstash.GraphContainer{
 							Graph: &logstash.Graph{
-								Vertices: []map[string]interface{}{
+								Vertices: []map[string]any{
 									{
 										"id":           "vertex_1_1",
 										"cluster_uuid": "es_1",
@@ -215,7 +216,7 @@ func TestMakeClusterToPipelinesMap(t *testing.T) {
 						ID: "test_pipeline_2",
 						Graph: &logstash.GraphContainer{
 							Graph: &logstash.Graph{
-								Vertices: []map[string]interface{}{
+								Vertices: []map[string]any{
 									{
 										"id": "vertex_2_1",
 									},
@@ -238,7 +239,7 @@ func TestMakeClusterToPipelinesMap(t *testing.T) {
 					ID: "test_pipeline_1",
 					Graph: &logstash.GraphContainer{
 						Graph: &logstash.Graph{
-							Vertices: []map[string]interface{}{
+							Vertices: []map[string]any{
 								{
 									"id":           "vertex_1_1",
 									"cluster_uuid": "es_1",
@@ -258,7 +259,7 @@ func TestMakeClusterToPipelinesMap(t *testing.T) {
 					ID: "test_pipeline_2",
 					Graph: &logstash.GraphContainer{
 						Graph: &logstash.Graph{
-							Vertices: []map[string]interface{}{
+							Vertices: []map[string]any{
 								{
 									"id": "vertex_2_1",
 								},
@@ -280,7 +281,7 @@ func TestMakeClusterToPipelinesMap(t *testing.T) {
 						ID: "test_pipeline_1",
 						Graph: &logstash.GraphContainer{
 							Graph: &logstash.Graph{
-								Vertices: []map[string]interface{}{
+								Vertices: []map[string]any{
 									{
 										"id":           "vertex_1_1",
 										"cluster_uuid": "es_1",
@@ -302,7 +303,7 @@ func TestMakeClusterToPipelinesMap(t *testing.T) {
 						ID: "test_pipeline_1",
 						Graph: &logstash.GraphContainer{
 							Graph: &logstash.Graph{
-								Vertices: []map[string]interface{}{
+								Vertices: []map[string]any{
 									{
 										"id":           "vertex_1_1",
 										"cluster_uuid": "es_1",
@@ -324,7 +325,7 @@ func TestMakeClusterToPipelinesMap(t *testing.T) {
 						ID: "test_pipeline_2",
 						Graph: &logstash.GraphContainer{
 							Graph: &logstash.Graph{
-								Vertices: []map[string]interface{}{
+								Vertices: []map[string]any{
 									{
 										"id": "vertex_2_1",
 									},

--- a/metricbeat/module/logstash/node_stats/data.go
+++ b/metricbeat/module/logstash/node_stats/data.go
@@ -34,7 +34,7 @@ import (
 )
 
 type jvm struct {
-	GC  map[string]interface{} `json:"gc"`
+	GC  map[string]any `json:"gc"`
 	Mem struct {
 		HeapMaxInBytes  int `json:"heap_max_in_bytes"`
 		HeapUsedInBytes int `json:"heap_used_in_bytes"`
@@ -51,17 +51,17 @@ type events struct {
 }
 
 type commonStats struct {
-	Events  events                 `json:"events"`
-	JVM     jvm                    `json:"jvm"`
-	Reloads map[string]interface{} `json:"reloads"`
+	Events  events         `json:"events"`
+	JVM     jvm            `json:"jvm"`
+	Reloads map[string]any `json:"reloads"`
 	Queue   struct {
 		EventsCount int `json:"events_count"`
 	} `json:"queue"`
 }
 
 type cpu struct {
-	Percent     int                    `json:"percent"`
-	LoadAverage map[string]interface{} `json:"load_average,omitempty"`
+	Percent     int            `json:"percent"`
+	LoadAverage map[string]any `json:"load_average,omitempty"`
 }
 
 type process struct {
@@ -71,11 +71,11 @@ type process struct {
 }
 
 type cgroup struct {
-	CPUAcct map[string]interface{} `json:"cpuacct"`
+	CPUAcct map[string]any `json:"cpuacct"`
 	CPU     struct {
-		Stat           map[string]interface{} `json:"stat"`
-		ControlGroup   string                 `json:"control_group"`
-		CFSQuotaMicros int64                  `json:"cfs_quota_micros"`
+		Stat           map[string]any `json:"stat"`
+		ControlGroup   string         `json:"control_group"`
+		CFSQuotaMicros int64          `json:"cfs_quota_micros"`
 	} `json:"cpu"`
 }
 
@@ -138,13 +138,13 @@ type LogstashStats struct {
 
 // PipelineStats represents the stats of a Logstash pipeline
 type PipelineStats struct {
-	ID          string                   `json:"id"`
-	Hash        string                   `json:"hash"`
-	EphemeralID string                   `json:"ephemeral_id"`
-	Events      map[string]interface{}   `json:"events"`
-	Reloads     reloads                  `json:"reloads"`
-	Queue       map[string]interface{}   `json:"queue"`
-	Vertices    []map[string]interface{} `json:"vertices"`
+	ID          string           `json:"id"`
+	Hash        string           `json:"hash"`
+	EphemeralID string           `json:"ephemeral_id"`
+	Events      map[string]any   `json:"events"`
+	Reloads     reloads          `json:"reloads"`
+	Queue       map[string]any   `json:"queue"`
+	Vertices    []map[string]any `json:"vertices"`
 }
 
 func eventMapping(r mb.ReporterV2, content []byte, isXpack bool, logger *logp.Logger) error {

--- a/metricbeat/module/logstash/node_stats/data_test.go
+++ b/metricbeat/module/logstash/node_stats/data_test.go
@@ -21,9 +21,9 @@ package node_stats
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	os0 "os"
 	"testing"
 
 	"github.com/elastic/beats/v7/metricbeat/module/logstash"
@@ -57,7 +57,7 @@ func EventMappingForFiles(t *testing.T, fixtureVersions []string, expectedEvents
 
 	for _, f := range fixtureVersions {
 		path := fmt.Sprintf("./_meta/test/node_stats.%s.json", f)
-		input, err := ioutil.ReadFile(path)
+		input, err := os0.ReadFile(path)
 		require.NoError(t, err)
 
 		reporter := &mbtest.CapturingReporterV2{}
@@ -75,13 +75,13 @@ func TestData(t *testing.T) {
 			http.NotFound(w, r)
 		}
 
-		input, _ := ioutil.ReadFile("./_meta/test/root.710.json")
+		input, _ := os0.ReadFile("./_meta/test/root.710.json")
 		w.Write(input)
 	}))
 
 	mux.Handle("/_node/stats", http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
-			input, _ := ioutil.ReadFile("./_meta/test/node_stats.710.json")
+			input, _ := os0.ReadFile("./_meta/test/node_stats.710.json")
 			w.Write(input)
 		}))
 
@@ -94,8 +94,8 @@ func TestData(t *testing.T) {
 	}
 }
 
-func getConfig(host string) map[string]interface{} {
-	return map[string]interface{}{
+func getConfig(host string) map[string]any {
+	return map[string]any{
 		"module":     logstash.ModuleName,
 		"metricsets": []string{"node_stats"},
 		"hosts":      []string{host},
@@ -112,7 +112,7 @@ func TestMakeClusterToPipelinesMap(t *testing.T) {
 			pipelines: []PipelineStats{
 				{
 					ID: "test_pipeline",
-					Vertices: []map[string]interface{}{
+					Vertices: []map[string]any{
 						{
 							"id": "vertex_1",
 						},
@@ -130,7 +130,7 @@ func TestMakeClusterToPipelinesMap(t *testing.T) {
 				"prod_cluster_id": {
 					{
 						ID: "test_pipeline",
-						Vertices: []map[string]interface{}{
+						Vertices: []map[string]any{
 							{
 								"id": "vertex_1",
 							},
@@ -149,7 +149,7 @@ func TestMakeClusterToPipelinesMap(t *testing.T) {
 			pipelines: []PipelineStats{
 				{
 					ID: "test_pipeline",
-					Vertices: []map[string]interface{}{
+					Vertices: []map[string]any{
 						{
 							"id":           "vertex_1",
 							"cluster_uuid": "es_1",
@@ -168,7 +168,7 @@ func TestMakeClusterToPipelinesMap(t *testing.T) {
 				"prod_cluster_id": {
 					{
 						ID: "test_pipeline",
-						Vertices: []map[string]interface{}{
+						Vertices: []map[string]any{
 							{
 								"id":           "vertex_1",
 								"cluster_uuid": "es_1",
@@ -188,7 +188,7 @@ func TestMakeClusterToPipelinesMap(t *testing.T) {
 			pipelines: []PipelineStats{
 				{
 					ID: "test_pipeline_1",
-					Vertices: []map[string]interface{}{
+					Vertices: []map[string]any{
 						{
 							"id":           "vertex_1_1",
 							"cluster_uuid": "es_1",
@@ -203,7 +203,7 @@ func TestMakeClusterToPipelinesMap(t *testing.T) {
 				},
 				{
 					ID: "test_pipeline_2",
-					Vertices: []map[string]interface{}{
+					Vertices: []map[string]any{
 						{
 							"id": "vertex_2_1",
 						},
@@ -221,7 +221,7 @@ func TestMakeClusterToPipelinesMap(t *testing.T) {
 				"prod_cluster_id": {
 					{
 						ID: "test_pipeline_1",
-						Vertices: []map[string]interface{}{
+						Vertices: []map[string]any{
 							{
 								"id":           "vertex_1_1",
 								"cluster_uuid": "es_1",
@@ -236,7 +236,7 @@ func TestMakeClusterToPipelinesMap(t *testing.T) {
 					},
 					{
 						ID: "test_pipeline_2",
-						Vertices: []map[string]interface{}{
+						Vertices: []map[string]any{
 							{
 								"id": "vertex_2_1",
 							},
@@ -255,7 +255,7 @@ func TestMakeClusterToPipelinesMap(t *testing.T) {
 			pipelines: []PipelineStats{
 				{
 					ID: "test_pipeline_1",
-					Vertices: []map[string]interface{}{
+					Vertices: []map[string]any{
 						{
 							"id":           "vertex_1_1",
 							"cluster_uuid": "es_1",
@@ -271,7 +271,7 @@ func TestMakeClusterToPipelinesMap(t *testing.T) {
 				},
 				{
 					ID: "test_pipeline_2",
-					Vertices: []map[string]interface{}{
+					Vertices: []map[string]any{
 						{
 							"id": "vertex_2_1",
 						},
@@ -288,7 +288,7 @@ func TestMakeClusterToPipelinesMap(t *testing.T) {
 				"es_1": {
 					{
 						ID: "test_pipeline_1",
-						Vertices: []map[string]interface{}{
+						Vertices: []map[string]any{
 							{
 								"id":           "vertex_1_1",
 								"cluster_uuid": "es_1",
@@ -306,7 +306,7 @@ func TestMakeClusterToPipelinesMap(t *testing.T) {
 				"es_2": {
 					{
 						ID: "test_pipeline_1",
-						Vertices: []map[string]interface{}{
+						Vertices: []map[string]any{
 							{
 								"id":           "vertex_1_1",
 								"cluster_uuid": "es_1",
@@ -324,7 +324,7 @@ func TestMakeClusterToPipelinesMap(t *testing.T) {
 				"": {
 					{
 						ID: "test_pipeline_2",
-						Vertices: []map[string]interface{}{
+						Vertices: []map[string]any{
 							{
 								"id": "vertex_2_1",
 							},

--- a/metricbeat/module/logstash/node_stats/node_stats_test.go
+++ b/metricbeat/module/logstash/node_stats/node_stats_test.go
@@ -69,7 +69,7 @@ func TestGetServiceURIMultipleCalls(t *testing.T) {
 		uri := "_node/stats"
 
 		numCalls := 2 + (r % 10) // between 2 and 11
-		for i := uint(0); i < numCalls; i++ {
+		for range numCalls {
 			uri, err = getServiceURI(uri, func() error { return nil })
 			if err != nil {
 				return false


### PR DESCRIPTION
## Proposed commit message

```
metricbeat: fix modernize lint findings

Fixes the `modernize` findings that `mage lint` reports in the 54 file(s)
owned by @elastic/stack-monitoring in .github/CODEOWNERS.

The rewrites are mechanical and behaviour-preserving, produced by
`golangci-lint --enable-only modernize --fix` and `go fix`: `interface{}` becomes
`any`, 3-clause loops become `for range n`, manual map copies become `maps.Copy`,
and so on.

The repo-wide change is split per team so each PR is reviewable by the people
who own the code.
```

<details>
<summary>dev-tools/modernize_split.py, the script that generated this branch</summary>

```python
#!/usr/bin/env python3
"""Apply `modernize` fixes repo-wide and split them into one branch per CODEOWNERS team.

Run from a clean worktree that sits on the commit you want to base the branches on
(normally `main`):

    ./dev-tools/modernize_split.py

Phases:

1. Fix     `golangci-lint --enable-only modernize --fix` plus `go fix`, looped over every
           GOOS/GOARCH and both build-tag sets until the tree stops changing.
2. Split   `codeowners` maps every changed file to its owning team.
3. Branch  Each team gets `modernize-<team>` containing exactly one generated commit,
           carrying the `Modernize-Automated: true` trailer.

The script is idempotent. Re-running it regenerates every automated commit from the
current base and re-applies, via `git merge-tree`, any hand-written commits stacked on
top of the automated one. Branches whose regenerated commit is byte-identical to the
existing one are left alone, so unchanged branches never need a force-push.
"""

from __future__ import annotations

import argparse
import os
import re
import shutil
import subprocess
import sys
import tempfile
import time
from collections import Counter, defaultdict
from dataclasses import dataclass, field
from pathlib import Path

import yaml

AUTO_TRAILER = "Modernize-Automated: true"
MANUAL_TRAILER = "Modernize-Manual: true"
SNAPSHOT_REF = "refs/modernize/snapshot"
BACKUP_NS = "refs/modernize/backup"
BRANCH_PREFIX = "modernize-"
CONFIG_TEMPLATE = ".golangci.modernize-{}.yml"

# GOOS/GOARCH pairs that appear in build constraints across the repo. Files behind a
# constraint are invisible to the analyzers unless we type-check for that platform.
FULL_MATRIX = [
    ("linux", "amd64"),
    ("linux", "arm64"),
    ("linux", "386"),
    ("darwin", "amd64"),
    ("darwin", "arm64"),
    ("windows", "amd64"),
    ("windows", "arm64"),
    ("windows", "386"),
    ("aix", "ppc64"),
    ("freebsd", "amd64"),
    ("openbsd", "amd64"),
    ("netbsd", "amd64"),
    ("dragonfly", "amd64"),
    ("solaris", "amd64"),
]
QUICK_MATRIX = [("linux", "amd64"), ("darwin", "arm64"), ("windows", "amd64")]

# Build-tag sets to analyze. A file is invisible to the analyzers unless some set
# satisfies its constraint, so the union has to cover every tag the repo uses.
#   - The empty set is not redundant: `!integration` files are only visible without it.
#   - `requirefips` and the feature tags are kept apart because constraints like
#     `!requirefips && integration && azure` are satisfied by neither alone.
#   - `ignore` is deliberately absent; those files are excluded on purpose.
FEATURE_TAGS = (
    "aws", "awshealth", "azure", "billing", "carbon", "cloudfoundry", "ech", "gcp",
    "nooteloutput", "oracle", "race", "salesforce_live", "stresstest", "synthetics",
    "win_integration",
)
TAG_SETS: list[tuple[str, ...]] = [
    ("integration",),
    (),
    ("integration", "requirefips"),
    ("integration", *FEATURE_TAGS),
    ("mage", "tools"),
]

# `go fix` bundles the same modernizers as the golangci-lint `modernize` linter plus a
# few extras. Keep the disabled set in sync with the `modernize` section of .golangci.yml.
GO_FIX_DISABLED = ["omitzero"]

# Modules that live inside the repo but outside the root module's ./... expansion.
# `x-pack/osquerybeat/ext/osquery-extension/cmd/gentables` is deliberately absent: its
# example packages import paths that do not resolve, so nothing there type-checks.
EXTRA_MODULES: list[str] = []

GENERATED_RE = re.compile(r"^//.*(code generated|autogenerated|do not edit)", re.IGNORECASE)

START = time.monotonic()


def log(msg: str) -> None:
    print(f"[{time.monotonic() - START:7.1f}s] {msg}", flush=True)


def git(*args: str, stdin: str | None = None, env: dict | None = None) -> str:
    """Run a git command that must succeed and return its stripped stdout."""
    res = subprocess.run(
        ["git", *args],
        input=stdin,
        capture_output=True,
        text=True,
        env={**os.environ, **(env or {})},
    )
    if res.returncode != 0:
        raise RuntimeError(f"git {' '.join(args)} failed ({res.returncode}):\n{res.stderr}")
    return res.stdout.strip()


def git_try(*args: str, stdin: str | None = None, env: dict | None = None):
    res = subprocess.run(
        ["git", *args],
        input=stdin,
        capture_output=True,
        text=True,
        env={**os.environ, **(env or {})},
    )
    return res.returncode, res.stdout, res.stderr


_SIGN: list[str] | None = None


def sign_flags() -> list[str]:
    """`-S` if commit.gpgsign is on, which `git commit-tree` ignores unlike `git commit`."""
    global _SIGN
    if _SIGN is None:
        code, out, _ = git_try("config", "--get", "--type=bool", "commit.gpgsign")
        _SIGN = ["-S"] if code == 0 and out.strip() == "true" else []
    return _SIGN


def commit_tree(tree: str, parent: str, message: str, env: dict | None = None) -> str:
    return git("commit-tree", tree, "-p", parent, *sign_flags(), stdin=message, env=env)


def signed(commit: str) -> bool:
    """False for an unsigned commit, so a re-run can replace one made before signing was on."""
    return not sign_flags() or git("log", "-1", "--format=%G?", commit) != "N"


# --------------------------------------------------------------------------------------
# Phase 1: fixers
# --------------------------------------------------------------------------------------


def host_platform() -> tuple[str, str]:
    global _HOST
    if _HOST is None:
        out = subprocess.run(
            ["go", "env", "GOHOSTOS", "GOHOSTARCH"], capture_output=True, text=True
        ).stdout.split()
        _HOST = (out[0], out[1])
    return _HOST


_HOST: tuple[str, str] | None = None


def platform_env(goos: str, goarch: str, tmpdir: Path, memlimit: int) -> dict:
    # Cross-compilation has no C toolchain here, so cgo-gated files are only reachable
    # on the host platform.
    cgo = "1" if (goos, goarch) == host_platform() else "0"
    return {
        "GOOS": goos,
        "GOARCH": goarch,
        "CGO_ENABLED": cgo,
        # A distro that mounts /tmp as tmpfs turns every multi-GB build work directory
        # into resident memory, and a killed toolchain leaks it until reboot. Type-checking
        # the whole repo for a dozen platforms exhausts RAM that way.
        "TMPDIR": str(tmpdir),
        "GOTMPDIR": str(tmpdir),
        "GOMEMLIMIT": f"{memlimit}GiB",
    }


def write_configs(root: Path) -> dict[tuple[str, ...], Path]:
    """Derive one .golangci.yml per tag set.

    The configs must live next to the original: golangci-lint resolves the paths in
    `exclusions` relative to the config file.
    """
    base = yaml.safe_load((root / ".golangci.yml").read_text())
    configs = {}
    for i, tags in enumerate(TAG_SETS):
        data = dict(base)
        run = dict(data.get("run", {}))
        if tags:
            run["build-tags"] = list(tags)
        else:
            run.pop("build-tags", None)
        data["run"] = run
        path = root / CONFIG_TEMPLATE.format(i)
        path.write_text(yaml.safe_dump(data, sort_keys=False))
        configs[tags] = path
    return configs


def run_fixer(cmd: list[str], env: dict, cwd: Path, label: str) -> None:
    started = time.monotonic()
    res = subprocess.run(
        cmd, cwd=cwd, env={**os.environ, **env}, capture_output=True, text=True
    )
    took = time.monotonic() - started
    # Both tools exit non-zero when they still have findings or when a package fails to
    # type-check for the target platform. Neither is fatal: the fixes are applied to
    # whatever did type-check, and the next platform covers the rest.
    status = "ok" if res.returncode == 0 else f"rc={res.returncode}"
    log(f"    {label}: {status} in {took:.0f}s")
    if res.returncode != 0:
        tail = "\n".join(res.stderr.strip().splitlines()[-3:])
        if tail:
            log(f"      {tail}")


def is_generated(path: Path) -> bool:
    try:
        with path.open("r", encoding="utf-8", errors="replace") as fh:
            for _ in range(40):
                line = fh.readline()
                if not line:
                    break
                if GENERATED_RE.match(line.strip()):
                    return True
    except OSError:
        return False
    return False


def changed_files(root: Path) -> list[str]:
    out = git("diff", "--name-only", "--diff-filter=d", "-z")
    return [p for p in out.split("\0") if p]


def revert_generated(root: Path, files: list[str]) -> list[str]:
    """Undo edits to generated files; golangci-lint skips them and so should we."""
    generated = [f for f in files if is_generated(root / f)]
    for i in range(0, len(generated), 200):
        git("checkout", "--", *generated[i : i + 200])
    return generated


def sweep_tmpdir(tmpdir: Path) -> None:
    """Drop build work directories the toolchain leaked when it was killed."""
    for leftover in tmpdir.glob("go-build*"):
        shutil.rmtree(leftover, ignore_errors=True)


def run_goimports(root: Path, files: list[str], goimports: str) -> None:
    """Fixers can leave imports stale (e.g. `sort` dropped for `slices`)."""
    for i in range(0, len(files), 200):
        subprocess.run(
            [goimports, "-local", "github.com/elastic", "-w", *files[i : i + 200]],
            cwd=root,
            capture_output=True,
            text=True,
        )


def modernize(root: Path, args, configs: dict[tuple[str, ...], Path], tmpdir: Path) -> list[str]:
    matrix = QUICK_MATRIX if args.quick else FULL_MATRIX
    modules = [Path(".")] + [Path(m) for m in EXTRA_MODULES]
    goimports = shutil.which("goimports")
    if not goimports:
        log("WARNING: goimports not on PATH, stale imports will not be cleaned up")

    previous = None
    for attempt in range(1, args.max_passes + 1):
        log(f"pass {attempt}/{args.max_passes}")
        for goos, goarch in matrix:
            env = platform_env(goos, goarch, tmpdir, args.memlimit)
            for tags in TAG_SETS:
                log(f"  {goos}/{goarch} tags={','.join(tags) or '-'}")
                cfg = configs[tags]
                for module in modules:
                    prefix = f"{module}: " if str(module) != "." else ""
                    run_fixer(
                        [
                            args.golangci_lint, "run",
                            "--config", str(cfg),
                            "--max-issues-per-linter", "0",
                            "--max-same-issues", "0",
                            "--enable-only", "modernize",
                            "--fix",
                            "--timeout", "60m",
                            "--issues-exit-code", "0",
                            "--concurrency", str(args.jobs),
                            "./...",
                        ],
                        env, root / module, f"{prefix}golangci-lint",
                    )
                    go_fix = ["go", "fix"]
                    if tags:
                        go_fix.append("-tags=" + ",".join(tags))
                    go_fix += [f"-{name}=false" for name in GO_FIX_DISABLED]
                    run_fixer(go_fix + ["./..."], env, root / module, f"{prefix}go fix")
                # A fix can strip the last use of an import (`to.Ptr(x)` becoming
                # `new(x)`). Tidy up immediately: a package left in that state does not
                # type-check, and every later platform would silently skip it.
                if goimports:
                    run_goimports(root, [f for f in changed_files(root) if f.endswith(".go")], goimports)
                sweep_tmpdir(tmpdir)

        files = changed_files(root)
        reverted = revert_generated(root, files)
        if reverted:
            log(f"  reverted {len(reverted)} generated files")
        files = [f for f in changed_files(root) if f.endswith(".go")]

        digest = git("diff", "--no-ext-diff")
        log(f"  pass {attempt}: {len(files)} files changed")
        if digest == previous:
            log("  converged")
            break
        previous = digest
    else:
        log(f"WARNING: still changing after {args.max_passes} passes")

    return [f for f in changed_files(root) if f.endswith(".go")]


def verify_build(root: Path, env: dict) -> list[str]:
    """Type-check the host platform, tests included.

    Only the host is checked. Beats does not build for most of the GOOS values in the
    matrix, so cross-platform failures say nothing about the fixes.
    """
    env = {**os.environ, **env}
    res = subprocess.run(
        ["go", "build", "-tags=integration", "./..."],
        cwd=root, env=env, capture_output=True, text=True,
    )
    vet = subprocess.run(
        ["go", "vet", "-tags=integration", "./..."],
        cwd=root, env=env, capture_output=True, text=True,
    )
    # `go vet` also reports genuine vet findings; only load errors indicate broken fixes.
    broken = [
        line for line in vet.stderr.splitlines()
        if ": undefined:" in line or "could not import" in line or "declared and not used" in line
    ]
    return res.stderr.splitlines()[:20] + broken[:20]


UNUSED_RE = re.compile(r"^(\S+\.go):\d+:\d+:\s*(.*?)\s*\(unused\)$")


def repo_relative(raw: str, worktree: Path) -> str:
    """Trim a reported path down to the part that exists inside `worktree`.

    Reported paths are relative to whichever directory produced them, and cached
    findings keep the path of the run that first computed them, so the same file can be
    spelled several ways. The longest suffix that resolves to a real file is the answer.
    """
    parts = Path(os.path.normpath(raw)).parts
    for i in range(len(parts)):
        candidate = Path(*parts[i:])
        if (worktree / candidate).is_file():
            return str(candidate)
    return os.path.normpath(raw)


def unused_symbols(worktree: Path, ref: str, cache: Path) -> set[str]:
    """Run `unused` against `ref`, using the .golangci.yml that ref ships with."""
    git("-C", str(worktree), "checkout", "--quiet", "--detach", ref)
    res = subprocess.run(
        [
            "golangci-lint", "run",
            "--max-issues-per-linter", "0", "--max-same-issues", "0",
            "--enable-only", "unused", "--issues-exit-code", "0", "--timeout", "30m", "./...",
        ],
        cwd=worktree, capture_output=True, text=True,
        env={**os.environ, "GOLANGCI_LINT_CACHE": str(cache)},
    )
    found = set()
    for line in res.stdout.splitlines():
        m = UNUSED_RE.match(line)
        if m:
            found.add(f"{repo_relative(m.group(1), worktree)}: {m.group(2)}")
    return found


def leftovers(base: str, snap: str, tmpdir: Path) -> list[str]:
    """Symbols the fixes orphaned, typically pointer helpers replaced by `new(expr)`.

    Removing them is the manual follow-up; nothing here rewrites code.
    """
    worktree = tmpdir / "leftovers"
    # A cache of its own: golangci-lint replays a cached finding with the path of the run
    # that produced it, which would make the two sides incomparable.
    cache = tmpdir / "leftovers-cache"
    shutil.rmtree(worktree, ignore_errors=True)
    git("worktree", "prune")
    git("worktree", "add", "--quiet", "--detach", str(worktree), base)
    try:
        before = unused_symbols(worktree, base, cache)
        after = unused_symbols(worktree, snap, cache)
    finally:
        git("worktree", "remove", "--force", str(worktree))
    return sorted(after - before)


# --------------------------------------------------------------------------------------
# Phase 2: ownership
# --------------------------------------------------------------------------------------


def team_of(owners: list[str]) -> str:
    """Reduce a CODEOWNERS entry to a single branch-name-safe team slug.

    Multi-owner paths go to their first owner: duplicating a file across branches would
    create PRs that conflict with each other.
    """
    if not owners:
        return "unowned"
    owner = owners[0].removeprefix("@")
    return owner.removeprefix("elastic/").replace("/", "-")


def split_by_team(root: Path, files: list[str], codeowners: str) -> dict[str, list[str]]:
    by_team: dict[str, list[str]] = defaultdict(list)
    for i in range(0, len(files), 200):
        batch = files[i : i + 200]
        res = subprocess.run(
            [codeowners, "-f", ".github/CODEOWNERS", *batch],
            cwd=root, capture_output=True, text=True, check=True,
        )
        for line in res.stdout.splitlines():
            fields = line.split()
            if not fields:
                continue
            path, owners = fields[0], [f for f in fields[1:] if f.startswith("@")]
            by_team[team_of(owners)].append(path)
    return dict(sorted(by_team.items()))


# --------------------------------------------------------------------------------------
# Phase 3: branches
# --------------------------------------------------------------------------------------


@dataclass
class Outcome:
    team: str
    files: int
    branch: str
    action: str = ""
    manual: list[str] = field(default_factory=list)
    dropped: list[str] = field(default_factory=list)
    conflicts: list[str] = field(default_factory=list)
    leftovers: list[str] = field(default_factory=list)


def snapshot(root: Path, base: str) -> str:
    """Commit the whole modernized worktree to an unreferenced commit.

    Uses a scratch index so the caller's index and untracked files (this script included)
    are never touched.
    """
    with tempfile.TemporaryDirectory() as tmp:
        env = {"GIT_INDEX_FILE": str(Path(tmp) / "index")}
        git("read-tree", base, env=env)
        git("add", "-u", env=env)
        tree = git("write-tree", env=env)
    commit = git("commit-tree", tree, "-p", base, stdin="modernize: full-tree snapshot")
    git("update-ref", SNAPSHOT_REF, commit)
    return commit


def tree_with(base: str, source: str, paths: list[str]) -> str:
    """Build a tree that is `base` with `paths` taken from `source`."""
    wanted = set(paths)
    entries = [
        record for record in git("ls-tree", "-r", "-z", source).split("\0")
        if record and record.split("\t", 1)[1] in wanted
    ]
    with tempfile.TemporaryDirectory() as tmp:
        env = {"GIT_INDEX_FILE": str(Path(tmp) / "index")}
        git("read-tree", base, env=env)
        git("update-index", "-z", "--index-info", stdin="\0".join(entries) + "\0", env=env)
        return git("write-tree", env=env)


def components(files: list[str], limit: int = 3, share: float = 0.15, budget: int = 40) -> str:
    """Name the areas a commit touches, for the `area: summary` subject convention.

    x-pack is split per beat, since `x-pack` alone says nothing about what changed.
    Areas are dropped from the tail until the list fits `budget`, keeping the subject
    within the ~72 columns git tooling shows without truncating.
    """
    def area(path: str) -> str:
        parts = path.split("/")
        return "/".join(parts[:2]) if parts[0] == "x-pack" else parts[0]

    counts = Counter(area(f) for f in files)
    top = [a for a, n in counts.most_common(limit) if n >= share * len(files)]
    while len(",".join(top)) > budget and len(top) > 1:
        top.pop()
    return ",".join(top)


def auto_message(team: str, base: str, files: list[str]) -> str:
    return f"""{components(files)}: fix modernize lint findings

Fixes the `modernize` findings that `mage lint` reports in the {len(files)} file(s)
owned by @elastic/{team} in .github/CODEOWNERS.

The rewrites are mechanical and behaviour-preserving, produced by
`golangci-lint --enable-only modernize --fix` and `go fix`: `interface{{}}` becomes
`any`, 3-clause loops become `for range n`, manual map copies become `maps.Copy`,
and so on.

The repo-wide change is split per team so each PR is reviewable by the people
who own the code.

Regenerate with dev-tools/modernize_split.py; do not hand-edit this commit,
put follow-up cleanups in a separate commit on top.

Modernize-Base: {base}
Modernize-Team: {team}
{AUTO_TRAILER}
"""


def stacked_commits(branch: str, limit: int = 50) -> tuple[list[str], str | None]:
    """Return commits stacked above the newest automated commit, oldest first."""
    log_out = git("log", "--format=%H%x1f%B%x1e", f"-{limit}", branch)
    stacked = []
    for entry in log_out.split("\x1e"):
        entry = entry.strip("\n")
        if not entry:
            continue
        sha, _, body = entry.partition("\x1f")
        if AUTO_TRAILER in body:
            return list(reversed(stacked)), sha
        stacked.append(sha)
    return [], None


def replay(commit: str, onto: str) -> tuple[str | None, str]:
    """Cherry-pick `commit` onto `onto` without touching the worktree."""
    parent = git("rev-parse", f"{commit}^")
    rc, out, err = git_try("merge-tree", "--write-tree", "--merge-base", parent, onto, commit)
    if rc != 0:
        return None, (out + err).strip()
    tree = out.strip().splitlines()[0]
    if tree == git("rev-parse", f"{onto}^{{tree}}"):
        return onto, "empty"
    author = git("log", "-1", "--format=%an%x1f%ae%x1f%aI", commit).split("\x1f")
    env = {"GIT_AUTHOR_NAME": author[0], "GIT_AUTHOR_EMAIL": author[1], "GIT_AUTHOR_DATE": author[2]}
    message = git("log", "-1", "--format=%B", commit)
    return commit_tree(tree, onto, message, env=env), "ok"


def checked_out_branches() -> set[str]:
    """Branches a worktree sits on; moving their tip behind git's back desyncs it."""
    return {
        line.removeprefix("branch refs/heads/")
        for line in git("worktree", "list", "--porcelain").splitlines()
        if line.startswith("branch ")
    }


def update_branch(team: str, files: list[str], base: str, snap: str, busy: set[str],
                  prefix: str) -> Outcome:
    branch = f"{prefix}{team}"
    result = Outcome(team=team, files=len(files), branch=branch)
    if branch in busy:
        result.action = "SKIPPED (checked out in a worktree)"
        return result

    tree = tree_with(base, snap, files)
    message = auto_message(team, base, files)
    exists = git_try("rev-parse", "--verify", f"refs/heads/{branch}")[0] == 0
    stacked, previous_auto = ([], None)
    if exists:
        old = git("rev-parse", branch)
        git("update-ref", f"{BACKUP_NS}/{branch}", old)
        stacked, previous_auto = stacked_commits(branch)
        if previous_auto is None:
            result.action = f"SKIPPED (no {AUTO_TRAILER} commit, backed up to {BACKUP_NS}/{branch})"
            return result
        unchanged = (
            git("rev-parse", f"{previous_auto}^{{tree}}") == tree
            and git("rev-parse", f"{previous_auto}^") == git("rev-parse", base)
            and git("log", "-1", "--format=%B", previous_auto).strip() == message.strip()
            and signed(previous_auto)
        )
        if unchanged:
            result.action = "unchanged"
            result.manual = stacked
            return result

    head = commit_tree(tree, base, message)
    for commit in stacked:
        replayed, status = replay(commit, head)
        if replayed is None:
            result.conflicts.append(commit)
        elif status == "empty":
            result.dropped.append(commit)
        else:
            result.manual.append(commit)
            head = replayed
    git("update-ref", f"refs/heads/{branch}", head)
    result.action = "updated" if exists else "created"
    return result


# --------------------------------------------------------------------------------------


def stale_branches(active: set[str], prefix: str) -> list[str]:
    """Branches this script owns whose team no longer has any modernizable file."""
    refs = git("for-each-ref", "--format=%(refname:short)", f"refs/heads/{prefix}*")
    return [
        b for b in refs.splitlines()
        if b not in active and stacked_commits(b)[1] is not None
    ]


def report(results: list[Outcome], base: str, teams_skipped: list[str], stale: list[str],
           prefix: str) -> None:
    print("\n" + "=" * 88)
    print(f"base {base[:12]}   {len(results)} team branch(es)")
    print("=" * 88)
    width = max((len(r.branch) for r in results), default=10)
    for r in sorted(results, key=lambda r: -r.files):
        extra = ""
        if r.manual:
            extra += f"  +{len(r.manual)} manual"
        if r.dropped:
            extra += f"  {len(r.dropped)} manual now redundant"
        if r.conflicts:
            extra += f"  CONFLICT on {' '.join(c[:8] for c in r.conflicts)}"
        print(f"  {r.branch:<{width}}  {r.files:>5} files  {r.action}{extra}")
    if teams_skipped:
        print(f"\n  filtered out: {', '.join(teams_skipped)}")
    if stale:
        print(f"\n  no modernizable files left, delete when merged: {', '.join(stale)}")

    conflicted = [r for r in results if r.conflicts]
    if conflicted:
        print("\nManual commits that could not be replayed (branch holds the automated commit only).")
        print(f"Previous branch tips are saved under {BACKUP_NS}/<branch>. To re-apply by hand:")
        for r in conflicted:
            print(f"  git worktree add /tmp/{r.branch} {r.branch} && "
                  f"git -C /tmp/{r.branch} cherry-pick {' '.join(r.conflicts)}")

    print("\nNext: the manual cleanup, one extra commit per branch.")
    print("  git worktree add /tmp/<branch> <branch>")
    print(f"  git commit -am 'modernize(<team>): drop leftovers' -m '{MANUAL_TRAILER}'")
    print("Commits stacked on top of the automated one are replayed automatically on the next run.")

    orphans = {r.team: r.leftovers for r in results if r.leftovers}
    if orphans:
        print("\nOrphaned by the rewrites, delete in the manual commit:")
        for team, items in sorted(orphans.items()):
            print(f"  {prefix}{team}")
            for item in items:
                print(f"    {item}")

    print("\nPRs need the `skip-changelog` label: mechanical rewrites have no user-visible effect.")


def parse_args() -> argparse.Namespace:
    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
    p.add_argument("--base", default="HEAD", help="commit the branches are based on (default: HEAD)")
    p.add_argument("--branch-prefix", default=BRANCH_PREFIX,
                   help="branch name prefix; give each base its own when targeting release branches")
    p.add_argument("--quick", action="store_true", help="only linux/amd64, darwin/arm64, windows/amd64")
    p.add_argument("--max-passes", type=int, default=4, help="fixer passes before giving up on convergence")
    p.add_argument("--jobs", type=int, default=os.cpu_count(), help="golangci-lint concurrency")
    p.add_argument("--memlimit", type=int, default=32, help="GOMEMLIMIT for the fixers, in GiB")
    p.add_argument("--tmpdir", type=Path,
                   default=Path(os.environ.get("XDG_CACHE_HOME", Path.home() / ".cache")) / "beats-modernize-tmp",
                   help="disk-backed scratch dir for the Go toolchain (must not be tmpfs)")
    p.add_argument("--teams", help="comma-separated team slugs to branch (others are reported only)")
    p.add_argument("--skip-fix", action="store_true", help="reuse the worktree as-is instead of running the fixers")
    p.add_argument("--from-snapshot", action="store_true", help=f"reuse {SNAPSHOT_REF} instead of the worktree")
    p.add_argument("--no-split", action="store_true", help="stop after the fixers, leaving the worktree dirty")
    p.add_argument("--verify", action="store_true", help="type-check the host platform before splitting")
    p.add_argument("--no-leftovers", dest="leftovers", action="store_false",
                   help="skip the `unused` diff that lists symbols the rewrites orphaned")
    p.add_argument("--keep-dirty", action="store_true", help="do not restore the worktree at the end")
    p.add_argument("--push", metavar="REMOTE", help="force-with-lease push every touched branch")
    p.add_argument("--golangci-lint", default="golangci-lint")
    p.add_argument("--codeowners", default="codeowners")
    return p.parse_args()


def main() -> int:
    args = parse_args()
    root = Path(git("rev-parse", "--show-toplevel"))
    os.chdir(root)

    for tool in [args.golangci_lint, args.codeowners, "go", "git"]:
        if not shutil.which(tool):
            print(f"error: {tool} not found on PATH", file=sys.stderr)
            return 1

    base = git("rev-parse", f"{args.base}^{{commit}}")
    if not args.from_snapshot:
        if git("rev-parse", "HEAD") != base:
            print(f"error: HEAD is not {args.base}; check it out first", file=sys.stderr)
            return 1
        if not args.skip_fix and git("status", "--porcelain", "-uno"):
            print("error: worktree has uncommitted changes to tracked files", file=sys.stderr)
            return 1

    args.tmpdir.mkdir(parents=True, exist_ok=True)
    sweep_tmpdir(args.tmpdir)
    configs = write_configs(root)
    restore = not args.keep_dirty and not args.from_snapshot
    try:
        if args.from_snapshot:
            snap = git("rev-parse", SNAPSHOT_REF)
            files = [f for f in git("diff", "--name-only", "--diff-filter=d", base, snap).splitlines() if f.endswith(".go")]
            log(f"reusing snapshot {snap[:12]} with {len(files)} files")
        else:
            files = modernize(root, args, configs, args.tmpdir) if not args.skip_fix else \
                [f for f in changed_files(root) if f.endswith(".go")]
            if not files:
                log("nothing to modernize")
                return 0
            if args.verify:
                log("verifying host build")
                failures = verify_build(root, platform_env(*host_platform(), args.tmpdir, args.memlimit))
                for failure in failures:
                    log(f"  {failure}")
                log("  ok" if not failures else "  BROKEN, not splitting")
                if failures:
                    restore = False
                    return 1
            if args.no_split:
                restore = False
                log(f"{len(files)} files changed, left in the worktree")
                return 0
            snap = snapshot(root, base)
            log(f"snapshot {snap[:12]} with {len(files)} files")

        by_team = split_by_team(root, files, args.codeowners)
        wanted = set(args.teams.split(",")) if args.teams else None
        busy = checked_out_branches()

        orphans: dict[str, list[str]] = defaultdict(list)
        if args.leftovers:
            log("looking for symbols the rewrites orphaned")
            found = leftovers(base, snap, args.tmpdir)
            owners = split_by_team(root, sorted({i.split(":", 1)[0] for i in found}), args.codeowners)
            team_of_file = {f: t for t, fs in owners.items() for f in fs}
            for item in found:
                orphans[team_of_file.get(item.split(":", 1)[0], "unowned")].append(item)
            log(f"  {len(found)} orphaned symbol(s)")

        results, skipped = [], []
        for team, team_files in by_team.items():
            if wanted is not None and team not in wanted:
                skipped.append(f"{team} ({len(team_files)})")
                continue
            outcome = update_branch(team, team_files, base, snap, busy, args.branch_prefix)
            outcome.leftovers = orphans.get(team, [])
            results.append(outcome)

        if args.push:
            for r in results:
                if r.action in ("created", "updated"):
                    rc, _, err = git_try("push", "--force-with-lease", args.push, f"{r.branch}:{r.branch}")
                    r.action += " pushed" if rc == 0 else f" PUSH FAILED: {err.strip().splitlines()[-1]}"

        report(results, base, skipped,
               stale_branches({r.branch for r in results}, args.branch_prefix),
               args.branch_prefix)
        return 0
    except BaseException:
        # Never throw away hours of fixing because of a late failure.
        restore = False
        raise
    finally:
        for cfg in configs.values():
            cfg.unlink(missing_ok=True)
        sweep_tmpdir(args.tmpdir)
        if restore and git("status", "--porcelain", "-uno"):
            git("checkout", "--", ".")


if __name__ == "__main__":
    sys.exit(main())
```

</details>

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.~~
- [ ] ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).~~ Labelled `skip-changelog`: no user-visible change.

## Disruptive User Impact

None.

## Review notes

Single commit, produced entirely by tooling. Nothing on this branch needed a hand-written follow-up.

## Related issues

- Relates https://github.com/elastic/beats/issues/52485
