### PR TITLE
x-pack/osquerybeat,winlogbeat: fix modernize lint findings

### DIFF
--- a/libbeat/processors/decode_xml_wineventlog/processor.go
+++ b/libbeat/processors/decode_xml_wineventlog/processor.go
@@ -156,7 +156,7 @@ func fields(evt winevent.Event) (mapstr.M, mapstr.M) {
 	return win, ecs
 }
 
-func getValue(m mapstr.M, key string) interface{} {
+func getValue(m mapstr.M, key string) any {
 	v, _ := m.GetValue(key)
 	return v
 }

--- a/libbeat/processors/decode_xml_wineventlog/processor_test.go
+++ b/libbeat/processors/decode_xml_wineventlog/processor_test.go
@@ -127,7 +127,6 @@ func TestProcessor(t *testing.T) {
 	}
 
 	for _, test := range testCases {
-		test := test
 		t.Run(test.description, func(t *testing.T) {
 			t.Parallel()
 

--- a/libbeat/processors/translate_ldap_attribute/ldap_sspi_cbt_windows.go
+++ b/libbeat/processors/translate_ldap_attribute/ldap_sspi_cbt_windows.go
@@ -257,10 +257,7 @@ func handshakePayload(secLayer byte, maxSize uint32, authzid []byte) []byte {
 	var truncatedSize uint32
 	if selectedSecurity != 0 {
 		// Only 3 bytes available for max size, set to 0x00FFFFFF per RFC 4752.
-		truncatedSize = 0b00000000_11111111_11111111_11111111
-		if truncatedSize > maxSize {
-			truncatedSize = maxSize
-		}
+		truncatedSize = min(0b00000000_11111111_11111111_11111111, maxSize)
 	}
 	payload := make([]byte, 4, 4+len(authzid))
 	binary.BigEndian.PutUint32(payload, truncatedSize)

--- a/libbeat/processors/translate_sid/translatesid_test.go
+++ b/libbeat/processors/translate_sid/translatesid_test.go
@@ -66,7 +66,7 @@ func TestTranslateSID(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			evt := &beat.Event{Fields: map[string]interface{}{
+			evt := &beat.Event{Fields: map[string]any{
 				"sid": tc.SID,
 			}}
 
@@ -120,7 +120,7 @@ func TestTranslateSIDEmptyTarget(t *testing.T) {
 	c := defaultConfig()
 	c.Field = "sid"
 
-	evt := &beat.Event{Fields: map[string]interface{}{
+	evt := &beat.Event{Fields: map[string]any{
 		"sid": "S-1-5-32-544",
 	}}
 
@@ -134,7 +134,6 @@ func TestTranslateSIDEmptyTarget(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.Name, func(t *testing.T) {
 			p, err := newFromConfig(tc.Config, logger)
 			require.NoError(t, err)
@@ -162,7 +161,7 @@ func BenchmarkProcessor_Run(b *testing.B) {
 	}
 
 	b.Run("builtin", func(b *testing.B) {
-		evt := &beat.Event{Fields: map[string]interface{}{
+		evt := &beat.Event{Fields: map[string]any{
 			"sid": "S-1-5-7",
 		}}
 
@@ -175,7 +174,7 @@ func BenchmarkProcessor_Run(b *testing.B) {
 	})
 
 	b.Run("no_mapping", func(b *testing.B) {
-		evt := &beat.Event{Fields: map[string]interface{}{
+		evt := &beat.Event{Fields: map[string]any{
 			"sid": "S-1-5-2025429265-500",
 		}}
 
@@ -188,7 +187,7 @@ func BenchmarkProcessor_Run(b *testing.B) {
 	})
 }
 
-func assertEqualIgnoreCase(t *testing.T, expected string, actual interface{}) {
+func assertEqualIgnoreCase(t *testing.T, expected string, actual any) {
 	t.Helper()
 	actualStr, ok := actual.(string)
 	if !ok {

--- a/libbeat/reader/etw/eventrenderer.go
+++ b/libbeat/reader/etw/eventrenderer.go
@@ -188,7 +188,7 @@ func renderStructArray(cache providerCache, eventInfo *cachedEventInfo, propInfo
 	}
 
 	result := make([]any, arraySize)
-	for j := 0; j < arraySize; j++ {
+	for j := range arraySize {
 		value, err := renderStruct(cache, eventInfo, propInfo, r, ptrSize, buf, bufferPools)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse struct member %d: %w", j, err)
@@ -221,7 +221,7 @@ func renderSimpleArray(cache providerCache, eventInfo *cachedEventInfo, propInfo
 	}
 
 	result := make([]any, count)
-	for i := uint32(0); i < count; i++ {
+	for i := range count {
 		// For each array element, process it as a single property
 		value, err := renderSingleProperty(cache, eventInfo, propInfo, r, ptrSize, buf, mapInfo, cachedMapInfo, bufferPools)
 		if err != nil {

--- a/libbeat/reader/etw/metadata_cache.go
+++ b/libbeat/reader/etw/metadata_cache.go
@@ -262,19 +262,19 @@ type bufferPools struct {
 func newBufferPools() *bufferPools {
 	return &bufferPools{
 		smallBufferPool: sync.Pool{
-			New: func() interface{} {
+			New: func() any {
 				buf := make([]byte, 256)
 				return &buf
 			},
 		},
 		mediumBufferPool: sync.Pool{
-			New: func() interface{} {
+			New: func() any {
 				buf := make([]byte, 1024)
 				return &buf
 			},
 		},
 		largeBufferPool: sync.Pool{
-			New: func() interface{} {
+			New: func() any {
 				buf := make([]byte, 4096)
 				return &buf
 			},

--- a/libbeat/reader/etw/session_integration_test.go
+++ b/libbeat/reader/etw/session_integration_test.go
@@ -526,7 +526,7 @@ func compareRenderedEvents(actual, expected RenderedEtwEvent, eventIndex int) []
 }
 
 // comparePropertyValues compares two property values recursively
-func comparePropertyValues(actual, expected interface{}) bool {
+func comparePropertyValues(actual, expected any) bool {
 	actualJSON, err1 := json.Marshal(actual)
 	expectedJSON, err2 := json.Marshal(expected)
 	return err1 == nil && err2 == nil && string(actualJSON) == string(expectedJSON)

--- a/libbeat/reader/etw/testingutils_test.go
+++ b/libbeat/reader/etw/testingutils_test.go
@@ -320,7 +320,7 @@ func (g *ETWEventGenerator) close() error {
 
 // generateEvents generates n random events, alternating between the two event types
 func (g *ETWEventGenerator) generateEvents(n int, wait time.Duration) error {
-	for i := 0; i < n; i++ {
+	for i := range n {
 		if i%2 == 0 {
 			if err := g.writeAllDataTypesEvent(); err != nil {
 				return err

--- a/winlogbeat/beater/acker.go
+++ b/winlogbeat/beater/acker.go
@@ -41,7 +41,7 @@ func newEventACKer(checkpoint *checkpoint.Checkpoint) *eventACKer {
 
 // ACKEvents receives callbacks from the publisher for every event that is
 // published. It persists the record number of the last event in each
-func (a *eventACKer) ACKEvents(data []interface{}) {
+func (a *eventACKer) ACKEvents(data []any) {
 	states := make(map[string]*checkpoint.EventLogState)
 
 	for _, datum := range data {

--- a/winlogbeat/beater/eventlogger.go
+++ b/winlogbeat/beater/eventlogger.go
@@ -118,7 +118,7 @@ func (e *eventLogger) run(
 	// Initialize per event log metrics.
 	initMetrics(api.Name())
 
-	pipeline = pipetool.WithACKer(pipeline, acker.EventPrivateReporter(func(_ int, private []interface{}) {
+	pipeline = pipetool.WithACKer(pipeline, acker.EventPrivateReporter(func(_ int, private []any) {
 		eventACKer.ACKEvents(private)
 	}))
 

--- a/winlogbeat/checkpoint/checkpoint.go
+++ b/winlogbeat/checkpoint/checkpoint.go
@@ -22,7 +22,8 @@ package checkpoint
 
 import (
 	"fmt"
-	"io/ioutil"
+
+	"maps"
 	"os"
 	"path/filepath"
 	"sort"
@@ -169,9 +170,7 @@ func (c *Checkpoint) States() map[string]EventLogState {
 	defer c.lock.RUnlock()
 
 	copy := make(map[string]EventLogState)
-	for k, v := range c.states {
-		copy[k] = v
-	}
+	maps.Copy(copy, c.states)
 
 	return copy
 }
@@ -267,7 +266,7 @@ func (c *Checkpoint) read() (*PersistedState, error) {
 	c.fileLock.RLock()
 	defer c.fileLock.RUnlock()
 
-	contents, err := ioutil.ReadFile(c.file)
+	contents, err := os.ReadFile(c.file)
 	if err != nil {
 		if os.IsNotExist(err) {
 			err = nil

--- a/winlogbeat/checkpoint/checkpoint_test.go
+++ b/winlogbeat/checkpoint/checkpoint_test.go
@@ -20,7 +20,6 @@
 package checkpoint
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -34,13 +33,7 @@ func eventually(t *testing.T, predicate func() (bool, error), timeout time.Durat
 	const minInterval = time.Millisecond * 5
 	const maxInterval = time.Millisecond * 500
 
-	checkInterval := timeout / 100
-	if checkInterval < minInterval {
-		checkInterval = minInterval
-	}
-	if checkInterval > maxInterval {
-		checkInterval = maxInterval
-	}
+	checkInterval := min(max(timeout/100, minInterval), maxInterval)
 	for deadline, first := time.Now().Add(timeout), true; first || time.Now().Before(deadline); first = false {
 		ok, err := predicate()
 		if err != nil {
@@ -58,7 +51,7 @@ func eventually(t *testing.T, predicate func() (bool, error), timeout time.Durat
 // Test that a write is triggered when the maximum time period since the last
 // write is reached.
 func TestWriteTimedFlush(t *testing.T) {
-	dir, err := ioutil.TempDir("", "wlb-checkpoint-test")
+	dir, err := os.MkdirTemp("", "wlb-checkpoint-test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -103,7 +96,7 @@ func TestWriteTimedFlush(t *testing.T) {
 
 // Test that createDir creates the directory with 0750 permissions.
 func TestCreateDir(t *testing.T) {
-	dir, err := ioutil.TempDir("", "wlb-checkpoint-test")
+	dir, err := os.MkdirTemp("", "wlb-checkpoint-test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -142,7 +135,7 @@ func TestCreateDir(t *testing.T) {
 // Test createDir when the directory already exists to verify that no error is
 // returned.
 func TestCreateDirAlreadyExists(t *testing.T) {
-	dir, err := ioutil.TempDir("", "wlb-checkpoint-test")
+	dir, err := os.MkdirTemp("", "wlb-checkpoint-test")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/winlogbeat/config/config_test.go
+++ b/winlogbeat/config/config_test.go
@@ -51,7 +51,7 @@ func TestConfigValidate(t *testing.T) {
 		{
 			WinlogbeatConfig{
 				EventLogs: []*conf.C{
-					newConfig(map[string]interface{}{
+					newConfig(map[string]any{
 						"Name": "App",
 					}),
 				},
@@ -69,7 +69,7 @@ func TestConfigValidate(t *testing.T) {
 	}
 }
 
-func newConfig(from map[string]interface{}) *conf.C {
+func newConfig(from map[string]any) *conf.C {
 	cfg, err := conf.NewConfigFrom(from)
 	if err != nil {
 		panic(err)

--- a/winlogbeat/eventlog/config.go
+++ b/winlogbeat/eventlog/config.go
@@ -33,7 +33,7 @@ type validator interface {
 	Validate() error
 }
 
-func readConfig(c *conf.C, config interface{}) error {
+func readConfig(c *conf.C, config any) error {
 	if err := c.Unpack(config); err != nil {
 		return fmt.Errorf("failed unpacking config. %w", err)
 	}

--- a/winlogbeat/eventlog/metrics.go
+++ b/winlogbeat/eventlog/metrics.go
@@ -44,7 +44,7 @@ var (
 // incrementMetric increments a value in the specified expvar.Map. The key
 // should be a windows syscall.Errno or a string. Any other types will be
 // reported under the "other" key.
-func incrementMetric(v *expvar.Map, key interface{}) {
+func incrementMetric(v *expvar.Map, key any) {
 	switch t := key.(type) {
 	default:
 		v.Add("other", 1)

--- a/winlogbeat/eventlog/record_filter.go
+++ b/winlogbeat/eventlog/record_filter.go
@@ -125,7 +125,7 @@ func parseLevels(raw string) (map[uint8]struct{}, error) {
 		}
 	}
 
-	for _, expr := range strings.Split(raw, ",") {
+	for expr := range strings.SplitSeq(raw, ",") {
 		expr = strings.ToLower(strings.TrimSpace(expr))
 		switch expr {
 		case "verbose", "5":
@@ -156,7 +156,7 @@ func parseEventIDRanges(raw string) ([]eventIDRange, []eventIDRange, error) {
 	var includes []eventIDRange
 	var excludes []eventIDRange
 
-	for _, component := range strings.Split(raw, ",") {
+	for component := range strings.SplitSeq(raw, ",") {
 		component = strings.TrimSpace(component)
 		if component == "" {
 			return nil, nil, fmt.Errorf("invalid event ID query component ('%s')", component)

--- a/winlogbeat/eventlog/wineventlog_test.go
+++ b/winlogbeat/eventlog/wineventlog_test.go
@@ -172,20 +172,20 @@ func testWindowsEventLog(t *testing.T, includeXML bool) {
 	// Publish large test messages.
 	const messageSize = 256 // Originally 31800, such a large value resulted in an empty eventlog under Win10.
 	const totalEvents = 1000
-	for i := 0; i < totalEvents; i++ {
+	for i := range totalEvents {
 		// #nosec G115 -- i is bounded by totalEvents and event ID is constrained to [1,1000].
 		safeWriteEvent(t, writer, uint32(i%1000)+1, strconv.Itoa(i)+" "+randomSentence(messageSize))
 	}
 
-	openLog := func(t testing.TB, config map[string]interface{}) EventLog {
+	openLog := func(t testing.TB, config map[string]any) EventLog {
 		return openLog(t, nil, config)
 	}
 
 	t.Run("has_message", func(t *testing.T) {
-		log := openLog(t, map[string]interface{}{"name": providerName, "batch_read_size": 1, "include_xml": includeXML})
+		log := openLog(t, map[string]any{"name": providerName, "batch_read_size": 1, "include_xml": includeXML})
 		defer log.Close()
 
-		for i := 0; i < 10; i++ {
+		for range 10 {
 			records, err := log.Read()
 			require.NotEmpty(t, records)
 			require.NoError(t, err)
@@ -197,7 +197,7 @@ func testWindowsEventLog(t *testing.T, includeXML bool) {
 
 	// Test reading from an event log using a custom XML query.
 	t.Run("custom_xml_query", func(t *testing.T) {
-		cfg := map[string]interface{}{
+		cfg := map[string]any{
 			"id":          "custom-xml-query",
 			"xml_query":   customXMLQuery,
 			"include_xml": includeXML,
@@ -227,7 +227,7 @@ func testWindowsEventLog(t *testing.T, includeXML bool) {
 	t.Run("batch_read_size_config", func(t *testing.T) {
 		const batchReadSize = 2
 
-		log := openLog(t, map[string]interface{}{"name": providerName, "batch_read_size": batchReadSize, "include_xml": includeXML})
+		log := openLog(t, map[string]any{"name": providerName, "batch_read_size": batchReadSize, "include_xml": includeXML})
 		defer log.Close()
 
 		records, err := log.Read()
@@ -242,7 +242,7 @@ func testWindowsEventLog(t *testing.T, includeXML bool) {
 	// When combined with large messages this causes EvtNext to fail with
 	// RPC_S_INVALID_BOUND error. The reader should recover from the error.
 	t.Run("large_batch_read", func(t *testing.T) {
-		log := openLog(t, map[string]interface{}{"name": providerName, "batch_read_size": 1024, "include_xml": includeXML})
+		log := openLog(t, map[string]any{"name": providerName, "batch_read_size": 1024, "include_xml": includeXML})
 		defer log.Close()
 
 		var eventCount int
@@ -270,7 +270,7 @@ func testWindowsEventLog(t *testing.T, includeXML bool) {
 			t.Fatal(err)
 		}
 
-		log := openLog(t, map[string]interface{}{
+		log := openLog(t, map[string]any{
 			"name":           path,
 			"no_more_events": "stop",
 			"include_xml":    includeXML,
@@ -293,7 +293,7 @@ func testWindowsEventLog(t *testing.T, includeXML bool) {
 			t.Fatal(err)
 		}
 
-		log := openLog(t, map[string]interface{}{
+		log := openLog(t, map[string]any{
 			"name":           path,
 			"no_more_events": "stop",
 			"event_id":       "3, 5",
@@ -374,7 +374,7 @@ func setLogSize(t testing.TB, provider string, sizeBytes int) {
 	}
 }
 
-func openLog(t testing.TB, state *checkpoint.EventLogState, config map[string]interface{}) EventLog {
+func openLog(t testing.TB, state *checkpoint.EventLogState, config map[string]any) EventLog {
 	cfg, err := conf.NewConfigFrom(config)
 	if err != nil {
 		t.Fatal(err)

--- a/winlogbeat/module/pipeline.go
+++ b/winlogbeat/module/pipeline.go
@@ -46,7 +46,7 @@ const logName = "pipeline"
 
 type pipeline struct {
 	id       string
-	contents map[string]interface{}
+	contents map[string]any
 }
 
 // UploadPipelines reads all pipelines embedded in the Winlogbeat executable
@@ -178,9 +178,9 @@ func load(esClient *eslegclient.Connection, pipelines []pipeline, overwritePipel
 	return loaded, nil
 }
 
-func applyTemplates(prefix string, version string, filename string, original []byte) (converted map[string]interface{}, err error) {
-	vars := map[string]interface{}{
-		"builtin": map[string]interface{}{
+func applyTemplates(prefix string, version string, filename string, original []byte) (converted map[string]any, err error) {
+	vars := map[string]any{
+		"builtin": map[string]any{
 			"prefix":      prefix,
 			"module":      "",
 			"fileset":     "",
@@ -193,7 +193,7 @@ func applyTemplates(prefix string, version string, filename string, original []b
 		return nil, fmt.Errorf("failed to apply template: %w", err)
 	}
 
-	var content map[string]interface{}
+	var content map[string]any
 	switch extension := strings.ToLower(filepath.Ext(filename)); extension {
 	case ".json":
 		if err = json.Unmarshal([]byte(encodedString), &content); err != nil {
@@ -208,7 +208,7 @@ func applyTemplates(prefix string, version string, filename string, original []b
 			return nil, fmt.Errorf("failed to sanitize the YAML pipeline file: %s: %w", filename, err)
 		}
 		//nolint:errcheck // ignore
-		content = newContent.(map[string]interface{})
+		content = newContent.(map[string]any)
 	default:
 		return nil, fmt.Errorf("unsupported extension '%s' for pipeline file: %s", extension, filename)
 	}

--- a/winlogbeat/scripts/mage/config.go
+++ b/winlogbeat/scripts/mage/config.go
@@ -29,7 +29,7 @@ func config() error {
 
 func configFileParams() devtools.ConfigFileParams {
 	conf := devtools.DefaultConfigFileParams()
-	conf.ExtraVars = map[string]interface{}{"GOOS": "windows"}
+	conf.ExtraVars = map[string]any{"GOOS": "windows"}
 	conf.Templates = append(conf.Templates, devtools.OSSBeatDir("_meta/config/*.tmpl"))
 	if devtools.XPackProject == SelectLogic {
 		conf.Templates = append(conf.Templates, devtools.XPackBeatDir("_meta/config/*.tmpl"))

--- a/winlogbeat/sys/bufferpool.go
+++ b/winlogbeat/sys/bufferpool.go
@@ -23,7 +23,7 @@ import (
 
 // bufferPool contains a pool of PooledByteBuffer objects.
 var bufferPool = sync.Pool{
-	New: func() interface{} { return &PooledByteBuffer{ByteBuffer: NewByteBuffer(1024)} },
+	New: func() any { return &PooledByteBuffer{ByteBuffer: NewByteBuffer(1024)} },
 }
 
 // PooledByteBuffer is an expandable buffer backed by a byte slice.

--- a/winlogbeat/sys/winevent/maputil.go
+++ b/winlogbeat/sys/winevent/maputil.go
@@ -29,7 +29,7 @@ import (
 // AddOptional adds a key and value to the given MapStr if the value is not the
 // zero value for the type of v. It is safe to call the function with a nil
 // MapStr.
-func AddOptional(m mapstr.M, key string, v interface{}) {
+func AddOptional(m mapstr.M, key string, v any) {
 	if m != nil && !isZero(v) {
 		_, _ = m.Put(key, v)
 	}
@@ -49,7 +49,7 @@ func AddPairs(m mapstr.M, key string, pairs []KeyValue) mapstr.M {
 
 	// Explicitly use the unnamed type to prevent accidental use
 	// of mapstr.M path look-up methods.
-	h := make(map[string]interface{}, len(pairs))
+	h := make(map[string]any, len(pairs))
 
 	for i, kv := range pairs {
 		// Ignore empty values.
@@ -84,7 +84,7 @@ func AddPairs(m mapstr.M, key string, pairs []KeyValue) mapstr.M {
 }
 
 // isZero return true if the given value is the zero value for its type.
-func isZero(i interface{}) bool {
+func isZero(i any) bool {
 	switch i := i.(type) {
 	case nil:
 		return true

--- a/winlogbeat/sys/wineventlog/iterator_test.go
+++ b/winlogbeat/sys/wineventlog/iterator_test.go
@@ -32,7 +32,7 @@ func TestEventIterator(t *testing.T) {
 	defer tearDown()
 
 	const eventCount = 1500
-	for i := 0; i < eventCount; i++ {
+	for i := range eventCount {
 		safeWriteEvent(t, writer, 1, "Test message "+strconv.Itoa(i+1))
 	}
 

--- a/winlogbeat/sys/wineventlog/metadata_store.go
+++ b/winlogbeat/sys/wineventlog/metadata_store.go
@@ -628,7 +628,7 @@ func (c *publisherMetadataCache) close() error {
 // --- Template Funcs
 
 // eventParam return an event data value inside a text/template.
-func eventParam(items []interface{}, paramNumber int) (interface{}, error) {
+func eventParam(items []any, paramNumber int) (any, error) {
 	// Windows parameter values start at %1 so adjust index value by -1.
 	index := paramNumber - 1
 	if index < len(items) {

--- a/winlogbeat/sys/wineventlog/publisher_metadata.go
+++ b/winlogbeat/sys/wineventlog/publisher_metadata.go
@@ -198,7 +198,7 @@ func NewMetadataKeywords(publisherMetadataHandle EvtHandle) ([]MetadataKeyword, 
 	}
 
 	var values []MetadataKeyword
-	for i := uint32(0); i < arrayLen; i++ {
+	for i := range arrayLen {
 		md, err := NewMetadataKeyword(publisherMetadataHandle, arrayHandle, i)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get keyword at array index %v: %w", i, err)
@@ -272,7 +272,7 @@ func NewMetadataOpcodes(publisherMetadataHandle EvtHandle) ([]MetadataOpcode, er
 	}
 
 	var values []MetadataOpcode
-	for i := uint32(0); i < arrayLen; i++ {
+	for i := range arrayLen {
 		md, err := NewMetadataOpcode(publisherMetadataHandle, arrayHandle, i)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get opcode at array index %v: %w", i, err)
@@ -349,7 +349,7 @@ func NewMetadataLevels(publisherMetadataHandle EvtHandle) ([]MetadataLevel, erro
 	}
 
 	var values []MetadataLevel
-	for i := uint32(0); i < arrayLen; i++ {
+	for i := range arrayLen {
 		md, err := NewMetadataLevel(publisherMetadataHandle, arrayHandle, i)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get level at array index %v: %w", i, err)
@@ -423,7 +423,7 @@ func NewMetadataTasks(publisherMetadataHandle EvtHandle) ([]MetadataTask, error)
 	}
 
 	var values []MetadataTask
-	for i := uint32(0); i < arrayLen; i++ {
+	for i := range arrayLen {
 		md, err := NewMetadataTask(publisherMetadataHandle, arrayHandle, i)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get task at array index %v: %w", i, err)
@@ -504,7 +504,7 @@ func NewMetadataChannels(publisherMetadataHandle EvtHandle) ([]MetadataChannel, 
 	}
 
 	var values []MetadataChannel
-	for i := uint32(0); i < arrayLen; i++ {
+	for i := range arrayLen {
 		md, err := NewMetadataChannel(publisherMetadataHandle, arrayHandle, i)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get task at array index %v: %w", i, err)
@@ -613,7 +613,7 @@ func (itr *EventMetadataIterator) Err() error {
 	return itr.lastErr
 }
 
-func typeCastError(expected, got interface{}) error {
+func typeCastError(expected, got any) error {
 	return fmt.Errorf("wrong type for property. expected:%T got:%T", expected, got)
 }
 

--- a/winlogbeat/sys/wineventlog/renderer.go
+++ b/winlogbeat/sys/wineventlog/renderer.go
@@ -134,7 +134,7 @@ func (r *Renderer) renderSystem(handle EvtHandle, event *winevent.Event) error {
 	}
 	defer bb.Free()
 
-	for i := 0; i < propertyCount; i++ {
+	for i := range propertyCount {
 		property := EvtSystemPropertyID(i)
 		offset := i * int(sizeofEvtVariant)
 		evtVar := (*EvtVariant)(unsafe.Pointer(bb.PtrAt(offset)))
@@ -197,7 +197,7 @@ func (r *Renderer) renderSystem(handle EvtHandle, event *winevent.Event) error {
 // renderUser returns the event/user data values. This does not provide the
 // parameter names. It computes a fingerprint of the values types to help the
 // caller match the correct names to the returned values.
-func (r *Renderer) renderUser(mds *PublisherMetadataStore, handle EvtHandle, event *winevent.Event) (values []interface{}, fingerprint uint64, err error) {
+func (r *Renderer) renderUser(mds *PublisherMetadataStore, handle EvtHandle, event *winevent.Event) (values []any, fingerprint uint64, err error) {
 	bb, propertyCount, err := r.render(r.userContext, handle)
 	if err != nil {
 		return nil, 0, fmt.Errorf("failed to get user values: %w", err)
@@ -216,8 +216,8 @@ func (r *Renderer) renderUser(mds *PublisherMetadataStore, handle EvtHandle, eve
 		return nil, 0, fmt.Errorf("failed to hash property count: %w", err)
 	}
 
-	values = make([]interface{}, propertyCount)
-	for i := 0; i < propertyCount; i++ {
+	values = make([]any, propertyCount)
+	for i := range propertyCount {
 		offset := i * int(sizeofEvtVariant)
 		evtVar := (*EvtVariant)(unsafe.Pointer(bb.PtrAt(offset)))
 		binary.Write(argumentHash, binary.LittleEndian, uint32(evtVar.Type)) //nolint:errcheck // Hash writes never fail.
@@ -280,7 +280,7 @@ func (r *Renderer) render(context EvtHandle, eventHandle EvtHandle) (*sys.Pooled
 }
 
 // addEventData adds the event/user data values to the event.
-func (r *Renderer) addEventData(evtMeta *EventMetadata, values []interface{}, event *winevent.Event) {
+func (r *Renderer) addEventData(evtMeta *EventMetadata, values []any, event *winevent.Event) {
 	if len(values) == 0 {
 		return
 	}
@@ -341,7 +341,7 @@ func (r *Renderer) addEventData(evtMeta *EventMetadata, values []interface{}, ev
 
 // formatMessage adds the message to the event.
 func (r *Renderer) formatMessage(publisherMeta *PublisherMetadata,
-	eventMeta *EventMetadata, eventHandle EvtHandle, values []interface{},
+	eventMeta *EventMetadata, eventHandle EvtHandle, values []any,
 	eventID uint16) (string, error,
 ) {
 	if eventMeta != nil {
@@ -362,7 +362,7 @@ func (r *Renderer) formatMessage(publisherMeta *PublisherMetadata,
 
 // formatMessageFromTemplate creates the message by executing the stored Go
 // text/template with the event/user data values.
-func (r *Renderer) formatMessageFromTemplate(msgTmpl *template.Template, values []interface{}) (string, error) {
+func (r *Renderer) formatMessageFromTemplate(msgTmpl *template.Template, values []any) (string, error) {
 	bb := sys.NewPooledByteBuffer()
 	defer bb.Free()
 

--- a/winlogbeat/sys/wineventlog/renderer_test.go
+++ b/winlogbeat/sys/wineventlog/renderer_test.go
@@ -218,7 +218,7 @@ func TestTemplateFunc(t *testing.T) {
 		Parse(`Hello {{ eventParam $ 1 }}! Foo {{ eventParam $ 2 }}.`))
 
 	buf := new(bytes.Buffer)
-	err := tmpl.Execute(buf, []interface{}{"world"})
+	err := tmpl.Execute(buf, []any{"world"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -269,7 +269,7 @@ func BenchmarkRenderer(b *testing.B) {
 
 	const totalEvents = 1000000
 	msg := strings.Repeat("Hello world! ", 21)
-	for i := 0; i < totalEvents; i++ {
+	for range totalEvents {
 		safeWriteEvent(b, writer, 10, msg)
 	}
 

--- a/winlogbeat/sys/wineventlog/stringinserts.go
+++ b/winlogbeat/sys/wineventlog/stringinserts.go
@@ -56,7 +56,7 @@ func (si *stringInserts) Slice() []EvtVariant {
 // clear clears the pointers (and unsafe pointers) so that the memory can be
 // garbage collected.
 func (si *stringInserts) clear() {
-	for i := 0; i < len(si.evtVariants); i++ {
+	for i := range len(si.evtVariants) {
 		si.evtVariants[i] = EvtVariant{}
 		si.insertStrings[i] = nil
 	}
@@ -67,7 +67,7 @@ func (si *stringInserts) clear() {
 func newTemplateStringInserts() *stringInserts {
 	si := &stringInserts{}
 
-	for i := 0; i < len(si.evtVariants); i++ {
+	for i := range len(si.evtVariants) {
 		// Use i+1 to keep our inserts numbered the same as Window's inserts.
 		templateParam := leftTemplateDelim + `eventParam $ ` + strconv.Itoa(i+1) + rightTemplateDelim
 		strSlice, err := windows.UTF16FromString(templateParam)

--- a/winlogbeat/sys/wineventlog/syscall_windows.go
+++ b/winlogbeat/sys/wineventlog/syscall_windows.go
@@ -456,7 +456,7 @@ func evtVariantInt16(v uint16) int16 { return int16(v) } //nolint:gosec // prese
 func evtVariantInt32(v uint32) int32 { return int32(v) } //nolint:gosec // preserve Windows EVT_VARIANT bit pattern
 func evtVariantInt64(v uint64) int64 { return int64(v) } //nolint:gosec // preserve Windows EVT_VARIANT bit pattern
 
-func (v EvtVariant) Data(buf []byte) (interface{}, error) {
+func (v EvtVariant) Data(buf []byte) (any, error) {
 	typ := v.Type.Mask()
 	switch typ {
 	case EvtVarTypeNull:
@@ -582,7 +582,7 @@ const (
 	EvtPublisherMetadataKeywordMessageID
 )
 
-func EvtGetPublisherMetadataProperty(publisherMetadataHandle EvtHandle, propertyID EvtPublisherMetadataPropertyID) (interface{}, error) {
+func EvtGetPublisherMetadataProperty(publisherMetadataHandle EvtHandle, propertyID EvtPublisherMetadataPropertyID) (any, error) {
 	var bufferUsed uint32
 	err := _EvtGetPublisherMetadataProperty(publisherMetadataHandle, propertyID, 0, 0, nil, &bufferUsed)
 	if err != windows.ERROR_INSUFFICIENT_BUFFER { //nolint:errorlint // Bad linter! This is always errno or nil.
@@ -612,7 +612,7 @@ func EvtGetPublisherMetadataProperty(publisherMetadataHandle EvtHandle, property
 	}
 }
 
-func EvtGetObjectArrayProperty(arrayHandle EvtObjectArrayPropertyHandle, propertyID EvtPublisherMetadataPropertyID, index uint32) (interface{}, error) {
+func EvtGetObjectArrayProperty(arrayHandle EvtObjectArrayPropertyHandle, propertyID EvtPublisherMetadataPropertyID, index uint32) (any, error) {
 	var bufferUsed uint32
 	err := _EvtGetObjectArrayProperty(arrayHandle, propertyID, index, 0, 0, nil, &bufferUsed)
 	if err != windows.ERROR_INSUFFICIENT_BUFFER { //nolint:errorlint // Bad linter! This is always errno or nil.
@@ -647,7 +647,7 @@ func EvtGetObjectArraySize(handle EvtObjectArrayPropertyHandle) (uint32, error) 
 	return arrayLen, nil
 }
 
-func GetEventMetadataProperty(metadataHandle EvtHandle, propertyID EvtEventMetadataPropertyID) (interface{}, error) {
+func GetEventMetadataProperty(metadataHandle EvtHandle, propertyID EvtEventMetadataPropertyID) (any, error) {
 	var bufferUsed uint32
 	err := _EvtGetEventMetadataProperty(metadataHandle, 8, 0, 0, nil, &bufferUsed)
 	if err != windows.ERROR_INSUFFICIENT_BUFFER { //nolint:errorlint // Bad linter! This is always errno or nil.

--- a/winlogbeat/sys/wineventlog/util_test.go
+++ b/winlogbeat/sys/wineventlog/util_test.go
@@ -151,7 +151,7 @@ func mustNextHandle(t *testing.T, log EvtHandle) EvtHandle {
 	return h
 }
 
-func logAsJSON(t testing.TB, object interface{}) {
+func logAsJSON(t testing.TB, object any) {
 	data, err := json.MarshalIndent(object, "", "  ")
 	if err != nil {
 		t.Fatal(err)

--- a/winlogbeat/sys/wineventlog/wineventlog_windows.go
+++ b/winlogbeat/sys/wineventlog/wineventlog_windows.go
@@ -87,10 +87,7 @@ loop:
 				switch errno {
 				case ERROR_INSUFFICIENT_BUFFER:
 					// Grow buffer.
-					newLen := 2 * len(cpBuffer)
-					if int(used) > newLen {
-						newLen = int(used)
-					}
+					newLen := max(int(used), 2*len(cpBuffer))
 					cpBuffer = make([]uint16, newLen)
 					continue
 				case ERROR_NO_MORE_ITEMS:

--- a/winlogbeat/tests/testscript/commands_windows.go
+++ b/winlogbeat/tests/testscript/commands_windows.go
@@ -516,7 +516,7 @@ func reportEvent(source string, eventType uint16, eventID uint32, sid *windows.S
 }
 
 // readNDJSON reads all *.ndjson files in dir and returns the parsed events.
-func readNDJSON(script *testscript.TestScript, dir string) []map[string]interface{} {
+func readNDJSON(script *testscript.TestScript, dir string) []map[string]any {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -525,7 +525,7 @@ func readNDJSON(script *testscript.TestScript, dir string) []map[string]interfac
 		script.Fatalf("readNDJSON: ReadDir(%q): %v", dir, err)
 	}
 
-	var events []map[string]interface{}
+	var events []map[string]any
 	for _, entry := range entries {
 		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".ndjson") {
 			continue
@@ -534,12 +534,12 @@ func readNDJSON(script *testscript.TestScript, dir string) []map[string]interfac
 		if err != nil {
 			script.Fatalf("readNDJSON: ReadFile: %v", err)
 		}
-		for _, line := range strings.Split(string(data), "\n") {
+		for line := range strings.SplitSeq(string(data), "\n") {
 			line = strings.TrimSpace(line)
 			if line == "" {
 				continue
 			}
-			var evt map[string]interface{}
+			var evt map[string]any
 			if err := json.Unmarshal([]byte(line), &evt); err != nil {
 				script.Fatalf("readNDJSON: Unmarshal: %v\nline: %s", err, line)
 			}
@@ -550,7 +550,7 @@ func readNDJSON(script *testscript.TestScript, dir string) []map[string]interfac
 }
 
 // getField retrieves a value from a nested map using dot-separated field names.
-func getField(evt map[string]interface{}, field string) (interface{}, bool) {
+func getField(evt map[string]any, field string) (any, bool) {
 	parts := strings.SplitN(field, ".", 2)
 	val, ok := evt[parts[0]]
 	if !ok {
@@ -559,7 +559,7 @@ func getField(evt map[string]interface{}, field string) (interface{}, bool) {
 	if len(parts) == 1 {
 		return val, true
 	}
-	nested, ok := val.(map[string]interface{})
+	nested, ok := val.(map[string]any)
 	if !ok {
 		return nil, false
 	}

--- a/x-pack/filebeat/input/etw/input_test.go
+++ b/x-pack/filebeat/input/etw/input_test.go
@@ -219,8 +219,7 @@ func Test_RunEtwInput_StartConsumerError(t *testing.T) {
 	}
 
 	// Setup cancellation
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
+	ctx := t.Context()
 
 	// Setup input
 	inputCtx := input.Context{

--- a/x-pack/osquerybeat/beater/action_handler.go
+++ b/x-pack/osquerybeat/beater/action_handler.go
@@ -22,11 +22,11 @@ var (
 )
 
 type actionResultPublisher interface {
-	PublishActionResult(req map[string]interface{}, res map[string]interface{})
+	PublishActionResult(req map[string]any, res map[string]any)
 }
 
 type queryResultPublisher interface {
-	Publish(index, idValue, idFieldKey, responseID, spaceID, packID, packName, queryName string, meta map[string]interface{}, hits []map[string]interface{}, ecsm ecs.Mapping, reqData interface{})
+	Publish(index, idValue, idFieldKey, responseID, spaceID, packID, packName, queryName string, meta map[string]any, hits []map[string]any, ecsm ecs.Mapping, reqData any)
 }
 
 type scheduledResponsePublisher interface {
@@ -34,11 +34,11 @@ type scheduledResponsePublisher interface {
 }
 
 type queryProfilePublisher interface {
-	PublishQueryProfile(index, queryName, actionID, responseID string, profile map[string]interface{}, reqData interface{})
+	PublishQueryProfile(index, queryName, actionID, responseID string, profile map[string]any, reqData any)
 }
 
 type liveProfileRecorder interface {
-	RecordLiveProfile(query string, profile map[string]interface{})
+	RecordLiveProfile(query string, profile map[string]any)
 }
 
 type scheduledQueryPublisher interface {
@@ -53,7 +53,7 @@ type actionQueryPublisher interface {
 }
 
 type queryExecutor interface {
-	Query(ctx context.Context, sql string, timeout time.Duration) ([]map[string]interface{}, error)
+	Query(ctx context.Context, sql string, timeout time.Duration) ([]map[string]any, error)
 }
 
 type namespaceProvider interface {
@@ -91,13 +91,13 @@ func (a *actionHandler) Name() string {
 }
 
 // Execute handles the action request.
-func (a *actionHandler) Execute(ctx context.Context, req map[string]interface{}) (map[string]interface{}, error) {
+func (a *actionHandler) Execute(ctx context.Context, req map[string]any) (map[string]any, error) {
 
 	start := time.Now().UTC()
 	count, err := a.execute(ctx, req)
 	end := time.Now().UTC()
 
-	res := map[string]interface{}{
+	res := map[string]any{
 		"started_at":   start.Format(time.RFC3339Nano),
 		"completed_at": end.Format(time.RFC3339Nano),
 	}
@@ -110,7 +110,7 @@ func (a *actionHandler) Execute(ctx context.Context, req map[string]interface{})
 	return res, nil
 }
 
-func (a *actionHandler) execute(ctx context.Context, req map[string]interface{}) (int, error) {
+func (a *actionHandler) execute(ctx context.Context, req map[string]any) (int, error) {
 	ac, err := action.FromMap(req)
 	if err != nil {
 		return 0, fmt.Errorf("%w: %w", err, ErrQueryExecution)
@@ -132,7 +132,7 @@ func (a *actionHandler) namespace() string {
 	return config.DefaultNamespace
 }
 
-func (a *actionHandler) executeQuery(ctx context.Context, index string, ac action.Action, responseID string, req map[string]interface{}) (int, error) {
+func (a *actionHandler) executeQuery(ctx context.Context, index string, ac action.Action, responseID string, req map[string]any) (int, error) {
 
 	if a.queryExec == nil {
 		return 0, ErrNoQueryExecutor

--- a/x-pack/osquerybeat/beater/action_handler_test.go
+++ b/x-pack/osquerybeat/beater/action_handler_test.go
@@ -19,13 +19,13 @@ import (
 )
 
 type mockExecutor struct {
-	result []map[string]interface{}
+	result []map[string]any
 	err    error
 
 	receivedSql string
 }
 
-func (e *mockExecutor) Query(ctx context.Context, sql string, to time.Duration) ([]map[string]interface{}, error) {
+func (e *mockExecutor) Query(ctx context.Context, sql string, to time.Duration) ([]map[string]any, error) {
 	e.receivedSql = sql
 
 	return e.result, e.err
@@ -40,14 +40,14 @@ type mockPublisher struct {
 	packID     string
 	packName   string
 	queryName  string
-	meta       map[string]interface{}
-	hits       []map[string]interface{}
+	meta       map[string]any
+	hits       []map[string]any
 	ecsm       ecs.Mapping
-	reqData    interface{}
-	profile    map[string]interface{}
+	reqData    any
+	profile    map[string]any
 }
 
-func (p *mockPublisher) Publish(index, idValue, idFieldKey, responseID, spaceID, packID, packName, queryName string, meta map[string]interface{}, hits []map[string]interface{}, ecsm ecs.Mapping, reqData interface{}) {
+func (p *mockPublisher) Publish(index, idValue, idFieldKey, responseID, spaceID, packID, packName, queryName string, meta map[string]any, hits []map[string]any, ecsm ecs.Mapping, reqData any) {
 	p.index = index
 	p.idValue = idValue
 	p.idFieldKey = idFieldKey
@@ -62,7 +62,7 @@ func (p *mockPublisher) Publish(index, idValue, idFieldKey, responseID, spaceID,
 	p.reqData = reqData
 }
 
-func (p *mockPublisher) PublishQueryProfile(index, queryName, actionID, responseID string, profile map[string]interface{}, reqData interface{}) {
+func (p *mockPublisher) PublishQueryProfile(index, queryName, actionID, responseID string, profile map[string]any, reqData any) {
 	p.profile = profile
 }
 
@@ -78,9 +78,9 @@ func TestActionHandlerExecute(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		nonMatchingPlatform = "linux"
 	}
-	request := map[string]interface{}{
+	request := map[string]any{
 		"id": actionID,
-		"data": map[string]interface{}{
+		"data": map[string]any{
 			"query": actionSQL,
 		},
 	}
@@ -90,7 +90,7 @@ func TestActionHandlerExecute(t *testing.T) {
 		QueryExecutor queryExecutor
 		Publisher     actionQueryPublisher
 
-		Request map[string]interface{}
+		Request map[string]any
 		Err     error
 		Skipped bool
 	}{
@@ -115,9 +115,9 @@ func TestActionHandlerExecute(t *testing.T) {
 			Name:          "skips non matching platform",
 			QueryExecutor: &mockExecutor{},
 			Publisher:     &mockPublisher{},
-			Request: map[string]interface{}{
+			Request: map[string]any{
 				"id": actionID,
-				"data": map[string]interface{}{
+				"data": map[string]any{
 					"query":    actionSQL,
 					"platform": nonMatchingPlatform,
 				},

--- a/x-pack/osquerybeat/beater/config_plugin.go
+++ b/x-pack/osquerybeat/beater/config_plugin.go
@@ -26,7 +26,7 @@ const (
 
 // nativeOsqueryOptionDefaults are applied to the options map when building the
 // config for osqueryd, only when each key is not already set in the native config.
-var nativeOsqueryOptionDefaults = map[string]interface{}{
+var nativeOsqueryOptionDefaults = map[string]any{
 	"schedule_splay_percent": 10,
 	"schedule_max_drift":     60,
 }
@@ -234,7 +234,7 @@ func newOsqueryConfig(osqueryConfig *config.OsqueryConfig) *config.OsqueryConfig
 		osqueryConfig = &config.OsqueryConfig{}
 	}
 	if osqueryConfig.Options == nil {
-		osqueryConfig.Options = make(map[string]interface{})
+		osqueryConfig.Options = make(map[string]any)
 	}
 	// Apply native osquery option defaults only when not already set in config
 	for k, v := range nativeOsqueryOptionDefaults {
@@ -416,7 +416,7 @@ func getPackQueryName(packName, queryName string) string {
 // Due to current configuration passing between the agent and beats the keys that contain dots (".")
 // are split into the nested tree-like structure.
 // This converts this dynamic map[string]interface{} tree into strongly typed flat map.
-func flattenECSMapping(m map[string]interface{}) (ecs.Mapping, error) {
+func flattenECSMapping(m map[string]any) (ecs.Mapping, error) {
 	if m == nil {
 		return nil, nil
 	}
@@ -433,7 +433,7 @@ func flattenECSMapping(m map[string]interface{}) (ecs.Mapping, error) {
 	return ecsm, nil
 }
 
-func traverseTree(depth int, ecsm ecs.Mapping, path []string, v interface{}) error {
+func traverseTree(depth int, ecsm ecs.Mapping, path []string, v any) error {
 
 	if path[len(path)-1] == keyField {
 		if s, ok := v.(string); ok {
@@ -462,7 +462,7 @@ func traverseTree(depth int, ecsm ecs.Mapping, path []string, v interface{}) err
 			Value: v,
 		}
 		return nil
-	} else if m, ok := v.(map[string]interface{}); ok {
+	} else if m, ok := v.(map[string]any); ok {
 		if depth < maxECSMappingDepth {
 			for k, v := range m {
 				if strings.TrimSpace(k) == "" {

--- a/x-pack/osquerybeat/beater/config_plugin_test.go
+++ b/x-pack/osquerybeat/beater/config_plugin_test.go
@@ -96,7 +96,7 @@ func TestConfigPluginNew(t *testing.T) {
 
 func TestFlattenECSMapping(t *testing.T) {
 	const mapping = `{"user":{"custom":{"shoeSize":{"value":45}},"id":{"field":"uid"},"name":{"field":"username"}}}`
-	var m map[string]interface{}
+	var m map[string]any
 	err := json.Unmarshal([]byte(mapping), &m)
 	if err != nil {
 		t.Fatal(err)
@@ -122,13 +122,13 @@ func TestFlattenECSMapping(t *testing.T) {
 	}
 }
 
-func generateTestMapping(depth int, k string, v interface{}) map[string]interface{} {
-	m := make(map[string]interface{})
+func generateTestMapping(depth int, k string, v any) map[string]any {
+	m := make(map[string]any)
 	res := m
 	key := 'a'
 
-	for i := 0; i < depth; i++ {
-		newmap := make(map[string]interface{})
+	for range depth {
+		newmap := make(map[string]any)
 		m[string(key)] = newmap
 		m = newmap
 		key += 1
@@ -176,41 +176,41 @@ func TestFlattenECSMappingMoreEdges(t *testing.T) {
 	}
 
 	values := map[string]struct {
-		m   interface{}
+		m   any
 		err error
 	}{
 		"empty field": {
-			map[string]interface{}{
+			map[string]any{
 				"field": "",
 			},
 			ErrECSMappingIsInvalid,
 		},
 		"empty field with whitespaces": {
-			map[string]interface{}{
+			map[string]any{
 				"field": "   ",
 			},
 			ErrECSMappingIsInvalid,
 		},
 		"nil field": {
-			map[string]interface{}{
+			map[string]any{
 				"field": nil,
 			},
 			ErrECSMappingIsInvalid,
 		},
 		"empty string value": {
-			map[string]interface{}{
+			map[string]any{
 				"value": "",
 			},
 			nil,
 		},
 		"empty string value with whitespaces": {
-			map[string]interface{}{
+			map[string]any{
 				"value": "   ",
 			},
 			nil,
 		},
 		"nil value": {
-			map[string]interface{}{
+			map[string]any{
 				"value": nil,
 			},
 			nil,
@@ -265,17 +265,17 @@ func TestSet(t *testing.T) {
 					ID:       "users",
 					Query:    "select * from users limit 2",
 					Interval: 60,
-					ECSMapping: map[string]interface{}{
-						"user": map[string]interface{}{
-							"custom": map[string]interface{}{
-								"shoeSize": map[string]interface{}{
+					ECSMapping: map[string]any{
+						"user": map[string]any{
+							"custom": map[string]any{
+								"shoeSize": map[string]any{
 									"value": 45,
 								},
 							},
-							"id": map[string]interface{}{
+							"id": map[string]any{
 								"field": "uid",
 							},
-							"name": map[string]interface{}{
+							"name": map[string]any{
 								"field": "username",
 							},
 						},

--- a/x-pack/osquerybeat/beater/live_profile_store.go
+++ b/x-pack/osquerybeat/beater/live_profile_store.go
@@ -63,7 +63,7 @@ func newLiveProfileStore(log *logp.Logger, dir string, maxProfiles int) (*livePr
 	return store, nil
 }
 
-func (s *liveProfileStore) Record(query string, profile map[string]interface{}) {
+func (s *liveProfileStore) Record(query string, profile map[string]any) {
 	if s == nil || query == "" {
 		return
 	}
@@ -91,11 +91,11 @@ func (s *liveProfileStore) Record(query string, profile map[string]interface{}) 
 	s.mx.Unlock()
 }
 
-func (s *liveProfileStore) RecordLiveProfile(query string, profile map[string]interface{}) {
+func (s *liveProfileStore) RecordLiveProfile(query string, profile map[string]any) {
 	s.Record(query, profile)
 }
 
-func (s *liveProfileStore) List() []map[string]interface{} {
+func (s *liveProfileStore) List() []map[string]any {
 	if s == nil {
 		return nil
 	}
@@ -110,7 +110,7 @@ func (s *liveProfileStore) List() []map[string]interface{} {
 
 	type profileEntry struct {
 		modTime int64
-		data    map[string]interface{}
+		data    map[string]any
 	}
 
 	var results []profileEntry
@@ -130,7 +130,7 @@ func (s *liveProfileStore) List() []map[string]interface{} {
 			}
 			continue
 		}
-		var payload map[string]interface{}
+		var payload map[string]any
 		if err := json.Unmarshal(bytes, &payload); err != nil {
 			if s.log != nil {
 				s.log.Debugw("failed to unmarshal live query profile", "file", path, "error", err)
@@ -154,7 +154,7 @@ func (s *liveProfileStore) List() []map[string]interface{} {
 		return results[i].modTime > results[j].modTime
 	})
 
-	profiles := make([]map[string]interface{}, 0, len(results))
+	profiles := make([]map[string]any, 0, len(results))
 	for _, item := range results {
 		profiles = append(profiles, item.data)
 	}

--- a/x-pack/osquerybeat/beater/live_profile_store_test.go
+++ b/x-pack/osquerybeat/beater/live_profile_store_test.go
@@ -22,13 +22,13 @@ func TestLiveProfileStoreEvictsAndDeletesFiles(t *testing.T) {
 	query1 := "select * from uptime"
 	query2 := "select * from osquery_info"
 
-	store.Record(query1, map[string]interface{}{"source": "live", "query": query1})
+	store.Record(query1, map[string]any{"source": "live", "query": query1})
 	file1 := filepath.Join(dir, liveProfileFilename(liveProfileKey(query1)))
 	if _, err := os.Stat(file1); err != nil {
 		t.Fatalf("expected profile file for query1, got error: %v", err)
 	}
 
-	store.Record(query2, map[string]interface{}{"source": "live", "query": query2})
+	store.Record(query2, map[string]any{"source": "live", "query": query2})
 	file2 := filepath.Join(dir, liveProfileFilename(liveProfileKey(query2)))
 	if _, err := os.Stat(file2); err != nil {
 		t.Fatalf("expected profile file for query2, got error: %v", err)

--- a/x-pack/osquerybeat/beater/osquery_runner_test.go
+++ b/x-pack/osquerybeat/beater/osquery_runner_test.go
@@ -144,7 +144,7 @@ func TestOsqueryRunnerRestart(t *testing.T) {
 	inputConfigs := []config.InputConfig{
 		{
 			Osquery: &config.OsqueryConfig{
-				Options: map[string]interface{}{
+				Options: map[string]any{
 					"foo": "bar",
 				},
 			},

--- a/x-pack/osquerybeat/beater/osquerybeat_extensions_test.go
+++ b/x-pack/osquerybeat/beater/osquerybeat_extensions_test.go
@@ -47,7 +47,7 @@ func TestExtensionsDiagnosticsPayload(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	loaded := []map[string]interface{}{
+	loaded := []map[string]any{
 		{"name": "valid_ext", "version": "1.0", "path": validExt},
 	}
 
@@ -74,7 +74,7 @@ func TestExtensionsDiagnosticsPayload(t *testing.T) {
 		t.Fatalf("expected extensions_require [valid_ext], got %v", payload["extensions_require"])
 	}
 
-	entries, ok := payload["configured_entries"].([]map[string]interface{})
+	entries, ok := payload["configured_entries"].([]map[string]any)
 	if !ok || len(entries) != 2 {
 		t.Fatalf("unexpected configured_entries: %v", payload["configured_entries"])
 	}
@@ -84,7 +84,7 @@ func TestExtensionsDiagnosticsPayload(t *testing.T) {
 	if loadedPaths, ok := entries[0]["loaded"].([]string); !ok || len(loadedPaths) != 1 || loadedPaths[0] != validExt {
 		t.Fatalf("expected %q loaded, got %v", validExt, entries[0]["loaded"])
 	}
-	if skipped, ok := entries[0]["skipped"].([]map[string]interface{}); !ok || len(skipped) != 1 || skipped[0]["path"] != skippedExt {
+	if skipped, ok := entries[0]["skipped"].([]map[string]any); !ok || len(skipped) != 1 || skipped[0]["path"] != skippedExt {
 		t.Fatalf("expected %q skipped, got %v", skippedExt, entries[0]["skipped"])
 	}
 	if entries[1]["status"] != "error" || entries[1]["reason"] == nil {

--- a/x-pack/osquerybeat/beater/osquerybeat_publisher_test.go
+++ b/x-pack/osquerybeat/beater/osquerybeat_publisher_test.go
@@ -21,16 +21,16 @@ type mockBeatPublisher struct {
 var _ osquerybeatPublisher = (*mockBeatPublisher)(nil)
 var _ scheduledQueryPublisher = (*mockBeatPublisher)(nil)
 
-func (m *mockBeatPublisher) Publish(index, idValue, idFieldKey, responseID, spaceID, packID, packName, queryName string, meta map[string]interface{}, hits []map[string]interface{}, ecsm ecs.Mapping, reqData interface{}) {
+func (m *mockBeatPublisher) Publish(index, idValue, idFieldKey, responseID, spaceID, packID, packName, queryName string, meta map[string]any, hits []map[string]any, ecsm ecs.Mapping, reqData any) {
 }
 
-func (m *mockBeatPublisher) PublishActionResult(req map[string]interface{}, res map[string]interface{}) {
+func (m *mockBeatPublisher) PublishActionResult(req map[string]any, res map[string]any) {
 }
 
 func (m *mockBeatPublisher) PublishScheduledResponse(scheduleID, packID, packName, queryName, spaceID, responseID string, startedAt, completedAt, plannedScheduleTime time.Time, resultCount int, scheduleExecutionCount int64) {
 }
 
-func (m *mockBeatPublisher) PublishQueryProfile(index, queryName, actionID, responseID string, profile map[string]interface{}, reqData interface{}) {
+func (m *mockBeatPublisher) PublishQueryProfile(index, queryName, actionID, responseID string, profile map[string]any, reqData any) {
 }
 
 func (m *mockBeatPublisher) Configure(inputs []config.InputConfig) error {

--- a/x-pack/osquerybeat/beater/osquerybeat_status_test.go
+++ b/x-pack/osquerybeat/beater/osquerybeat_status_test.go
@@ -74,11 +74,11 @@ type testManager struct {
 }
 
 type diagnosticsQueryExecutor struct {
-	rows []map[string]interface{}
+	rows []map[string]any
 	err  error
 }
 
-func (e *diagnosticsQueryExecutor) Query(context.Context, string, time.Duration) ([]map[string]interface{}, error) {
+func (e *diagnosticsQueryExecutor) Query(context.Context, string, time.Duration) ([]map[string]any, error) {
 	return e.rows, e.err
 }
 
@@ -378,7 +378,7 @@ func TestOsquerybeatRegistersScheduledProfilesDiagnostics(t *testing.T) {
 		qp: newQueryProfiler(logp.NewLogger("test")),
 	}
 	ob.setDiagnosticsQueryExecutor(&diagnosticsQueryExecutor{
-		rows: []map[string]interface{}{
+		rows: []map[string]any{
 			{
 				"name":              "pack_test_query",
 				"query":             "select * from users limit 1",
@@ -402,7 +402,7 @@ func TestOsquerybeatRegistersScheduledProfilesDiagnostics(t *testing.T) {
 	hook, ok := mgr.diagHook["scheduled_query_profiles"]
 	require.True(t, ok, "expected scheduled profiles diagnostics hook")
 
-	var payload map[string]interface{}
+	var payload map[string]any
 	err := json.Unmarshal(hook(), &payload)
 	require.NoError(t, err)
 
@@ -411,11 +411,11 @@ func TestOsquerybeatRegistersScheduledProfilesDiagnostics(t *testing.T) {
 	//nolint:testifylint // We're comparing integers from a JSON
 	assert.Equal(t, float64(1), count)
 
-	profiles, ok := payload["osquery_schedule"].([]interface{})
+	profiles, ok := payload["osquery_schedule"].([]any)
 	require.True(t, ok)
 	require.Len(t, profiles, 1)
 
-	p0, ok := profiles[0].(map[string]interface{})
+	p0, ok := profiles[0].(map[string]any)
 	require.True(t, ok)
 	assert.Equal(t, "select * from users limit 1", p0["query"])
 
@@ -424,7 +424,7 @@ func TestOsquerybeatRegistersScheduledProfilesDiagnostics(t *testing.T) {
 	//nolint:testifylint // We're comparing integers from a JSON
 	assert.Equal(t, float64(0), liveCount)
 
-	liveProfiles, ok := payload["live_query_profiles"].([]interface{})
+	liveProfiles, ok := payload["live_query_profiles"].([]any)
 	require.True(t, ok)
 	assert.Empty(t, liveProfiles)
 }

--- a/x-pack/osquerybeat/beater/query_profiler.go
+++ b/x-pack/osquerybeat/beater/query_profiler.go
@@ -52,7 +52,7 @@ func newQueryProfiler(log *logp.Logger) *queryProfiler {
 	}
 }
 
-func (p *queryProfiler) profileScheduledQuery(ctx context.Context, qe queryExecutor, queryName string) (map[string]interface{}, error) {
+func (p *queryProfiler) profileScheduledQuery(ctx context.Context, qe queryExecutor, queryName string) (map[string]any, error) {
 	escapedName := strings.ReplaceAll(queryName, "'", "''")
 	query := osqueryScheduleProfileQueryPrefix + escapedName + osqueryScheduleProfileQuerySuffix
 	rows, err := qe.Query(ctx, query, 10*time.Second)
@@ -74,7 +74,7 @@ func (p *queryProfiler) profileScheduledQuery(ctx context.Context, qe queryExecu
 	lastMemory := toInt64(row["last_memory"])
 
 	cpuMS := userMS + systemMS
-	profile := map[string]interface{}{
+	profile := map[string]any{
 		"source":                 "scheduled",
 		"query_name":             queryName,
 		"utilization":            utilizationFromMillis(cpuMS, wallMS),
@@ -113,7 +113,7 @@ func (p *queryProfiler) scheduledProfilesDiagnostics(ctx context.Context, qe que
 	return data
 }
 
-func (p *queryProfiler) scheduledProfilesDiagnosticsPayload(ctx context.Context, qe queryExecutor) (map[string]interface{}, error) {
+func (p *queryProfiler) scheduledProfilesDiagnosticsPayload(ctx context.Context, qe queryExecutor) (map[string]any, error) {
 	if qe == nil {
 		return nil, fmt.Errorf("osquery client is not connected")
 	}
@@ -123,14 +123,14 @@ func (p *queryProfiler) scheduledProfilesDiagnosticsPayload(ctx context.Context,
 		return nil, fmt.Errorf("failed to query osquery_schedule: %w", err)
 	}
 
-	return map[string]interface{}{
+	return map[string]any{
 		"osquery_schedule": rows,
 		"count":            len(rows),
 	}, nil
 }
 
 func diagnosticsErrorJSON(message string) []byte {
-	payload := map[string]interface{}{
+	payload := map[string]any{
 		"error": message,
 	}
 	data, err := json.MarshalIndent(payload, "", "  ")
@@ -172,34 +172,25 @@ LIMIT 1`, 5*time.Second)
 	return snap, nil
 }
 
-func buildLiveQueryProfile(query string, before, after runtimeSnapshot, duration time.Duration, queryErr error) map[string]interface{} {
+func buildLiveQueryProfile(query string, before, after runtimeSnapshot, duration time.Duration, queryErr error) map[string]any {
 	return buildRuntimeQueryProfile("live", query, before, after, duration, queryErr)
 }
 
 // buildRuntimeQueryProfile builds a profile from osquery process metrics before and after a query.
 // source distinguishes collection contexts (for example "live" vs "rrule") for downstream consumers.
 // See the comment above collectRuntimeSnapshot for how concurrent osquery work affects these metrics.
-func buildRuntimeQueryProfile(source, query string, before, after runtimeSnapshot, duration time.Duration, queryErr error) map[string]interface{} {
-	userDelta := after.userTimeMS - before.userTimeMS
-	if userDelta < 0 {
-		userDelta = 0
-	}
-	systemDelta := after.systemTimeMS - before.systemTimeMS
-	if systemDelta < 0 {
-		systemDelta = 0
-	}
+func buildRuntimeQueryProfile(source, query string, before, after runtimeSnapshot, duration time.Duration, queryErr error) map[string]any {
+	userDelta := max(after.userTimeMS-before.userTimeMS, 0)
+	systemDelta := max(after.systemTimeMS-before.systemTimeMS, 0)
 	cpuMS := userDelta + systemDelta
-	wallMS := duration.Milliseconds()
-	if wallMS < 0 {
-		wallMS = 0
-	}
+	wallMS := max(duration.Milliseconds(), 0)
 
 	exitCode := int64(0)
 	if queryErr != nil {
 		exitCode = 1
 	}
 
-	return map[string]interface{}{
+	return map[string]any{
 		"source":      source,
 		"query":       query,
 		"utilization": utilizationFromMillis(cpuMS, wallMS),
@@ -219,7 +210,7 @@ func utilizationFromMillis(cpuMS, wallMS int64) float64 {
 	return float64(cpuMS) / float64(wallMS) * 100.0
 }
 
-func toInt64(v interface{}) int64 {
+func toInt64(v any) int64 {
 	switch n := v.(type) {
 	case int:
 		return int64(n)
@@ -246,7 +237,7 @@ func toInt64(v interface{}) int64 {
 	return 0
 }
 
-func toString(v interface{}) string {
+func toString(v any) string {
 	switch s := v.(type) {
 	case string:
 		return s

--- a/x-pack/osquerybeat/beater/query_profiler_test.go
+++ b/x-pack/osquerybeat/beater/query_profiler_test.go
@@ -16,7 +16,7 @@ import (
 func TestToInt64(t *testing.T) {
 	tests := []struct {
 		name string
-		in   interface{}
+		in   any
 		want int64
 	}{
 		{"int", 42, 42},
@@ -40,7 +40,7 @@ func TestToInt64(t *testing.T) {
 func TestToString(t *testing.T) {
 	tests := []struct {
 		name string
-		in   interface{}
+		in   any
 		want string
 	}{
 		{"string", "hello", "hello"},
@@ -111,7 +111,7 @@ func TestBuildLiveQueryProfile(t *testing.T) {
 
 func TestDiagnosticsErrorJSON(t *testing.T) {
 	data := diagnosticsErrorJSON("something failed")
-	var m map[string]interface{}
+	var m map[string]any
 	if err := json.Unmarshal(data, &m); err != nil {
 		t.Fatal(err)
 	}
@@ -128,18 +128,18 @@ func TestNewQueryProfiler(t *testing.T) {
 }
 
 type mockProfileQueryExecutor struct {
-	rows []map[string]interface{}
+	rows []map[string]any
 	err  error
 }
 
-func (m *mockProfileQueryExecutor) Query(ctx context.Context, sql string, timeout time.Duration) ([]map[string]interface{}, error) {
+func (m *mockProfileQueryExecutor) Query(ctx context.Context, sql string, timeout time.Duration) ([]map[string]any, error) {
 	return m.rows, m.err
 }
 
 func TestProfileScheduledQuery_FirstRun(t *testing.T) {
 	ctx := context.Background()
 	qe := &mockProfileQueryExecutor{
-		rows: []map[string]interface{}{
+		rows: []map[string]any{
 			{
 				"name":              "q1",
 				"query":             "SELECT * FROM osquery_info",
@@ -179,7 +179,7 @@ func TestScheduledProfilesDiagnosticsWithResolver_NilExecutor(t *testing.T) {
 	ctx := context.Background()
 	p := newQueryProfiler(logp.NewLogger("test"))
 	data := p.scheduledProfilesDiagnostics(ctx, nil)
-	var m map[string]interface{}
+	var m map[string]any
 	if err := json.Unmarshal(data, &m); err != nil {
 		t.Fatal(err)
 	}

--- a/x-pack/osquerybeat/beater/recurrence_query_handler.go
+++ b/x-pack/osquerybeat/beater/recurrence_query_handler.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"runtime"
 	"strings"
 	"sync"
@@ -51,7 +52,7 @@ type recurrenceQueryHandler struct {
 	osqueryVer   string
 
 	mx              sync.Mutex
-	previousResults map[string]map[string]map[string]interface{}
+	previousResults map[string]map[string]map[string]any
 }
 
 // newRecurrenceQueryHandler creates a new RRULE query handler.
@@ -65,7 +66,7 @@ func newRecurrenceQueryHandler(log *logp.Logger, cli *osqdcli.Client, configPlug
 		publisher:       pub,
 		profiles:        profiles,
 		osqueryVer:      osqueryVersion,
-		previousResults: make(map[string]map[string]map[string]interface{}),
+		previousResults: make(map[string]map[string]map[string]any),
 	}
 
 	h.scheduler = scheduler.New(log, h.executeQuery)
@@ -191,7 +192,7 @@ func platformMatches(selector, goos string) bool {
 	if selector == "" || selector == "all" {
 		return true
 	}
-	for _, platform := range strings.Split(selector, ",") {
+	for platform := range strings.SplitSeq(selector, ",") {
 		switch strings.TrimSpace(strings.ToLower(platform)) {
 		case "all":
 			return true
@@ -332,7 +333,7 @@ func (h *recurrenceQueryHandler) executeQuery(ctx context.Context, scheduledQuer
 
 	scheduleID := scheduledQuery.ScheduleID()
 
-	baseMeta := map[string]interface{}{
+	baseMeta := map[string]any{
 		"unix_time":                completedAt.Unix(),
 		"planned_schedule_time":    plannedScheduleTime.Format(time.RFC3339Nano),
 		"rrule_query":              true,
@@ -341,7 +342,7 @@ func (h *recurrenceQueryHandler) executeQuery(ctx context.Context, scheduledQuer
 	}
 
 	totalHits := 0
-	publish := func(typ, action string, rows []map[string]interface{}) {
+	publish := func(typ, action string, rows []map[string]any) {
 		if len(rows) == 0 {
 			return
 		}
@@ -369,15 +370,13 @@ func (h *recurrenceQueryHandler) executeQuery(ctx context.Context, scheduledQuer
 	return nil
 }
 
-func cloneRRuleMeta(meta map[string]interface{}) map[string]interface{} {
-	out := make(map[string]interface{}, len(meta)+2)
-	for k, v := range meta {
-		out[k] = v
-	}
+func cloneRRuleMeta(meta map[string]any) map[string]any {
+	out := make(map[string]any, len(meta)+2)
+	maps.Copy(out, meta)
 	return out
 }
 
-func (h *recurrenceQueryHandler) diffResults(name string, hits []map[string]interface{}, includeRemoved bool) ([]map[string]interface{}, []map[string]interface{}) {
+func (h *recurrenceQueryHandler) diffResults(name string, hits []map[string]any, includeRemoved bool) ([]map[string]any, []map[string]any) {
 	current := rowsByKey(hits)
 
 	h.mx.Lock()
@@ -389,8 +388,8 @@ func (h *recurrenceQueryHandler) diffResults(name string, hits []map[string]inte
 	return added, removed
 }
 
-func diffRows(previous, current map[string]map[string]interface{}, includeRemoved bool) ([]map[string]interface{}, []map[string]interface{}) {
-	var added []map[string]interface{}
+func diffRows(previous, current map[string]map[string]any, includeRemoved bool) ([]map[string]any, []map[string]any) {
+	var added []map[string]any
 	for key, row := range current {
 		if _, ok := previous[key]; !ok {
 			added = append(added, row)
@@ -399,7 +398,7 @@ func diffRows(previous, current map[string]map[string]interface{}, includeRemove
 	if !includeRemoved {
 		return added, nil
 	}
-	var removed []map[string]interface{}
+	var removed []map[string]any
 	for key, row := range previous {
 		if _, ok := current[key]; !ok {
 			removed = append(removed, row)
@@ -408,15 +407,15 @@ func diffRows(previous, current map[string]map[string]interface{}, includeRemove
 	return added, removed
 }
 
-func rowsByKey(rows []map[string]interface{}) map[string]map[string]interface{} {
-	out := make(map[string]map[string]interface{}, len(rows))
+func rowsByKey(rows []map[string]any) map[string]map[string]any {
+	out := make(map[string]map[string]any, len(rows))
 	for _, row := range rows {
 		out[rowKey(row)] = row
 	}
 	return out
 }
 
-func rowKey(row map[string]interface{}) string {
+func rowKey(row map[string]any) string {
 	raw, err := json.Marshal(row)
 	if err != nil {
 		return fmt.Sprintf("%v", row)

--- a/x-pack/osquerybeat/beater/recurrence_query_handler_test.go
+++ b/x-pack/osquerybeat/beater/recurrence_query_handler_test.go
@@ -70,21 +70,21 @@ func TestRecurrenceQueryHandlerCreateScheduledQuerySkipsIneligibleQueries(t *tes
 }
 
 func TestRRuleDiffRows(t *testing.T) {
-	previous := rowsByKey([]map[string]interface{}{
+	previous := rowsByKey([]map[string]any{
 		{"id": int64(1), "name": "old"},
 		{"id": int64(2), "name": "same"},
 	})
-	current := rowsByKey([]map[string]interface{}{
+	current := rowsByKey([]map[string]any{
 		{"id": int64(2), "name": "same"},
 		{"id": int64(3), "name": "new"},
 	})
 
 	added, removed := diffRows(previous, current, true)
-	assert.ElementsMatch(t, []map[string]interface{}{{"id": int64(3), "name": "new"}}, added)
-	assert.ElementsMatch(t, []map[string]interface{}{{"id": int64(1), "name": "old"}}, removed)
+	assert.ElementsMatch(t, []map[string]any{{"id": int64(3), "name": "new"}}, added)
+	assert.ElementsMatch(t, []map[string]any{{"id": int64(1), "name": "old"}}, removed)
 
 	added, removed = diffRows(previous, current, false)
-	assert.ElementsMatch(t, []map[string]interface{}{{"id": int64(3), "name": "new"}}, added)
+	assert.ElementsMatch(t, []map[string]any{{"id": int64(3), "name": "new"}}, added)
 	assert.Empty(t, removed)
 }
 

--- a/x-pack/osquerybeat/beater/resetable_action_handler.go
+++ b/x-pack/osquerybeat/beater/resetable_action_handler.go
@@ -63,7 +63,7 @@ func resetableActionHandlerWithTimeout(timeout time.Duration) optionFunc {
 	}
 }
 
-func (a *resetableActionHandler) Execute(ctx context.Context, req map[string]interface{}) (res map[string]interface{}, err error) {
+func (a *resetableActionHandler) Execute(ctx context.Context, req map[string]any) (res map[string]any, err error) {
 	a.log.Debug(formatLogMessage("execute"))
 
 	// Normalize error on exit, always return nil as error and encode it into result as per current contract
@@ -120,14 +120,14 @@ func (a *resetableActionHandler) Execute(ctx context.Context, req map[string]int
 	return res, nil
 }
 
-func formatLogMessage(format string, args ...interface{}) string {
+func formatLogMessage(format string, args ...any) string {
 	return "resetable action handler: " + fmt.Sprintf(format, args...)
 }
 
-func renderResult(res map[string]interface{}, err error) map[string]interface{} {
+func renderResult(res map[string]any, err error) map[string]any {
 	if res == nil {
 		now := time.Now().UTC()
-		res = map[string]interface{}{
+		res = map[string]any{
 			"started_at":   now.Format(time.RFC3339Nano),
 			"completed_at": now.Format(time.RFC3339Nano),
 		}
@@ -138,7 +138,7 @@ func renderResult(res map[string]interface{}, err error) map[string]interface{} 
 	return res
 }
 
-func (a *resetableActionHandler) execute(ctx context.Context, req map[string]interface{}) (map[string]interface{}, error) {
+func (a *resetableActionHandler) execute(ctx context.Context, req map[string]any) (map[string]any, error) {
 	a.mx.Lock()
 	defer a.mx.Unlock()
 

--- a/x-pack/osquerybeat/beater/resetable_action_handler_test.go
+++ b/x-pack/osquerybeat/beater/resetable_action_handler_test.go
@@ -22,9 +22,9 @@ type mockActionHandler struct {
 	err error
 }
 
-func (a *mockActionHandler) Execute(ctx context.Context, req map[string]interface{}) (map[string]interface{}, error) {
+func (a *mockActionHandler) Execute(ctx context.Context, req map[string]any) (map[string]any, error) {
 	now := time.Now().UTC()
-	res := map[string]interface{}{
+	res := map[string]any{
 		"started_at":   now.Format(time.RFC3339Nano),
 		"completed_at": now.Format(time.RFC3339Nano),
 	}
@@ -41,17 +41,16 @@ func (a *mockActionHandler) Name() string {
 }
 
 type mockActionResultPublisher struct {
-	req, res map[string]interface{}
+	req, res map[string]any
 }
 
-func (p *mockActionResultPublisher) PublishActionResult(req map[string]interface{}, res map[string]interface{}) {
+func (p *mockActionResultPublisher) PublishActionResult(req map[string]any, res map[string]any) {
 	p.req = req
 	p.res = res
 }
 
 func TestResetableActionHandler(t *testing.T) {
-	ctx, cn := context.WithCancel(context.Background())
-	defer cn()
+	ctx := t.Context()
 
 	log := logp.NewLogger("resetable_action_handler_test")
 

--- a/x-pack/osquerybeat/cmd/root.go
+++ b/x-pack/osquerybeat/cmd/root.go
@@ -149,7 +149,7 @@ func osquerybeatCfgFromStreams(rawIn *proto.UnitExpectedConfig, agentInfo *clien
 			streamList[iter]["type"] = rawIn.Type
 		}
 		if v, ok := streamList[iter]["data_stream"]; ok {
-			if m, ok := v.(map[string]interface{}); ok {
+			if m, ok := v.(map[string]any); ok {
 				if _, ok := m["namespace"]; !ok {
 					m["namespace"] = ns
 				}

--- a/x-pack/osquerybeat/cmd/root_test.go
+++ b/x-pack/osquerybeat/cmd/root_test.go
@@ -72,7 +72,7 @@ func readRawIn(filename string, rawIn *proto.UnitExpectedConfig) error {
 	return err
 }
 
-func readOut(filename string) (cfg []map[string]interface{}, err error) {
+func readOut(filename string) (cfg []map[string]any, err error) {
 	b, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
@@ -84,15 +84,15 @@ func readOut(filename string) (cfg []map[string]interface{}, err error) {
 	return cfg, err
 }
 
-func cfgToArrMap(cfg []*reload.ConfigWithMeta) ([]map[string]interface{}, error) {
-	res := make([]map[string]interface{}, 0, len(cfg))
+func cfgToArrMap(cfg []*reload.ConfigWithMeta) ([]map[string]any, error) {
+	res := make([]map[string]any, 0, len(cfg))
 	for _, c := range cfg {
 		var m mapstr.M
 		err := c.Config.Unpack(&m)
 		if err != nil {
 			return nil, err
 		}
-		res = append(res, map[string]interface{}(m))
+		res = append(res, map[string]any(m))
 	}
 	return res, nil
 }

--- a/x-pack/osquerybeat/ext/osquery-extension/pkg/amcache/tables/state_test.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/pkg/amcache/tables/state_test.go
@@ -130,13 +130,11 @@ func TestGetAmcacheState(t *testing.T) {
 
 	var wg sync.WaitGroup
 	for range 10 {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			got := GetAmcacheState()
 			assert.NotNil(t, got, "Expected GetAmcacheState to return a non-nil value")
 			assert.Equal(t, got, instance, "Expected GetAmcacheState to return the same instance")
-		}()
+		})
 	}
 	wg.Wait()
 

--- a/x-pack/osquerybeat/ext/osquery-extension/pkg/amcache/tables/tables.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/pkg/amcache/tables/tables.go
@@ -158,7 +158,7 @@ func fillInEntryFromKey(e Entry, key *regparser.CM_KEY_NODE, log *logger.Logger)
 			}
 		case reflect.Struct:
 			switch field.Type() {
-			case reflect.TypeOf(time.Time{}):
+			case reflect.TypeFor[time.Time]():
 				timeString := strings.TrimRight(value.ValueData().String, "\x00")
 				timestamp, err := time.Parse("01/02/2006 15:04:05", timeString)
 				if err != nil {

--- a/x-pack/osquerybeat/ext/osquery-extension/pkg/browserhistory/safari.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/pkg/browserhistory/safari.go
@@ -42,8 +42,8 @@ func newSafariParser(ctx context.Context, location searchLocation, log *logger.L
 
 func inferSafariBrowserName(path string) string {
 	normalized := filepath.ToSlash(path)
-	segments := strings.Split(normalized, "/")
-	for _, segment := range segments {
+	segments := strings.SplitSeq(normalized, "/")
+	for segment := range segments {
 		segment = strings.TrimSpace(segment)
 		if segment == "" {
 			continue

--- a/x-pack/osquerybeat/ext/osquery-extension/pkg/browserhistory/users.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/pkg/browserhistory/users.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 
 	"github.com/elastic/beats/v7/x-pack/osquerybeat/ext/osquery-extension/pkg/logger"
@@ -54,13 +55,7 @@ func discoverUsers(log *logger.Logger) []string {
 					continue
 				}
 
-				found := false
-				for _, existing := range userDirs {
-					if existing == match { // Compare full paths, not just usernames
-						found = true
-						break
-					}
-				}
+				found := slices.Contains(userDirs, match)
 				if !found {
 					log.Infof("discovered user: %s, fullPath: %s", username, match)
 					userDirs = append(userDirs, match) // Store full path instead of just username

--- a/x-pack/osquerybeat/ext/osquery-extension/pkg/encoding/encoding.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/pkg/encoding/encoding.go
@@ -6,6 +6,7 @@ package encoding
 
 import (
 	"fmt"
+	"maps"
 	"reflect"
 	"strconv"
 	"strings"
@@ -46,7 +47,7 @@ func MarshalToMapWithFlags(in any, flags EncodingFlag) (map[string]string, error
 	v := reflect.ValueOf(in)
 	t := reflect.TypeOf(in)
 
-	if v.Kind() == reflect.Ptr {
+	if v.Kind() == reflect.Pointer {
 		if v.IsNil() {
 			return nil, fmt.Errorf("input pointer is nil")
 		}
@@ -91,7 +92,7 @@ func MarshalToMapWithFlags(in any, flags EncodingFlag) (map[string]string, error
 		// and the tag will be empty.  We need to recurse into the embedded struct and merge the results.
 		if fieldType.Anonymous && tag == "" {
 			// Handle pointer to struct if necessary
-			if fieldValue.Kind() == reflect.Ptr {
+			if fieldValue.Kind() == reflect.Pointer {
 				if fieldValue.IsNil() {
 					continue
 				}
@@ -105,9 +106,7 @@ func MarshalToMapWithFlags(in any, flags EncodingFlag) (map[string]string, error
 					return nil, err
 				}
 				// Merge the embedded results into the current map
-				for k, v := range embeddedMap {
-					result[k] = v
-				}
+				maps.Copy(result, embeddedMap)
 				continue // Skip the rest of the loop for this field
 			}
 		}
@@ -141,7 +140,7 @@ func GenerateColumnDefinitions(in any) ([]table.ColumnDefinition, error) {
 	var columns []table.ColumnDefinition
 
 	// Handle pointer types by unwrapping to get the underlying type
-	if t.Kind() == reflect.Ptr {
+	if t.Kind() == reflect.Pointer {
 		t = t.Elem()
 	}
 
@@ -149,8 +148,7 @@ func GenerateColumnDefinitions(in any) ([]table.ColumnDefinition, error) {
 		return nil, fmt.Errorf("unsupported type: %s, must be a struct or pointer to struct", t.Kind())
 	}
 
-	for i := 0; i < t.NumField(); i++ {
-		fieldType := t.Field(i)
+	for fieldType := range t.Fields() {
 
 		if !fieldType.IsExported() {
 			continue
@@ -165,7 +163,7 @@ func GenerateColumnDefinitions(in any) ([]table.ColumnDefinition, error) {
 		if fieldType.Anonymous && key == "" {
 			// Get the embedded struct type, handling pointer to struct if necessary
 			embeddedType := fieldType.Type
-			if embeddedType.Kind() == reflect.Ptr {
+			if embeddedType.Kind() == reflect.Pointer {
 				embeddedType = embeddedType.Elem()
 			}
 
@@ -196,7 +194,7 @@ func GenerateColumnDefinitions(in any) ([]table.ColumnDefinition, error) {
 		fieldKind := fieldType.Type.Kind()
 
 		// Handle pointer types by unwrapping to get the underlying type
-		if fieldKind == reflect.Ptr {
+		if fieldKind == reflect.Pointer {
 			fieldKind = fieldType.Type.Elem().Kind()
 		}
 
@@ -220,7 +218,7 @@ func GenerateColumnDefinitions(in any) ([]table.ColumnDefinition, error) {
 		case reflect.Struct:
 			// Handle time.Time type
 			switch fieldType.Type {
-			case reflect.TypeOf(time.Time{}):
+			case reflect.TypeFor[time.Time]():
 				if timeFormat, ok := tag.Lookup("format"); ok {
 					switch strings.ToLower(timeFormat) {
 					case "unix", "unixnano", "unixmilli", "unixmicro":
@@ -248,7 +246,7 @@ func GenerateColumnDefinitions(in any) ([]table.ColumnDefinition, error) {
 // It also handles the EncodingFlagUseNumbersZeroValues flag and the tag format and tz attributes.
 func convertValueToStringWithTag(fieldValue reflect.Value, flag EncodingFlag, tag *reflect.StructTag) (string, error) {
 	// Handle pointers first
-	if fieldValue.Kind() == reflect.Ptr {
+	if fieldValue.Kind() == reflect.Pointer {
 		if fieldValue.IsNil() {
 			return "", nil
 		}
@@ -298,7 +296,7 @@ func convertValueToStringWithTag(fieldValue reflect.Value, flag EncodingFlag, ta
 	case reflect.Struct:
 		// Handle time.Time type
 		switch fieldValue.Type() {
-		case reflect.TypeOf(time.Time{}):
+		case reflect.TypeFor[time.Time]():
 			return formatTimeWithTagFormat(fieldValue, flag, tag)
 		default:
 			return "", fmt.Errorf("unsupported struct type: %s", fieldValue.Type())

--- a/x-pack/osquerybeat/ext/osquery-extension/pkg/jumplists/application_id.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/pkg/jumplists/application_id.go
@@ -32,9 +32,9 @@ func newApplicationID(id string) *jumpliststypes.ApplicationID {
 // It is used to create a new ApplicationId object from the file name.
 func getAppIdFromFileName(filePath string) *jumpliststypes.ApplicationID {
 	fileName := filepath.Base(filePath)
-	dotIndex := strings.Index(fileName, ".")
-	if dotIndex != -1 {
-		return newApplicationID(fileName[:dotIndex])
+	before, _, ok := strings.Cut(fileName, ".")
+	if ok {
+		return newApplicationID(before)
 	}
 	return newApplicationID("")
 }

--- a/x-pack/osquerybeat/ext/osquery-extension/pkg/jumplists/generate/scrape_app_ids.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/pkg/jumplists/generate/scrape_app_ids.go
@@ -33,8 +33,8 @@ func scrapeJumplistAppIDs(opts generatorOptions, log *logger.Logger) (map[string
 		return nil, err
 	}
 
-	lines := strings.Split(bodyString, "\n")
-	for _, line := range lines {
+	lines := strings.SplitSeq(bodyString, "\n")
+	for line := range lines {
 		line = strings.TrimSpace(line)
 		if line == "" {
 			continue // Skip empty lines

--- a/x-pack/osquerybeat/ext/osquery-extension/pkg/logger/glog.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/pkg/logger/glog.go
@@ -158,7 +158,7 @@ func (l *Logger) Info(msg string) {
 }
 
 // Infof logs a formatted informational message (only if verbose is enabled)
-func (l *Logger) Infof(format string, args ...interface{}) {
+func (l *Logger) Infof(format string, args ...any) {
 	l.log(LevelInfo, fmt.Sprintf(format, args...))
 }
 
@@ -168,7 +168,7 @@ func (l *Logger) Warning(msg string) {
 }
 
 // Warningf logs a formatted warning message
-func (l *Logger) Warningf(format string, args ...interface{}) {
+func (l *Logger) Warningf(format string, args ...any) {
 	l.log(LevelWarning, fmt.Sprintf(format, args...))
 }
 
@@ -178,7 +178,7 @@ func (l *Logger) Error(msg string) {
 }
 
 // Errorf logs a formatted error message
-func (l *Logger) Errorf(format string, args ...interface{}) {
+func (l *Logger) Errorf(format string, args ...any) {
 	l.log(LevelError, fmt.Sprintf(format, args...))
 }
 
@@ -189,7 +189,7 @@ func (l *Logger) Fatal(msg string) {
 }
 
 // Fatalf logs a formatted error message and exits
-func (l *Logger) Fatalf(format string, args ...interface{}) {
+func (l *Logger) Fatalf(format string, args ...any) {
 	l.log(LevelError, fmt.Sprintf(format, args...))
 	osExit(1)
 }

--- a/x-pack/osquerybeat/ext/osquery-extension/pkg/logger/glog_test.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/pkg/logger/glog_test.go
@@ -366,7 +366,7 @@ func TestConcurrentLogging(t *testing.T) {
 
 	// Run concurrent logging operations
 	done := make(chan bool)
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		go func(id int) {
 			log.Infof("concurrent message %d", id)
 			log.Warningf("concurrent warning %d", id)
@@ -376,7 +376,7 @@ func TestConcurrentLogging(t *testing.T) {
 	}
 
 	// Wait for all goroutines to complete
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		<-done
 	}
 

--- a/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/io.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/io.go
@@ -41,8 +41,8 @@ func ReadIOFS(fsys fs.FS, pid string) (procio ProcIO, err error) {
 		return
 	}
 
-	lines := bytes.Split(b, []byte{'\n'})
-	for _, line := range lines {
+	lines := bytes.SplitSeq(b, []byte{'\n'})
+	for line := range lines {
 		detail := bytes.SplitN(line, []byte{':'}, 2)
 		if len(detail) != 2 {
 			continue

--- a/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/stat.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/stat.go
@@ -85,8 +85,8 @@ func ReadStatFS(sysfs fs.FS, pid string) (stat ProcStat, err error) {
 		return
 	}
 
-	lines := bytes.Split(b, []byte{'\n'})
-	for _, line := range lines {
+	lines := bytes.SplitSeq(b, []byte{'\n'})
+	for line := range lines {
 		detail := bytes.SplitN(line, []byte{':'}, 2)
 		if len(detail) != 2 {
 			continue

--- a/x-pack/osquerybeat/internal/action/action.go
+++ b/x-pack/osquerybeat/internal/action/action.go
@@ -31,7 +31,7 @@ type Action struct {
 	Profile *bool
 }
 
-func FromMap(m map[string]interface{}) (a Action, err error) {
+func FromMap(m map[string]any) (a Action, err error) {
 	if len(m) == 0 {
 		return a, ErrActionRequest
 	}
@@ -52,8 +52,8 @@ func FromMap(m map[string]interface{}) (a Action, err error) {
 		profile   *bool
 	)
 	if v, ok := m["data"]; ok {
-		var data map[string]interface{}
-		if data, ok = v.(map[string]interface{}); !ok {
+		var data map[string]any
+		if data, ok = v.(map[string]any); !ok {
 			return a, fmt.Errorf("invalid data: %w", ErrActionRequest)
 		}
 
@@ -71,7 +71,7 @@ func FromMap(m map[string]interface{}) (a Action, err error) {
 		}
 		// Parse optional ECS Mapping
 		if v, ok := data["ecs_mapping"]; ok && v != nil {
-			m, ok := v.(map[string]interface{})
+			m, ok := v.(map[string]any)
 			if !ok {
 				return a, fmt.Errorf("invalid ECS mapping: %w", ErrActionRequest)
 			}
@@ -167,20 +167,20 @@ func platformMatches(goos string, platforms []string) bool {
 	return false
 }
 
-func parseECSMapping(m map[string]interface{}) (ecsm ecs.Mapping, err error) {
+func parseECSMapping(m map[string]any) (ecsm ecs.Mapping, err error) {
 	ecsm = make(ecs.Mapping)
 	for k, v := range m {
 		k = strings.TrimSpace(k)
 		if k == "" {
 			return ecsm, ErrActionRequest
 		}
-		valmap, ok := v.(map[string]interface{})
+		valmap, ok := v.(map[string]any)
 		if !ok {
 			return ecsm, ErrActionRequest
 		}
 
 		var (
-			val   interface{}
+			val   any
 			field string
 		)
 
@@ -210,7 +210,7 @@ func parseECSMapping(m map[string]interface{}) (ecsm ecs.Mapping, err error) {
 	return ecsm, err
 }
 
-func convertToInt64(i interface{}) (int64, error) {
+func convertToInt64(i any) (int64, error) {
 	switch v := i.(type) {
 	case int8:
 		return int64(v), nil

--- a/x-pack/osquerybeat/internal/action/action_test.go
+++ b/x-pack/osquerybeat/internal/action/action_test.go
@@ -17,7 +17,7 @@ func TestActionFromMap(t *testing.T) {
 
 	tests := []struct {
 		Name string
-		Map  map[string]interface{}
+		Map  map[string]any
 		Err  error
 	}{
 		{
@@ -27,19 +27,19 @@ func TestActionFromMap(t *testing.T) {
 		},
 		{
 			Name: "empty",
-			Map:  map[string]interface{}{},
+			Map:  map[string]any{},
 			Err:  ErrActionRequest,
 		},
 		{
 			Name: "invalid id",
-			Map: map[string]interface{}{
+			Map: map[string]any{
 				"id": 123,
 			},
 			Err: ErrActionRequest,
 		},
 		{
 			Name: "invalid data",
-			Map: map[string]interface{}{
+			Map: map[string]any{
 				"id":   "123456789",
 				"data": "foo",
 			},
@@ -47,9 +47,9 @@ func TestActionFromMap(t *testing.T) {
 		},
 		{
 			Name: "invalid query",
-			Map: map[string]interface{}{
+			Map: map[string]any{
 				"id": "123456789",
-				"data": map[string]interface{}{
+				"data": map[string]any{
 					"query": 123221231,
 				},
 			},
@@ -57,18 +57,18 @@ func TestActionFromMap(t *testing.T) {
 		},
 		{
 			Name: "valid string for query",
-			Map: map[string]interface{}{
+			Map: map[string]any{
 				"id": "123456789",
-				"data": map[string]interface{}{
+				"data": map[string]any{
 					"query": "select * from foo",
 				},
 			},
 		},
 		{
 			Name: "valid profile flag",
-			Map: map[string]interface{}{
+			Map: map[string]any{
 				"id": "123456789",
-				"data": map[string]interface{}{
+				"data": map[string]any{
 					"query":   "select * from foo",
 					"profile": true,
 				},
@@ -76,9 +76,9 @@ func TestActionFromMap(t *testing.T) {
 		},
 		{
 			Name: "valid platform",
-			Map: map[string]interface{}{
+			Map: map[string]any{
 				"id": "123456789",
-				"data": map[string]interface{}{
+				"data": map[string]any{
 					"query":    "select * from foo",
 					"platform": " linux , windows ",
 				},
@@ -86,9 +86,9 @@ func TestActionFromMap(t *testing.T) {
 		},
 		{
 			Name: "invalid platform type",
-			Map: map[string]interface{}{
+			Map: map[string]any{
 				"id": "123456789",
-				"data": map[string]interface{}{
+				"data": map[string]any{
 					"query":    "select * from foo",
 					"platform": []string{"linux"},
 				},
@@ -97,9 +97,9 @@ func TestActionFromMap(t *testing.T) {
 		},
 		{
 			Name: "invalid profile flag type",
-			Map: map[string]interface{}{
+			Map: map[string]any{
 				"id": "123456789",
-				"data": map[string]interface{}{
+				"data": map[string]any{
 					"query":   "select * from foo",
 					"profile": "true",
 				},
@@ -108,9 +108,9 @@ func TestActionFromMap(t *testing.T) {
 		},
 		{
 			Name: "empty id",
-			Map: map[string]interface{}{
+			Map: map[string]any{
 				"id": "",
-				"data": map[string]interface{}{
+				"data": map[string]any{
 					"query": "select * from foo",
 				},
 			},
@@ -118,9 +118,9 @@ func TestActionFromMap(t *testing.T) {
 		},
 		{
 			Name: "space empty id",
-			Map: map[string]interface{}{
+			Map: map[string]any{
 				"id": "    ",
-				"data": map[string]interface{}{
+				"data": map[string]any{
 					"query": "select * from foo",
 				},
 			},
@@ -128,9 +128,9 @@ func TestActionFromMap(t *testing.T) {
 		},
 		{
 			Name: "empty query",
-			Map: map[string]interface{}{
+			Map: map[string]any{
 				"id": "123456789",
-				"data": map[string]interface{}{
+				"data": map[string]any{
 					"query": "",
 				},
 			},
@@ -138,9 +138,9 @@ func TestActionFromMap(t *testing.T) {
 		},
 		{
 			Name: "space empty query",
-			Map: map[string]interface{}{
+			Map: map[string]any{
 				"id": "123456789",
-				"data": map[string]interface{}{
+				"data": map[string]any{
 					"query": "   ",
 				},
 			},
@@ -214,15 +214,15 @@ func TestActionFromMapWithECSMapping(t *testing.T) {
 
 	tests := []struct {
 		Name   string
-		Map    map[string]interface{}
+		Map    map[string]any
 		Action Action
 		Err    error
 	}{
 		{
 			Name: "valid",
-			Map: map[string]interface{}{
+			Map: map[string]any{
 				"id": "214f219d-d67c-4744-8eb1-0a812594263f",
-				"data": map[string]interface{}{
+				"data": map[string]any{
 					"query": "select * from users limit 2",
 				},
 			},
@@ -233,9 +233,9 @@ func TestActionFromMapWithECSMapping(t *testing.T) {
 		},
 		{
 			Name: "ECS mapping nil",
-			Map: map[string]interface{}{
+			Map: map[string]any{
 				"id": "214f219d-d67c-4744-8eb1-0a812594263f",
-				"data": map[string]interface{}{
+				"data": map[string]any{
 					"query":       "select * from users limit 2",
 					"ecs_mapping": nil,
 				},
@@ -247,9 +247,9 @@ func TestActionFromMapWithECSMapping(t *testing.T) {
 		},
 		{
 			Name: "ECS mapping empty string",
-			Map: map[string]interface{}{
+			Map: map[string]any{
 				"id": "214f219d-d67c-4744-8eb1-0a812594263f",
-				"data": map[string]interface{}{
+				"data": map[string]any{
 					"query":       "select * from users limit 2",
 					"ecs_mapping": "",
 				},
@@ -258,11 +258,11 @@ func TestActionFromMapWithECSMapping(t *testing.T) {
 		},
 		{
 			Name: "ECS mapping empty",
-			Map: map[string]interface{}{
+			Map: map[string]any{
 				"id": "214f219d-d67c-4744-8eb1-0a812594263f",
-				"data": map[string]interface{}{
+				"data": map[string]any{
 					"query":       "select * from users limit 2",
-					"ecs_mapping": map[string]interface{}{},
+					"ecs_mapping": map[string]any{},
 				},
 			},
 			Action: Action{
@@ -273,11 +273,11 @@ func TestActionFromMapWithECSMapping(t *testing.T) {
 		},
 		{
 			Name: "ECS mapping invalid",
-			Map: map[string]interface{}{
+			Map: map[string]any{
 				"id": "214f219d-d67c-4744-8eb1-0a812594263f",
-				"data": map[string]interface{}{
+				"data": map[string]any{
 					"query": "select * from users limit 2",
-					"ecs_mapping": map[string]interface{}{
+					"ecs_mapping": map[string]any{
 						"foo": "bar",
 					},
 				},
@@ -286,12 +286,12 @@ func TestActionFromMapWithECSMapping(t *testing.T) {
 		},
 		{
 			Name: "ECS mapping invalid, field spaces string",
-			Map: map[string]interface{}{
+			Map: map[string]any{
 				"id": "214f219d-d67c-4744-8eb1-0a812594263f",
-				"data": map[string]interface{}{
+				"data": map[string]any{
 					"query": "select * from users limit 2",
-					"ecs_mapping": map[string]interface{}{
-						"user.custom.shoeSize": map[string]interface{}{
+					"ecs_mapping": map[string]any{
+						"user.custom.shoeSize": map[string]any{
 							"field": "      ",
 						},
 					},
@@ -301,12 +301,12 @@ func TestActionFromMapWithECSMapping(t *testing.T) {
 		},
 		{
 			Name: "ECS mapping invalid, key empty",
-			Map: map[string]interface{}{
+			Map: map[string]any{
 				"id": "214f219d-d67c-4744-8eb1-0a812594263f",
-				"data": map[string]interface{}{
+				"data": map[string]any{
 					"query": "select * from users limit 2",
-					"ecs_mapping": map[string]interface{}{
-						"": map[string]interface{}{
+					"ecs_mapping": map[string]any{
+						"": map[string]any{
 							"field": "uid",
 						},
 					},
@@ -316,12 +316,12 @@ func TestActionFromMapWithECSMapping(t *testing.T) {
 		},
 		{
 			Name: "ECS mapping invalid, key spaces",
-			Map: map[string]interface{}{
+			Map: map[string]any{
 				"id": "214f219d-d67c-4744-8eb1-0a812594263f",
-				"data": map[string]interface{}{
+				"data": map[string]any{
 					"query": "select * from users limit 2",
-					"ecs_mapping": map[string]interface{}{
-						"  ": map[string]interface{}{
+					"ecs_mapping": map[string]any{
+						"  ": map[string]any{
 							"field": "uid",
 						},
 					},
@@ -331,12 +331,12 @@ func TestActionFromMapWithECSMapping(t *testing.T) {
 		},
 		{
 			Name: "ECS mapping invalid, field non-string",
-			Map: map[string]interface{}{
+			Map: map[string]any{
 				"id": "214f219d-d67c-4744-8eb1-0a812594263f",
-				"data": map[string]interface{}{
+				"data": map[string]any{
 					"query": "select * from users limit 2",
-					"ecs_mapping": map[string]interface{}{
-						"user.custom.shoeSize": map[string]interface{}{
+					"ecs_mapping": map[string]any{
+						"user.custom.shoeSize": map[string]any{
 							"field": 123,
 						},
 					},
@@ -346,12 +346,12 @@ func TestActionFromMapWithECSMapping(t *testing.T) {
 		},
 		{
 			Name: "ECS mapping invalid, both field and value defined",
-			Map: map[string]interface{}{
+			Map: map[string]any{
 				"id": "214f219d-d67c-4744-8eb1-0a812594263f",
-				"data": map[string]interface{}{
+				"data": map[string]any{
 					"query": "select * from users limit 2",
-					"ecs_mapping": map[string]interface{}{
-						"user.custom.shoeSize": map[string]interface{}{
+					"ecs_mapping": map[string]any{
+						"user.custom.shoeSize": map[string]any{
 							"value": 48,
 							"field": "uid",
 						},
@@ -362,15 +362,15 @@ func TestActionFromMapWithECSMapping(t *testing.T) {
 		},
 		{
 			Name: "ECS mapping valid",
-			Map: map[string]interface{}{
+			Map: map[string]any{
 				"id": "214f219d-d67c-4744-8eb1-0a812594263f",
-				"data": map[string]interface{}{
+				"data": map[string]any{
 					"query": "select * from users limit 2",
-					"ecs_mapping": map[string]interface{}{
-						"user.custom.shoeSize": map[string]interface{}{
+					"ecs_mapping": map[string]any{
+						"user.custom.shoeSize": map[string]any{
 							"value": 48,
 						},
-						"user.id": map[string]interface{}{
+						"user.id": map[string]any{
 							"field": "uid",
 						},
 					},

--- a/x-pack/osquerybeat/internal/config/config_test.go
+++ b/x-pack/osquerybeat/internal/config/config_test.go
@@ -11,9 +11,6 @@ import (
 	"github.com/elastic/elastic-agent-libs/transport/tlscommon"
 )
 
-//go:fix inline
-func boolPtr(v bool) *bool { return new(v) }
-
 func TestInstallConfigNormalizeAndValidate(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/x-pack/osquerybeat/internal/config/config_test.go
+++ b/x-pack/osquerybeat/internal/config/config_test.go
@@ -11,7 +11,8 @@ import (
 	"github.com/elastic/elastic-agent-libs/transport/tlscommon"
 )
 
-func boolPtr(v bool) *bool { return &v }
+//go:fix inline
+func boolPtr(v bool) *bool { return new(v) }
 
 func TestInstallConfigNormalizeAndValidate(t *testing.T) {
 	tests := []struct {
@@ -77,7 +78,7 @@ func TestInstallConfigNormalizeAndValidate(t *testing.T) {
 					AMD64: &InstallArtifactConfig{
 						ArtifactURL:      "http://example.com/osquery.tar.gz",
 						SHA256:           "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-						AllowInsecureURL: boolPtr(true),
+						AllowInsecureURL: new(true),
 					},
 				},
 			},
@@ -89,7 +90,7 @@ func TestInstallConfigNormalizeAndValidate(t *testing.T) {
 					AMD64: &InstallArtifactConfig{
 						ArtifactURL:      "http://example.com/osquery.tar.gz",
 						SHA256:           "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-						AllowInsecureURL: boolPtr(false),
+						AllowInsecureURL: new(false),
 					},
 				},
 				AllowInsecureURL: true,
@@ -272,7 +273,7 @@ func TestInstallConfigPlatformOverrides(t *testing.T) {
 			AMD64: &InstallArtifactConfig{
 				ArtifactURL:      "https://example.org/osquery-linux.tar.gz",
 				SHA256:           "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-				AllowInsecureURL: boolPtr(true),
+				AllowInsecureURL: new(true),
 			},
 		},
 	}
@@ -304,7 +305,7 @@ func TestInstallConfigOverridePrecedence(t *testing.T) {
 			AMD64: &InstallArtifactConfig{
 				ArtifactURL:      "https://example.org/osquery-linux-amd64.tar.gz",
 				SHA256:           "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-				AllowInsecureURL: boolPtr(true),
+				AllowInsecureURL: new(true),
 				SSL:              archSSL,
 			},
 		},
@@ -422,12 +423,12 @@ func TestGetOsqueryExtensions(t *testing.T) {
 	})
 
 	t.Run("unpacks config tags from yaml", func(t *testing.T) {
-		c, err := conf.NewConfigFrom(map[string]interface{}{
-			"inputs": []map[string]interface{}{
+		c, err := conf.NewConfigFrom(map[string]any{
+			"inputs": []map[string]any{
 				{
-					"osquery": map[string]interface{}{
-						"elastic_options": map[string]interface{}{
-							"extensions": map[string]interface{}{
+					"osquery": map[string]any{
+						"elastic_options": map[string]any{
+							"extensions": map[string]any{
 								"paths":   []string{"/opt/ext"},
 								"timeout": 15,
 								"require": []string{"my_extension"},

--- a/x-pack/osquerybeat/internal/config/osquery.go
+++ b/x-pack/osquerybeat/internal/config/osquery.go
@@ -232,7 +232,7 @@ type Query struct {
 	Description int    `config:"description" json:"description,omitempty"`
 
 	// Optional ECS mapping for the query, not rendered into osqueryd configuration
-	ECSMapping map[string]interface{} `config:"ecs_mapping" json:"-"`
+	ECSMapping map[string]any `config:"ecs_mapping" json:"-"`
 
 	// A boolean to set 'snapshot' mode, default true
 	// This is different from the default osquery behavior where the missing value defaults to false
@@ -313,16 +313,16 @@ type Events struct {
 }
 
 type OsqueryConfig struct {
-	Options               map[string]interface{} `config:"options" json:"options,omitempty"`
-	ElasticOptions        *ElasticOptions        `config:"elastic_options" json:"-"`
-	Schedule              map[string]Query       `config:"schedule" json:"schedule,omitempty"`
-	Packs                 map[string]Pack        `config:"packs" json:"packs,omitempty"`
-	Filepaths             map[string][]string    `config:"file_paths" json:"file_paths,omitempty"`
-	Views                 map[string]string      `config:"views" json:"views,omitempty"`
-	Events                *Events                `config:"events" json:"events,omitempty"`
-	Yara                  map[string]interface{} `config:"yara" json:"yara,omitempty"`
-	PrometheusTargets     map[string]interface{} `config:"prometheus_targets" json:"prometheus_targets,omitempty"`
-	AutoTableConstruction map[string]interface{} `config:"auto_table_construction" json:"auto_table_construction,omitempty"`
+	Options               map[string]any      `config:"options" json:"options,omitempty"`
+	ElasticOptions        *ElasticOptions     `config:"elastic_options" json:"-"`
+	Schedule              map[string]Query    `config:"schedule" json:"schedule,omitempty"`
+	Packs                 map[string]Pack     `config:"packs" json:"packs,omitempty"`
+	Filepaths             map[string][]string `config:"file_paths" json:"file_paths,omitempty"`
+	Views                 map[string]string   `config:"views" json:"views,omitempty"`
+	Events                *Events             `config:"events" json:"events,omitempty"`
+	Yara                  map[string]any      `config:"yara" json:"yara,omitempty"`
+	PrometheusTargets     map[string]any      `config:"prometheus_targets" json:"prometheus_targets,omitempty"`
+	AutoTableConstruction map[string]any      `config:"auto_table_construction" json:"auto_table_construction,omitempty"`
 }
 
 // forOsqueryd returns a copy of c without queries that osquerybeat runs via RRULE (they would

--- a/x-pack/osquerybeat/internal/config/osquery_test.go
+++ b/x-pack/osquerybeat/internal/config/osquery_test.go
@@ -37,19 +37,19 @@ func TestOsqueryConfig_Render_OmitsRRULEQueries(t *testing.T) {
 	}
 	out, err := cfg.Render()
 	require.NoError(t, err)
-	var decoded map[string]interface{}
+	var decoded map[string]any
 	require.NoError(t, json.Unmarshal(out, &decoded))
-	sched, ok := decoded["schedule"].(map[string]interface{})
+	sched, ok := decoded["schedule"].(map[string]any)
 	require.True(t, ok, "schedule present")
 	_, hasRRule := sched["rrule"]
 	assert.False(t, hasRRule, "RRULE-only top-level query must not appear in osqueryd config")
 	_, hasNative := sched["native"]
 	assert.True(t, hasNative)
-	packs, ok := decoded["packs"].(map[string]interface{})
+	packs, ok := decoded["packs"].(map[string]any)
 	require.True(t, ok)
-	mixed, ok := packs["mixed"].(map[string]interface{})
+	mixed, ok := packs["mixed"].(map[string]any)
 	require.True(t, ok)
-	mq, ok := mixed["queries"].(map[string]interface{})
+	mq, ok := mixed["queries"].(map[string]any)
 	require.True(t, ok)
 	_, hasB := mq["b"]
 	assert.False(t, hasB, "RRULE pack query must be omitted")
@@ -63,16 +63,16 @@ func TestOsqueryConfig_Render_Options(t *testing.T) {
 	// Native osquery options (e.g. schedule_splay_percent, schedule_max_drift) are
 	// passed through in Options; defaults are applied when building config for osqueryd (beater).
 	rendered, err := OsqueryConfig{
-		Options: map[string]interface{}{
+		Options: map[string]any{
 			"schedule_splay_percent": 10,
 			"schedule_max_drift":     60,
 		},
 	}.Render()
 	require.NoError(t, err)
-	var result map[string]interface{}
+	var result map[string]any
 	err = json.Unmarshal(rendered, &result)
 	require.NoError(t, err)
-	options, ok := result["options"].(map[string]interface{})
+	options, ok := result["options"].(map[string]any)
 	require.True(t, ok)
 	assert.Equal(t, float64(10), options["schedule_splay_percent"])
 	assert.Equal(t, float64(60), options["schedule_max_drift"])
@@ -228,6 +228,7 @@ func TestRRuleScheduleConfig_ParseDates(t *testing.T) {
 	})
 }
 
+//go:fix inline
 func intPtr(i int) *int {
-	return &i
+	return new(i)
 }

--- a/x-pack/osquerybeat/internal/config/osquery_test.go
+++ b/x-pack/osquerybeat/internal/config/osquery_test.go
@@ -227,8 +227,3 @@ func TestRRuleScheduleConfig_ParseDates(t *testing.T) {
 		assert.Nil(t, parsed)
 	})
 }
-
-//go:fix inline
-func intPtr(i int) *int {
-	return new(i)
-}

--- a/x-pack/osquerybeat/internal/config/watcher.go
+++ b/x-pack/osquerybeat/internal/config/watcher.go
@@ -23,7 +23,7 @@ func (r *reloader) debugLogConfig(cfg *reload.ConfigWithMeta) {
 		return
 	}
 
-	var m map[string]interface{}
+	var m map[string]any
 	err := cfg.Config.Unpack(&m)
 	if err != nil {
 		r.log.Debugf("Failed to unpack the config for debug logging: %v", err)

--- a/x-pack/osquerybeat/internal/ecs/mapping.go
+++ b/x-pack/osquerybeat/internal/ecs/mapping.go
@@ -8,11 +8,11 @@ import "strings"
 
 const keySeparator = "."
 
-type Doc map[string]interface{}
+type Doc map[string]any
 
 type MappingInfo struct {
-	Field string      `json:"field,omitempty" config:"field,omitempty"`
-	Value interface{} `json:"value,omitempty" config:"value,omitempty"`
+	Field string `json:"field,omitempty" config:"field,omitempty"`
+	Value any    `json:"value,omitempty" config:"value,omitempty"`
 }
 
 // Mapping is ECS mapping definition where the key is the dotted ECS field name
@@ -20,7 +20,7 @@ type Mapping map[string]MappingInfo
 
 // Map creates the copy of the values from the doc[src] key to the doc[dst] key where the dst can be nested '.' delimited key
 // Source is expected to be a simple key name, the destination could be nested child node
-func (m Mapping) Map(doc map[string]interface{}) map[string]interface{} {
+func (m Mapping) Map(doc map[string]any) map[string]any {
 	res := make(Doc)
 	for dst, mi := range m {
 		if mi.Value != nil {
@@ -36,7 +36,7 @@ func (m Mapping) Map(doc map[string]interface{}) map[string]interface{} {
 	return res
 }
 
-func (d Doc) Get(key string) (val interface{}, ok bool) {
+func (d Doc) Get(key string) (val any, ok bool) {
 	keys := getKeys(key)
 	node := d
 
@@ -46,7 +46,7 @@ func (d Doc) Get(key string) (val interface{}, ok bool) {
 		}
 		val, ok = node[keys[i]]
 		if ok {
-			node, ok = val.(map[string]interface{})
+			node, ok = val.(map[string]any)
 			if ok {
 				continue
 			} else {
@@ -63,9 +63,9 @@ func (d Doc) Get(key string) (val interface{}, ok bool) {
 	return val, ok
 }
 
-func (d Doc) Set(key string, val interface{}) {
+func (d Doc) Set(key string, val any) {
 	keys := getKeys(key)
-	node := map[string]interface{}(d)
+	node := map[string]any(d)
 
 	// Create nested keys if needed
 	for i := 0; i < len(keys)-1; i++ {
@@ -75,7 +75,7 @@ func (d Doc) Set(key string, val interface{}) {
 
 		inode, ok := node[keys[i]]
 		if ok {
-			node, ok = inode.(map[string]interface{})
+			node, ok = inode.(map[string]any)
 			// Should never happen, internal implementation
 			if !ok {
 				return
@@ -85,7 +85,7 @@ func (d Doc) Set(key string, val interface{}) {
 			// otherwise the large numbers are serialized into scientific notation in bulk json
 			// which breaks values like unix timestamp in seconds
 			// Fixes the issue https://github.com/elastic/security-team/issues/1950
-			m := make(map[string]interface{})
+			m := make(map[string]any)
 			node[keys[i]] = m
 			node = m
 		}

--- a/x-pack/osquerybeat/internal/ecs/mapping_test.go
+++ b/x-pack/osquerybeat/internal/ecs/mapping_test.go
@@ -70,8 +70,8 @@ func TestMapValue(t *testing.T) {
 		"value.empty":  {Value: ""},
 		"value.zero":   {Value: 0},
 		"value.number": {Value: 42},
-		"value.map":    {Value: map[string]interface{}{"foo": "bar"}},
-		"value.array":  {Value: []interface{}{"1234", "test", 42}},
+		"value.map":    {Value: map[string]any{"foo": "bar"}},
+		"value.array":  {Value: []any{"1234", "test", 42}},
 	}
 
 	doc := Doc(mapping.Map(testOsqueryResult))

--- a/x-pack/osquerybeat/internal/install/artifact/artifact_test.go
+++ b/x-pack/osquerybeat/internal/install/artifact/artifact_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/Masterminds/semver"
+
 	"github.com/elastic/beats/v7/x-pack/osquerybeat/internal/config"
 	"github.com/elastic/beats/v7/x-pack/osquerybeat/internal/distro"
 	"github.com/elastic/elastic-agent-libs/logp"
@@ -370,7 +371,7 @@ func TestEnsureConcurrentCallsUseSingleInstallFlow(t *testing.T) {
 	results := make(chan Result, 2)
 
 	wg.Add(2)
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		go func() {
 			defer wg.Done()
 			res, err := Ensure(context.Background(), cfg, installDir, log)

--- a/x-pack/osquerybeat/internal/osqd/args.go
+++ b/x-pack/osquerybeat/internal/osqd/args.go
@@ -6,6 +6,7 @@ package osqd
 
 import (
 	"fmt"
+	"maps"
 	"reflect"
 	"strings"
 )
@@ -21,7 +22,7 @@ const (
 )
 
 type Args []string
-type Flags map[string]interface{}
+type Flags map[string]any
 
 func (f Flags) GetString(key string) string {
 	if f == nil {
@@ -108,9 +109,7 @@ var protectedFlags = Flags{
 func init() {
 	// Append platform specific flags
 	plArgs := platformArgs()
-	for k, v := range plArgs {
-		protectedFlags[k] = v
-	}
+	maps.Copy(protectedFlags, plArgs)
 }
 
 func convertToArgs(flags Flags) Args {

--- a/x-pack/osquerybeat/internal/osqd/osqueryd_test.go
+++ b/x-pack/osquerybeat/internal/osqd/osqueryd_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 	"testing"
 
@@ -368,13 +369,7 @@ func TestArgsExtensionsRequire(t *testing.T) {
 
 	args := osq.args(nil)
 	want := "--extensions_require=ext_one,ext_two"
-	found := false
-	for _, a := range args {
-		if a == want {
-			found = true
-			break
-		}
-	}
+	found := slices.Contains(args, want)
 	if !found {
 		t.Fatalf("expected %q in osqueryd args, got: %v", want, args)
 	}

--- a/x-pack/osquerybeat/internal/osqd/osqueryd_unix.go
+++ b/x-pack/osquerybeat/internal/osqd/osqueryd_unix.go
@@ -44,7 +44,7 @@ func SocketPath(dir string) string {
 	return filepath.Join(dir, "osquery.sock")
 }
 
-func platformArgs() map[string]interface{} {
+func platformArgs() map[string]any {
 	return nil
 }
 

--- a/x-pack/osquerybeat/internal/osqd/osqueryd_windows.go
+++ b/x-pack/osquerybeat/internal/osqd/osqueryd_windows.go
@@ -27,7 +27,7 @@ func SocketPath(dir string) string {
 	return `\\.\pipe\elastic\osquery\` + uuid.Must(uuid.NewV4()).String()
 }
 
-func platformArgs() map[string]interface{} {
+func platformArgs() map[string]any {
 	return nil
 }
 

--- a/x-pack/osquerybeat/internal/osqdcli/client_test.go
+++ b/x-pack/osquerybeat/internal/osqdcli/client_test.go
@@ -18,11 +18,11 @@ func TestResolveHitTypes(t *testing.T) {
 	tests := []struct {
 		name          string
 		hit, colTypes map[string]string
-		res           map[string]interface{}
+		res           map[string]any
 	}{
 		{
 			name: "empty",
-			res:  map[string]interface{}{},
+			res:  map[string]any{},
 		},
 		{
 			name: "resolvable",
@@ -39,7 +39,7 @@ func TestResolveHitTypes(t *testing.T) {
 				"pid_uint": "UNSIGNED_BIGINT",
 				"pid_text": "TEXT",
 			},
-			res: map[string]interface{}{
+			res: map[string]any{
 				"pid":      int64(5551),
 				"pid_int":  int64(5552),
 				"pid_uint": uint64(5553),
@@ -55,7 +55,7 @@ func TestResolveHitTypes(t *testing.T) {
 				"foo":  "bar",
 			},
 			colTypes: map[string]string{"data": "BIGINT"},
-			res: map[string]interface{}{
+			res: map[string]any{
 				"data": "0,22,137,138,29754,49154,49155",
 				"foo":  "bar",
 			},

--- a/x-pack/osquerybeat/internal/osqdcli/retry.go
+++ b/x-pack/osquerybeat/internal/osqdcli/retry.go
@@ -21,7 +21,7 @@ type tryFunc func(ctx context.Context) error
 
 func (r *retry) Run(ctx context.Context, fn tryFunc) (err error) {
 	maxAttempts := r.maxRetry + 1
-	for i := 0; i < maxAttempts; i++ {
+	for i := range maxAttempts {
 		attempt := i + 1
 		if r.log != nil {
 			r.log.Debugf("attempt %v out of %v", attempt, maxAttempts)

--- a/x-pack/osquerybeat/internal/pub/publisher.go
+++ b/x-pack/osquerybeat/internal/pub/publisher.go
@@ -153,7 +153,7 @@ func (p *Publisher) Configure(inputs []config.InputConfig) error {
 	return nil
 }
 
-func (p *Publisher) Publish(index, idValue, idFieldKey, responseID, spaceID, packID, packName, queryName string, meta map[string]interface{}, hits []map[string]interface{}, ecsm ecs.Mapping, reqData interface{}) {
+func (p *Publisher) Publish(index, idValue, idFieldKey, responseID, spaceID, packID, packName, queryName string, meta map[string]any, hits []map[string]any, ecsm ecs.Mapping, reqData any) {
 	p.mx.Lock()
 	defer p.mx.Unlock()
 
@@ -182,7 +182,7 @@ func (p *Publisher) Close() {
 	}
 }
 
-func (p *Publisher) PublishActionResult(req map[string]interface{}, res map[string]interface{}) {
+func (p *Publisher) PublishActionResult(req map[string]any, res map[string]any) {
 	p.mx.Lock()
 	defer p.mx.Unlock()
 
@@ -210,7 +210,7 @@ func (p *Publisher) PublishScheduledResponse(scheduleID, packID, packName, query
 		return
 	}
 
-	fields := map[string]interface{}{
+	fields := map[string]any{
 		"schedule_id":              scheduleID,
 		"response_id":              responseID,
 		"action_input_type":        "osquery_scheduled",
@@ -218,8 +218,8 @@ func (p *Publisher) PublishScheduledResponse(scheduleID, packID, packName, query
 		"completed_at":             completedAt.Format(time.RFC3339Nano),
 		"planned_schedule_time":    plannedScheduleTime.Format(time.RFC3339Nano),
 		"schedule_execution_count": scheduleExecutionCount,
-		"action_response": map[string]interface{}{
-			"osquery": map[string]interface{}{
+		"action_response": map[string]any{
+			"osquery": map[string]any{
 				"count": resultCount,
 			},
 		},
@@ -241,7 +241,7 @@ func (p *Publisher) PublishScheduledResponse(scheduleID, packID, packName, query
 	p.publishActionResponseEvent(fields, completedAt)
 }
 
-func (p *Publisher) publishActionResponseEvent(fields map[string]interface{}, timestamp time.Time) {
+func (p *Publisher) publishActionResponseEvent(fields map[string]any, timestamp time.Time) {
 	event := beat.Event{
 		Timestamp: timestamp,
 		Fields:    fields,
@@ -249,7 +249,7 @@ func (p *Publisher) publishActionResponseEvent(fields map[string]interface{}, ti
 	p.actionResponsesClient.Publish(event)
 }
 
-func (p *Publisher) PublishQueryProfile(index, queryName, actionID, responseID string, profile map[string]interface{}, reqData interface{}) {
+func (p *Publisher) PublishQueryProfile(index, queryName, actionID, responseID string, profile map[string]any, reqData any) {
 	p.mx.Lock()
 	defer p.mx.Unlock()
 
@@ -263,13 +263,13 @@ func (p *Publisher) PublishQueryProfile(index, queryName, actionID, responseID s
 
 	fields := mapstr.M{
 		"type": "osquery_profile",
-		"event": map[string]interface{}{
+		"event": map[string]any{
 			"module": eventModule,
 		},
 		"osquery_profile": profile,
 	}
 	if queryName != "" {
-		fields["query"] = map[string]interface{}{
+		fields["query"] = map[string]any{
 			"name": queryName,
 		}
 	}
@@ -296,10 +296,10 @@ func (p *Publisher) PublishQueryProfile(index, queryName, actionID, responseID s
 	p.queryProfileClient.Publish(event)
 }
 
-func actionResultToEvent(req, res map[string]interface{}) map[string]interface{} {
-	m := make(map[string]interface{}, 9)
+func actionResultToEvent(req, res map[string]any) map[string]any {
+	m := make(map[string]any, 9)
 
-	copyKey := func(key string, src, dst map[string]interface{}) {
+	copyKey := func(key string, src, dst map[string]any) {
 		if v, ok := src[key]; ok {
 			dst[key] = v
 		}
@@ -310,8 +310,8 @@ func actionResultToEvent(req, res map[string]interface{}) map[string]interface{}
 	copyKey("error", res, m)
 
 	if v, ok := res["count"]; ok {
-		m["action_response"] = map[string]interface{}{
-			"osquery": map[string]interface{}{
+		m["action_response"] = map[string]any{
+			"osquery": map[string]any{
 				"count": v,
 			},
 		}
@@ -371,7 +371,7 @@ func (p *Publisher) processorsForInputConfig(inCfg config.InputConfig, defaultDa
 	return procs, nil
 }
 
-func hitToEvent(index, eventType, idValue, idFieldKey, responseID, spaceID, packID, packName, queryName string, meta, hit map[string]interface{}, ecsm ecs.Mapping, reqData interface{}) beat.Event {
+func hitToEvent(index, eventType, idValue, idFieldKey, responseID, spaceID, packID, packName, queryName string, meta, hit map[string]any, ecsm ecs.Mapping, reqData any) beat.Event {
 	var fields mapstr.M
 
 	if len(ecsm) > 0 {
@@ -383,13 +383,13 @@ func hitToEvent(index, eventType, idValue, idFieldKey, responseID, spaceID, pack
 
 	// Add event.module for ECS
 	// There could be already "event" properties set, preserve them and set the "event.module"
-	var evf map[string]interface{}
+	var evf map[string]any
 	ievf, ok := fields["event"]
 	if ok {
-		evf, ok = ievf.(map[string]interface{})
+		evf, ok = ievf.(map[string]any)
 	}
 	if !ok {
-		evf = make(map[string]interface{})
+		evf = make(map[string]any)
 	}
 	evf["module"] = eventModule
 	fields["event"] = evf

--- a/x-pack/osquerybeat/internal/pub/publisher_test.go
+++ b/x-pack/osquerybeat/internal/pub/publisher_test.go
@@ -22,10 +22,10 @@ func TestHitToEvent(t *testing.T) {
 
 	type params struct {
 		index, eventType, idValue, idFieldKey, responseID string
-		meta                                              map[string]interface{}
-		hit                                               map[string]interface{}
+		meta                                              map[string]any
+		hit                                               map[string]any
 		ecsm                                              ecs.Mapping
-		reqData                                           interface{}
+		reqData                                           any
 	}
 
 	genParams := func(mask int) (p params) {
@@ -43,7 +43,7 @@ func TestHitToEvent(t *testing.T) {
 			p.responseID = uuid.Must(uuid.NewV4()).String()
 		}
 		if mask>>2&1 > 0 {
-			p.hit = map[string]interface{}{
+			p.hit = map[string]any{
 				"foo": "bar",
 			}
 		}
@@ -55,14 +55,14 @@ func TestHitToEvent(t *testing.T) {
 			}
 		}
 		if mask&1 > 0 {
-			p.reqData = map[string]interface{}{
+			p.reqData = map[string]any{
 				"query": "select * from uptime",
 			}
 		}
 		return p
 	}
 
-	for i := 0; i < maxMask; i++ {
+	for i := range maxMask {
 		p := genParams(i)
 		ev := hitToEvent(p.index, p.eventType, p.idValue, p.idFieldKey, p.responseID, "", "", "", "", p.meta, p.hit, p.ecsm, p.reqData)
 
@@ -123,8 +123,8 @@ func TestActionResultToEvent(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		req, res map[string]interface{}
-		want     map[string]interface{}
+		req, res map[string]any
+		want     map[string]any
 	}{
 		{
 			name: "successful",
@@ -246,7 +246,7 @@ func TestHitToEvent_SpaceID(t *testing.T) {
 		"",
 		"",
 		nil,
-		map[string]interface{}{"foo": "bar"},
+		map[string]any{"foo": "bar"},
 		nil,
 		nil,
 	)
@@ -269,7 +269,7 @@ func TestHitToEvent_PackID(t *testing.T) {
 		"",
 		"",
 		nil,
-		map[string]interface{}{"foo": "bar"},
+		map[string]any{"foo": "bar"},
 		nil,
 		nil,
 	)
@@ -293,7 +293,7 @@ func TestHitToEvent_PackNameAndQueryName(t *testing.T) {
 		packName,
 		queryName,
 		nil,
-		map[string]interface{}{"foo": "bar"},
+		map[string]any{"foo": "bar"},
 		nil,
 		nil,
 	)
@@ -318,7 +318,7 @@ func TestHitToEvent_NoPackNameOrQueryName(t *testing.T) {
 		"",
 		"",
 		nil,
-		map[string]interface{}{"foo": "bar"},
+		map[string]any{"foo": "bar"},
 		nil,
 		nil,
 	)
@@ -331,8 +331,8 @@ func TestHitToEvent_NoPackNameOrQueryName(t *testing.T) {
 	}
 }
 
-func toMap(t *testing.T, s string) map[string]interface{} {
-	var m map[string]interface{}
+func toMap(t *testing.T, s string) map[string]any {
+	var m map[string]any
 	err := json.Unmarshal([]byte(s), &m)
 	if err != nil {
 		t.Fatal(err)

--- a/x-pack/osquerybeat/internal/scheduler/schedule.go
+++ b/x-pack/osquerybeat/internal/scheduler/schedule.go
@@ -96,7 +96,7 @@ func (s *RecurrenceSchedule) minimumInterval() (time.Duration, bool) {
 	found := false
 
 	// Sample a bounded number of upcoming occurrences to keep this validation cheap.
-	for i := 0; i < 16; i++ {
+	for range 16 {
 		next := s.rule.After(current, false)
 		if next.IsZero() {
 			break
@@ -243,7 +243,7 @@ func (s *RecurrenceSchedule) String() string {
 }
 
 // Unpack implements the config unpacker interface
-func (s *RecurrenceSchedule) Unpack(cfg map[string]interface{}) error {
+func (s *RecurrenceSchedule) Unpack(cfg map[string]any) error {
 	if v, ok := cfg["rrule"].(string); ok {
 		s.RRule = v
 	}

--- a/x-pack/osquerybeat/internal/scheduler/schedule_test.go
+++ b/x-pack/osquerybeat/internal/scheduler/schedule_test.go
@@ -335,9 +335,6 @@ func TestRecurrenceSchedule_ExecutionIndex_Weekly(t *testing.T) {
 	assert.Equal(t, 4, n)
 }
 
-//go:fix inline
-func ptr(t time.Time) *time.Time { return new(t) }
-
 func TestRecurrenceSchedule_WeeklyPattern(t *testing.T) {
 	// Every Monday and Wednesday
 	s := &RecurrenceSchedule{RRule: "FREQ=WEEKLY;BYDAY=MO,WE"}

--- a/x-pack/osquerybeat/internal/scheduler/schedule_test.go
+++ b/x-pack/osquerybeat/internal/scheduler/schedule_test.go
@@ -325,7 +325,7 @@ func TestRecurrenceSchedule_ExecutionIndex_Weekly(t *testing.T) {
 	// Every Monday and Wednesday, starting Monday Jan 15, 2024
 	s := &RecurrenceSchedule{
 		RRule:     "FREQ=WEEKLY;BYDAY=MO,WE",
-		StartDate: ptr(time.Date(2024, 1, 15, 9, 0, 0, 0, time.UTC)),
+		StartDate: new(time.Date(2024, 1, 15, 9, 0, 0, 0, time.UTC)),
 	}
 	require.NoError(t, s.Parse())
 
@@ -335,7 +335,8 @@ func TestRecurrenceSchedule_ExecutionIndex_Weekly(t *testing.T) {
 	assert.Equal(t, 4, n)
 }
 
-func ptr(t time.Time) *time.Time { return &t }
+//go:fix inline
+func ptr(t time.Time) *time.Time { return new(t) }
 
 func TestRecurrenceSchedule_WeeklyPattern(t *testing.T) {
 	// Every Monday and Wednesday
@@ -475,7 +476,7 @@ func TestRecurrenceSchedule_ValidateSplay(t *testing.T) {
 }
 
 func TestRecurrenceSchedule_Unpack(t *testing.T) {
-	cfg := map[string]interface{}{
+	cfg := map[string]any{
 		"rrule":      "FREQ=DAILY",
 		"start_date": "2024-01-15T09:00:00Z",
 		"end_date":   "2024-12-31T23:59:59Z",
@@ -494,7 +495,7 @@ func TestRecurrenceSchedule_Unpack(t *testing.T) {
 }
 
 func TestRecurrenceSchedule_UnpackNormalizesDatesToUTC(t *testing.T) {
-	cfg := map[string]interface{}{
+	cfg := map[string]any{
 		"rrule":      "FREQ=DAILY",
 		"start_date": "2024-01-15T11:00:00+02:00",
 		"end_date":   "2025-01-01T01:59:59+02:00",
@@ -511,7 +512,7 @@ func TestRecurrenceSchedule_UnpackNormalizesDatesToUTC(t *testing.T) {
 }
 
 func TestRecurrenceSchedule_UnpackDefaults(t *testing.T) {
-	cfg := map[string]interface{}{
+	cfg := map[string]any{
 		"rrule": "FREQ=DAILY",
 	}
 
@@ -524,12 +525,12 @@ func TestRecurrenceSchedule_UnpackDefaults(t *testing.T) {
 func TestRecurrenceSchedule_UnpackInvalidSplay(t *testing.T) {
 	tests := []struct {
 		name    string
-		cfg     map[string]interface{}
+		cfg     map[string]any
 		wantErr bool
 	}{
 		{
 			name: "invalid splay format",
-			cfg: map[string]interface{}{
+			cfg: map[string]any{
 				"rrule":      "FREQ=DAILY",
 				"start_date": "2024-01-15T09:00:00Z",
 				"splay":      "not a duration",
@@ -538,7 +539,7 @@ func TestRecurrenceSchedule_UnpackInvalidSplay(t *testing.T) {
 		},
 		{
 			name: "negative splay",
-			cfg: map[string]interface{}{
+			cfg: map[string]any{
 				"rrule":      "FREQ=DAILY",
 				"start_date": "2024-01-15T09:00:00Z",
 				"splay":      "-5m",
@@ -547,7 +548,7 @@ func TestRecurrenceSchedule_UnpackInvalidSplay(t *testing.T) {
 		},
 		{
 			name: "splay exceeds max",
-			cfg: map[string]interface{}{
+			cfg: map[string]any{
 				"rrule":      "FREQ=DAILY",
 				"start_date": "2024-01-15T09:00:00Z",
 				"splay":      "13h",
@@ -556,7 +557,7 @@ func TestRecurrenceSchedule_UnpackInvalidSplay(t *testing.T) {
 		},
 		{
 			name: "splay exceeds max",
-			cfg: map[string]interface{}{
+			cfg: map[string]any{
 				"rrule":      "FREQ=DAILY",
 				"start_date": "2024-01-15T09:00:00Z",
 				"splay":      "13h",

--- a/x-pack/osquerybeat/internal/scheduler/scheduler.go
+++ b/x-pack/osquerybeat/internal/scheduler/scheduler.go
@@ -274,10 +274,7 @@ func (s *Scheduler) runJob(ctx context.Context, job *scheduledJob) {
 
 		scheduledTime := nextRun.Add(splayDuration)
 
-		waitDuration := time.Until(scheduledTime)
-		if waitDuration < 0 {
-			waitDuration = 0
-		}
+		waitDuration := max(time.Until(scheduledTime), 0)
 
 		s.log.Debugf("Query '%s' scheduled for %v (splay: %v)", sq.Name, scheduledTime, splayDuration)
 

--- a/x-pack/osquerybeat/scripts/mage/config.go
+++ b/x-pack/osquerybeat/scripts/mage/config.go
@@ -12,7 +12,7 @@ import (
 func XPackConfigFileParams() devtools.ConfigFileParams {
 	p := devtools.DefaultConfigFileParams()
 	p.Templates = append(p.Templates, "_meta/config/*.tmpl")
-	p.ExtraVars = map[string]interface{}{
+	p.ExtraVars = map[string]any{
 		"ExcludeConsole":             false,
 		"ExcludeFileOutput":          true,
 		"ExcludeKafka":               true,

--- a/x-pack/osquerybeat/scripts/mage/update.go
+++ b/x-pack/osquerybeat/scripts/mage/update.go
@@ -14,7 +14,7 @@ import (
 type Update mg.Namespace
 
 // Aliases stores aliases for the targets.
-var Aliases = map[string]interface{}{
+var Aliases = map[string]any{
 	"update": Update.All,
 }
 

--- a/x-pack/winlogbeat/cmd/export.go
+++ b/x-pack/winlogbeat/cmd/export.go
@@ -53,7 +53,7 @@ func GenExportPipelineCmd(settings instance.Settings) *cobra.Command {
 	return genExportPipelineCmd
 }
 
-func fatalf(msg string, vs ...interface{}) {
+func fatalf(msg string, vs ...any) {
 	fmt.Fprintf(os.Stderr, msg, vs...)
 	fmt.Fprintln(os.Stderr)
 	os.Exit(1)

--- a/x-pack/winlogbeat/module/wintest/docker.go
+++ b/x-pack/winlogbeat/module/wintest/docker.go
@@ -135,7 +135,7 @@ func dockerCompose(env map[string]string, verbose bool) error {
 	}
 	var err error
 	const retries = 2
-	for n := 0; n < retries; n++ {
+	for range retries {
 		_, err = sh.Exec(
 			env,
 			out,

--- a/x-pack/winlogbeat/module/wintest/simulate.go
+++ b/x-pack/winlogbeat/module/wintest/simulate.go
@@ -195,8 +195,8 @@ func newError(body []byte) error {
 				Type     string `json:"type"`
 				Reason   string `json:"reason"`
 				CausedBy struct {
-					Type   string      `json:"type"`
-					Reason interface{} `json:"reason"`
+					Type   string `json:"type"`
+					Reason any    `json:"reason"`
 				} `json:"caused_by,omitempty"`
 			} `json:"caused_by,omitempty"`
 			Suppressed []struct {
@@ -223,12 +223,12 @@ func newError(body []byte) error {
 // marshalNormalizedJSON marshals test results ensuring that field
 // order remains consistent independent of field order returned by
 // ES to minimize diff noise during changes.
-func marshalNormalizedJSON(v interface{}) ([]byte, error) {
+func marshalNormalizedJSON(v any) ([]byte, error) {
 	msg, err := json.Marshal(v)
 	if err != nil {
 		return msg, err
 	}
-	var obj interface{}
+	var obj any
 	err = jsonUnmarshalUsingNumber(msg, &obj)
 	if err != nil {
 		return msg, err
@@ -240,7 +240,7 @@ func marshalNormalizedJSON(v interface{}) ([]byte, error) {
 // does not default to unmarshaling numeric values to float64 in order to
 // prevent low bit truncation of values greater than 1<<53.
 // See https://golang.org/cl/6202068 for details.
-func jsonUnmarshalUsingNumber(data []byte, v interface{}) error {
+func jsonUnmarshalUsingNumber(data []byte, v any) error {
 	dec := json.NewDecoder(bytes.NewReader(data))
 	dec.UseNumber()
 	err := dec.Decode(v)
@@ -263,7 +263,7 @@ func jsonUnmarshalUsingNumber(data []byte, v interface{}) error {
 func ErrorMessage(msg json.RawMessage) error {
 	var event struct {
 		Error struct {
-			Message interface{}
+			Message any
 		}
 	}
 	err := json.Unmarshal(msg, &event)


### PR DESCRIPTION
## Proposed commit message

```
x-pack/osquerybeat,winlogbeat: fix modernize lint findings

Fixes the `modernize` findings that `mage lint` reports in the 86 file(s)
owned by @elastic/sec-windows-platform in .github/CODEOWNERS.

The rewrites are mechanical and behaviour-preserving, produced by
`golangci-lint --enable-only modernize --fix` and `go fix`: `interface{}` becomes
`any`, 3-clause loops become `for range n`, manual map copies become `maps.Copy`,
and so on.

The repo-wide change is split per team so each PR is reviewable by the people
who own the code.

A second commit removes the helpers the rewrites orphaned; see the review notes below.
```

<details>
<summary>dev-tools/modernize_split.py, the script that generated this branch</summary>

```python
#!/usr/bin/env python3
"""Apply `modernize` fixes repo-wide and split them into one branch per CODEOWNERS team.

Run from a clean worktree that sits on the commit you want to base the branches on
(normally `main`):

    ./dev-tools/modernize_split.py

Phases:

1. Fix     `golangci-lint --enable-only modernize --fix` plus `go fix`, looped over every
           GOOS/GOARCH and both build-tag sets until the tree stops changing.
2. Split   `codeowners` maps every changed file to its owning team.
3. Branch  Each team gets `modernize-<team>` containing exactly one generated commit,
           carrying the `Modernize-Automated: true` trailer.

The script is idempotent. Re-running it regenerates every automated commit from the
current base and re-applies, via `git merge-tree`, any hand-written commits stacked on
top of the automated one. Branches whose regenerated commit is byte-identical to the
existing one are left alone, so unchanged branches never need a force-push.
"""

from __future__ import annotations

import argparse
import os
import re
import shutil
import subprocess
import sys
import tempfile
import time
from collections import Counter, defaultdict
from dataclasses import dataclass, field
from pathlib import Path

import yaml

AUTO_TRAILER = "Modernize-Automated: true"
MANUAL_TRAILER = "Modernize-Manual: true"
SNAPSHOT_REF = "refs/modernize/snapshot"
BACKUP_NS = "refs/modernize/backup"
BRANCH_PREFIX = "modernize-"
CONFIG_TEMPLATE = ".golangci.modernize-{}.yml"

# GOOS/GOARCH pairs that appear in build constraints across the repo. Files behind a
# constraint are invisible to the analyzers unless we type-check for that platform.
FULL_MATRIX = [
    ("linux", "amd64"),
    ("linux", "arm64"),
    ("linux", "386"),
    ("darwin", "amd64"),
    ("darwin", "arm64"),
    ("windows", "amd64"),
    ("windows", "arm64"),
    ("windows", "386"),
    ("aix", "ppc64"),
    ("freebsd", "amd64"),
    ("openbsd", "amd64"),
    ("netbsd", "amd64"),
    ("dragonfly", "amd64"),
    ("solaris", "amd64"),
]
QUICK_MATRIX = [("linux", "amd64"), ("darwin", "arm64"), ("windows", "amd64")]

# Build-tag sets to analyze. A file is invisible to the analyzers unless some set
# satisfies its constraint, so the union has to cover every tag the repo uses.
#   - The empty set is not redundant: `!integration` files are only visible without it.
#   - `requirefips` and the feature tags are kept apart because constraints like
#     `!requirefips && integration && azure` are satisfied by neither alone.
#   - `ignore` is deliberately absent; those files are excluded on purpose.
FEATURE_TAGS = (
    "aws", "awshealth", "azure", "billing", "carbon", "cloudfoundry", "ech", "gcp",
    "nooteloutput", "oracle", "race", "salesforce_live", "stresstest", "synthetics",
    "win_integration",
)
TAG_SETS: list[tuple[str, ...]] = [
    ("integration",),
    (),
    ("integration", "requirefips"),
    ("integration", *FEATURE_TAGS),
    ("mage", "tools"),
]

# `go fix` bundles the same modernizers as the golangci-lint `modernize` linter plus a
# few extras. Keep the disabled set in sync with the `modernize` section of .golangci.yml.
GO_FIX_DISABLED = ["omitzero"]

# Modules that live inside the repo but outside the root module's ./... expansion.
# `x-pack/osquerybeat/ext/osquery-extension/cmd/gentables` is deliberately absent: its
# example packages import paths that do not resolve, so nothing there type-checks.
EXTRA_MODULES: list[str] = []

GENERATED_RE = re.compile(r"^//.*(code generated|autogenerated|do not edit)", re.IGNORECASE)

START = time.monotonic()


def log(msg: str) -> None:
    print(f"[{time.monotonic() - START:7.1f}s] {msg}", flush=True)


def git(*args: str, stdin: str | None = None, env: dict | None = None) -> str:
    """Run a git command that must succeed and return its stripped stdout."""
    res = subprocess.run(
        ["git", *args],
        input=stdin,
        capture_output=True,
        text=True,
        env={**os.environ, **(env or {})},
    )
    if res.returncode != 0:
        raise RuntimeError(f"git {' '.join(args)} failed ({res.returncode}):\n{res.stderr}")
    return res.stdout.strip()


def git_try(*args: str, stdin: str | None = None, env: dict | None = None):
    res = subprocess.run(
        ["git", *args],
        input=stdin,
        capture_output=True,
        text=True,
        env={**os.environ, **(env or {})},
    )
    return res.returncode, res.stdout, res.stderr


_SIGN: list[str] | None = None


def sign_flags() -> list[str]:
    """`-S` if commit.gpgsign is on, which `git commit-tree` ignores unlike `git commit`."""
    global _SIGN
    if _SIGN is None:
        code, out, _ = git_try("config", "--get", "--type=bool", "commit.gpgsign")
        _SIGN = ["-S"] if code == 0 and out.strip() == "true" else []
    return _SIGN


def commit_tree(tree: str, parent: str, message: str, env: dict | None = None) -> str:
    return git("commit-tree", tree, "-p", parent, *sign_flags(), stdin=message, env=env)


def signed(commit: str) -> bool:
    """False for an unsigned commit, so a re-run can replace one made before signing was on."""
    return not sign_flags() or git("log", "-1", "--format=%G?", commit) != "N"


# --------------------------------------------------------------------------------------
# Phase 1: fixers
# --------------------------------------------------------------------------------------


def host_platform() -> tuple[str, str]:
    global _HOST
    if _HOST is None:
        out = subprocess.run(
            ["go", "env", "GOHOSTOS", "GOHOSTARCH"], capture_output=True, text=True
        ).stdout.split()
        _HOST = (out[0], out[1])
    return _HOST


_HOST: tuple[str, str] | None = None


def platform_env(goos: str, goarch: str, tmpdir: Path, memlimit: int) -> dict:
    # Cross-compilation has no C toolchain here, so cgo-gated files are only reachable
    # on the host platform.
    cgo = "1" if (goos, goarch) == host_platform() else "0"
    return {
        "GOOS": goos,
        "GOARCH": goarch,
        "CGO_ENABLED": cgo,
        # A distro that mounts /tmp as tmpfs turns every multi-GB build work directory
        # into resident memory, and a killed toolchain leaks it until reboot. Type-checking
        # the whole repo for a dozen platforms exhausts RAM that way.
        "TMPDIR": str(tmpdir),
        "GOTMPDIR": str(tmpdir),
        "GOMEMLIMIT": f"{memlimit}GiB",
    }


def write_configs(root: Path) -> dict[tuple[str, ...], Path]:
    """Derive one .golangci.yml per tag set.

    The configs must live next to the original: golangci-lint resolves the paths in
    `exclusions` relative to the config file.
    """
    base = yaml.safe_load((root / ".golangci.yml").read_text())
    configs = {}
    for i, tags in enumerate(TAG_SETS):
        data = dict(base)
        run = dict(data.get("run", {}))
        if tags:
            run["build-tags"] = list(tags)
        else:
            run.pop("build-tags", None)
        data["run"] = run
        path = root / CONFIG_TEMPLATE.format(i)
        path.write_text(yaml.safe_dump(data, sort_keys=False))
        configs[tags] = path
    return configs


def run_fixer(cmd: list[str], env: dict, cwd: Path, label: str) -> None:
    started = time.monotonic()
    res = subprocess.run(
        cmd, cwd=cwd, env={**os.environ, **env}, capture_output=True, text=True
    )
    took = time.monotonic() - started
    # Both tools exit non-zero when they still have findings or when a package fails to
    # type-check for the target platform. Neither is fatal: the fixes are applied to
    # whatever did type-check, and the next platform covers the rest.
    status = "ok" if res.returncode == 0 else f"rc={res.returncode}"
    log(f"    {label}: {status} in {took:.0f}s")
    if res.returncode != 0:
        tail = "\n".join(res.stderr.strip().splitlines()[-3:])
        if tail:
            log(f"      {tail}")


def is_generated(path: Path) -> bool:
    try:
        with path.open("r", encoding="utf-8", errors="replace") as fh:
            for _ in range(40):
                line = fh.readline()
                if not line:
                    break
                if GENERATED_RE.match(line.strip()):
                    return True
    except OSError:
        return False
    return False


def changed_files(root: Path) -> list[str]:
    out = git("diff", "--name-only", "--diff-filter=d", "-z")
    return [p for p in out.split("\0") if p]


def revert_generated(root: Path, files: list[str]) -> list[str]:
    """Undo edits to generated files; golangci-lint skips them and so should we."""
    generated = [f for f in files if is_generated(root / f)]
    for i in range(0, len(generated), 200):
        git("checkout", "--", *generated[i : i + 200])
    return generated


def sweep_tmpdir(tmpdir: Path) -> None:
    """Drop build work directories the toolchain leaked when it was killed."""
    for leftover in tmpdir.glob("go-build*"):
        shutil.rmtree(leftover, ignore_errors=True)


def run_goimports(root: Path, files: list[str], goimports: str) -> None:
    """Fixers can leave imports stale (e.g. `sort` dropped for `slices`)."""
    for i in range(0, len(files), 200):
        subprocess.run(
            [goimports, "-local", "github.com/elastic", "-w", *files[i : i + 200]],
            cwd=root,
            capture_output=True,
            text=True,
        )


def modernize(root: Path, args, configs: dict[tuple[str, ...], Path], tmpdir: Path) -> list[str]:
    matrix = QUICK_MATRIX if args.quick else FULL_MATRIX
    modules = [Path(".")] + [Path(m) for m in EXTRA_MODULES]
    goimports = shutil.which("goimports")
    if not goimports:
        log("WARNING: goimports not on PATH, stale imports will not be cleaned up")

    previous = None
    for attempt in range(1, args.max_passes + 1):
        log(f"pass {attempt}/{args.max_passes}")
        for goos, goarch in matrix:
            env = platform_env(goos, goarch, tmpdir, args.memlimit)
            for tags in TAG_SETS:
                log(f"  {goos}/{goarch} tags={','.join(tags) or '-'}")
                cfg = configs[tags]
                for module in modules:
                    prefix = f"{module}: " if str(module) != "." else ""
                    run_fixer(
                        [
                            args.golangci_lint, "run",
                            "--config", str(cfg),
                            "--max-issues-per-linter", "0",
                            "--max-same-issues", "0",
                            "--enable-only", "modernize",
                            "--fix",
                            "--timeout", "60m",
                            "--issues-exit-code", "0",
                            "--concurrency", str(args.jobs),
                            "./...",
                        ],
                        env, root / module, f"{prefix}golangci-lint",
                    )
                    go_fix = ["go", "fix"]
                    if tags:
                        go_fix.append("-tags=" + ",".join(tags))
                    go_fix += [f"-{name}=false" for name in GO_FIX_DISABLED]
                    run_fixer(go_fix + ["./..."], env, root / module, f"{prefix}go fix")
                # A fix can strip the last use of an import (`to.Ptr(x)` becoming
                # `new(x)`). Tidy up immediately: a package left in that state does not
                # type-check, and every later platform would silently skip it.
                if goimports:
                    run_goimports(root, [f for f in changed_files(root) if f.endswith(".go")], goimports)
                sweep_tmpdir(tmpdir)

        files = changed_files(root)
        reverted = revert_generated(root, files)
        if reverted:
            log(f"  reverted {len(reverted)} generated files")
        files = [f for f in changed_files(root) if f.endswith(".go")]

        digest = git("diff", "--no-ext-diff")
        log(f"  pass {attempt}: {len(files)} files changed")
        if digest == previous:
            log("  converged")
            break
        previous = digest
    else:
        log(f"WARNING: still changing after {args.max_passes} passes")

    return [f for f in changed_files(root) if f.endswith(".go")]


def verify_build(root: Path, env: dict) -> list[str]:
    """Type-check the host platform, tests included.

    Only the host is checked. Beats does not build for most of the GOOS values in the
    matrix, so cross-platform failures say nothing about the fixes.
    """
    env = {**os.environ, **env}
    res = subprocess.run(
        ["go", "build", "-tags=integration", "./..."],
        cwd=root, env=env, capture_output=True, text=True,
    )
    vet = subprocess.run(
        ["go", "vet", "-tags=integration", "./..."],
        cwd=root, env=env, capture_output=True, text=True,
    )
    # `go vet` also reports genuine vet findings; only load errors indicate broken fixes.
    broken = [
        line for line in vet.stderr.splitlines()
        if ": undefined:" in line or "could not import" in line or "declared and not used" in line
    ]
    return res.stderr.splitlines()[:20] + broken[:20]


UNUSED_RE = re.compile(r"^(\S+\.go):\d+:\d+:\s*(.*?)\s*\(unused\)$")


def repo_relative(raw: str, worktree: Path) -> str:
    """Trim a reported path down to the part that exists inside `worktree`.

    Reported paths are relative to whichever directory produced them, and cached
    findings keep the path of the run that first computed them, so the same file can be
    spelled several ways. The longest suffix that resolves to a real file is the answer.
    """
    parts = Path(os.path.normpath(raw)).parts
    for i in range(len(parts)):
        candidate = Path(*parts[i:])
        if (worktree / candidate).is_file():
            return str(candidate)
    return os.path.normpath(raw)


def unused_symbols(worktree: Path, ref: str, cache: Path) -> set[str]:
    """Run `unused` against `ref`, using the .golangci.yml that ref ships with."""
    git("-C", str(worktree), "checkout", "--quiet", "--detach", ref)
    res = subprocess.run(
        [
            "golangci-lint", "run",
            "--max-issues-per-linter", "0", "--max-same-issues", "0",
            "--enable-only", "unused", "--issues-exit-code", "0", "--timeout", "30m", "./...",
        ],
        cwd=worktree, capture_output=True, text=True,
        env={**os.environ, "GOLANGCI_LINT_CACHE": str(cache)},
    )
    found = set()
    for line in res.stdout.splitlines():
        m = UNUSED_RE.match(line)
        if m:
            found.add(f"{repo_relative(m.group(1), worktree)}: {m.group(2)}")
    return found


def leftovers(base: str, snap: str, tmpdir: Path) -> list[str]:
    """Symbols the fixes orphaned, typically pointer helpers replaced by `new(expr)`.

    Removing them is the manual follow-up; nothing here rewrites code.
    """
    worktree = tmpdir / "leftovers"
    # A cache of its own: golangci-lint replays a cached finding with the path of the run
    # that produced it, which would make the two sides incomparable.
    cache = tmpdir / "leftovers-cache"
    shutil.rmtree(worktree, ignore_errors=True)
    git("worktree", "prune")
    git("worktree", "add", "--quiet", "--detach", str(worktree), base)
    try:
        before = unused_symbols(worktree, base, cache)
        after = unused_symbols(worktree, snap, cache)
    finally:
        git("worktree", "remove", "--force", str(worktree))
    return sorted(after - before)


# --------------------------------------------------------------------------------------
# Phase 2: ownership
# --------------------------------------------------------------------------------------


def team_of(owners: list[str]) -> str:
    """Reduce a CODEOWNERS entry to a single branch-name-safe team slug.

    Multi-owner paths go to their first owner: duplicating a file across branches would
    create PRs that conflict with each other.
    """
    if not owners:
        return "unowned"
    owner = owners[0].removeprefix("@")
    return owner.removeprefix("elastic/").replace("/", "-")


def split_by_team(root: Path, files: list[str], codeowners: str) -> dict[str, list[str]]:
    by_team: dict[str, list[str]] = defaultdict(list)
    for i in range(0, len(files), 200):
        batch = files[i : i + 200]
        res = subprocess.run(
            [codeowners, "-f", ".github/CODEOWNERS", *batch],
            cwd=root, capture_output=True, text=True, check=True,
        )
        for line in res.stdout.splitlines():
            fields = line.split()
            if not fields:
                continue
            path, owners = fields[0], [f for f in fields[1:] if f.startswith("@")]
            by_team[team_of(owners)].append(path)
    return dict(sorted(by_team.items()))


# --------------------------------------------------------------------------------------
# Phase 3: branches
# --------------------------------------------------------------------------------------


@dataclass
class Outcome:
    team: str
    files: int
    branch: str
    action: str = ""
    manual: list[str] = field(default_factory=list)
    dropped: list[str] = field(default_factory=list)
    conflicts: list[str] = field(default_factory=list)
    leftovers: list[str] = field(default_factory=list)


def snapshot(root: Path, base: str) -> str:
    """Commit the whole modernized worktree to an unreferenced commit.

    Uses a scratch index so the caller's index and untracked files (this script included)
    are never touched.
    """
    with tempfile.TemporaryDirectory() as tmp:
        env = {"GIT_INDEX_FILE": str(Path(tmp) / "index")}
        git("read-tree", base, env=env)
        git("add", "-u", env=env)
        tree = git("write-tree", env=env)
    commit = git("commit-tree", tree, "-p", base, stdin="modernize: full-tree snapshot")
    git("update-ref", SNAPSHOT_REF, commit)
    return commit


def tree_with(base: str, source: str, paths: list[str]) -> str:
    """Build a tree that is `base` with `paths` taken from `source`."""
    wanted = set(paths)
    entries = [
        record for record in git("ls-tree", "-r", "-z", source).split("\0")
        if record and record.split("\t", 1)[1] in wanted
    ]
    with tempfile.TemporaryDirectory() as tmp:
        env = {"GIT_INDEX_FILE": str(Path(tmp) / "index")}
        git("read-tree", base, env=env)
        git("update-index", "-z", "--index-info", stdin="\0".join(entries) + "\0", env=env)
        return git("write-tree", env=env)


def components(files: list[str], limit: int = 3, share: float = 0.15, budget: int = 40) -> str:
    """Name the areas a commit touches, for the `area: summary` subject convention.

    x-pack is split per beat, since `x-pack` alone says nothing about what changed.
    Areas are dropped from the tail until the list fits `budget`, keeping the subject
    within the ~72 columns git tooling shows without truncating.
    """
    def area(path: str) -> str:
        parts = path.split("/")
        return "/".join(parts[:2]) if parts[0] == "x-pack" else parts[0]

    counts = Counter(area(f) for f in files)
    top = [a for a, n in counts.most_common(limit) if n >= share * len(files)]
    while len(",".join(top)) > budget and len(top) > 1:
        top.pop()
    return ",".join(top)


def auto_message(team: str, base: str, files: list[str]) -> str:
    return f"""{components(files)}: fix modernize lint findings

Fixes the `modernize` findings that `mage lint` reports in the {len(files)} file(s)
owned by @elastic/{team} in .github/CODEOWNERS.

The rewrites are mechanical and behaviour-preserving, produced by
`golangci-lint --enable-only modernize --fix` and `go fix`: `interface{{}}` becomes
`any`, 3-clause loops become `for range n`, manual map copies become `maps.Copy`,
and so on.

The repo-wide change is split per team so each PR is reviewable by the people
who own the code.

Regenerate with dev-tools/modernize_split.py; do not hand-edit this commit,
put follow-up cleanups in a separate commit on top.

Modernize-Base: {base}
Modernize-Team: {team}
{AUTO_TRAILER}
"""


def stacked_commits(branch: str, limit: int = 50) -> tuple[list[str], str | None]:
    """Return commits stacked above the newest automated commit, oldest first."""
    log_out = git("log", "--format=%H%x1f%B%x1e", f"-{limit}", branch)
    stacked = []
    for entry in log_out.split("\x1e"):
        entry = entry.strip("\n")
        if not entry:
            continue
        sha, _, body = entry.partition("\x1f")
        if AUTO_TRAILER in body:
            return list(reversed(stacked)), sha
        stacked.append(sha)
    return [], None


def replay(commit: str, onto: str) -> tuple[str | None, str]:
    """Cherry-pick `commit` onto `onto` without touching the worktree."""
    parent = git("rev-parse", f"{commit}^")
    rc, out, err = git_try("merge-tree", "--write-tree", "--merge-base", parent, onto, commit)
    if rc != 0:
        return None, (out + err).strip()
    tree = out.strip().splitlines()[0]
    if tree == git("rev-parse", f"{onto}^{{tree}}"):
        return onto, "empty"
    author = git("log", "-1", "--format=%an%x1f%ae%x1f%aI", commit).split("\x1f")
    env = {"GIT_AUTHOR_NAME": author[0], "GIT_AUTHOR_EMAIL": author[1], "GIT_AUTHOR_DATE": author[2]}
    message = git("log", "-1", "--format=%B", commit)
    return commit_tree(tree, onto, message, env=env), "ok"


def checked_out_branches() -> set[str]:
    """Branches a worktree sits on; moving their tip behind git's back desyncs it."""
    return {
        line.removeprefix("branch refs/heads/")
        for line in git("worktree", "list", "--porcelain").splitlines()
        if line.startswith("branch ")
    }


def update_branch(team: str, files: list[str], base: str, snap: str, busy: set[str],
                  prefix: str) -> Outcome:
    branch = f"{prefix}{team}"
    result = Outcome(team=team, files=len(files), branch=branch)
    if branch in busy:
        result.action = "SKIPPED (checked out in a worktree)"
        return result

    tree = tree_with(base, snap, files)
    message = auto_message(team, base, files)
    exists = git_try("rev-parse", "--verify", f"refs/heads/{branch}")[0] == 0
    stacked, previous_auto = ([], None)
    if exists:
        old = git("rev-parse", branch)
        git("update-ref", f"{BACKUP_NS}/{branch}", old)
        stacked, previous_auto = stacked_commits(branch)
        if previous_auto is None:
            result.action = f"SKIPPED (no {AUTO_TRAILER} commit, backed up to {BACKUP_NS}/{branch})"
            return result
        unchanged = (
            git("rev-parse", f"{previous_auto}^{{tree}}") == tree
            and git("rev-parse", f"{previous_auto}^") == git("rev-parse", base)
            and git("log", "-1", "--format=%B", previous_auto).strip() == message.strip()
            and signed(previous_auto)
        )
        if unchanged:
            result.action = "unchanged"
            result.manual = stacked
            return result

    head = commit_tree(tree, base, message)
    for commit in stacked:
        replayed, status = replay(commit, head)
        if replayed is None:
            result.conflicts.append(commit)
        elif status == "empty":
            result.dropped.append(commit)
        else:
            result.manual.append(commit)
            head = replayed
    git("update-ref", f"refs/heads/{branch}", head)
    result.action = "updated" if exists else "created"
    return result


# --------------------------------------------------------------------------------------


def stale_branches(active: set[str], prefix: str) -> list[str]:
    """Branches this script owns whose team no longer has any modernizable file."""
    refs = git("for-each-ref", "--format=%(refname:short)", f"refs/heads/{prefix}*")
    return [
        b for b in refs.splitlines()
        if b not in active and stacked_commits(b)[1] is not None
    ]


def report(results: list[Outcome], base: str, teams_skipped: list[str], stale: list[str],
           prefix: str) -> None:
    print("\n" + "=" * 88)
    print(f"base {base[:12]}   {len(results)} team branch(es)")
    print("=" * 88)
    width = max((len(r.branch) for r in results), default=10)
    for r in sorted(results, key=lambda r: -r.files):
        extra = ""
        if r.manual:
            extra += f"  +{len(r.manual)} manual"
        if r.dropped:
            extra += f"  {len(r.dropped)} manual now redundant"
        if r.conflicts:
            extra += f"  CONFLICT on {' '.join(c[:8] for c in r.conflicts)}"
        print(f"  {r.branch:<{width}}  {r.files:>5} files  {r.action}{extra}")
    if teams_skipped:
        print(f"\n  filtered out: {', '.join(teams_skipped)}")
    if stale:
        print(f"\n  no modernizable files left, delete when merged: {', '.join(stale)}")

    conflicted = [r for r in results if r.conflicts]
    if conflicted:
        print("\nManual commits that could not be replayed (branch holds the automated commit only).")
        print(f"Previous branch tips are saved under {BACKUP_NS}/<branch>. To re-apply by hand:")
        for r in conflicted:
            print(f"  git worktree add /tmp/{r.branch} {r.branch} && "
                  f"git -C /tmp/{r.branch} cherry-pick {' '.join(r.conflicts)}")

    print("\nNext: the manual cleanup, one extra commit per branch.")
    print("  git worktree add /tmp/<branch> <branch>")
    print(f"  git commit -am 'modernize(<team>): drop leftovers' -m '{MANUAL_TRAILER}'")
    print("Commits stacked on top of the automated one are replayed automatically on the next run.")

    orphans = {r.team: r.leftovers for r in results if r.leftovers}
    if orphans:
        print("\nOrphaned by the rewrites, delete in the manual commit:")
        for team, items in sorted(orphans.items()):
            print(f"  {prefix}{team}")
            for item in items:
                print(f"    {item}")

    print("\nPRs need the `skip-changelog` label: mechanical rewrites have no user-visible effect.")


def parse_args() -> argparse.Namespace:
    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
    p.add_argument("--base", default="HEAD", help="commit the branches are based on (default: HEAD)")
    p.add_argument("--branch-prefix", default=BRANCH_PREFIX,
                   help="branch name prefix; give each base its own when targeting release branches")
    p.add_argument("--quick", action="store_true", help="only linux/amd64, darwin/arm64, windows/amd64")
    p.add_argument("--max-passes", type=int, default=4, help="fixer passes before giving up on convergence")
    p.add_argument("--jobs", type=int, default=os.cpu_count(), help="golangci-lint concurrency")
    p.add_argument("--memlimit", type=int, default=32, help="GOMEMLIMIT for the fixers, in GiB")
    p.add_argument("--tmpdir", type=Path,
                   default=Path(os.environ.get("XDG_CACHE_HOME", Path.home() / ".cache")) / "beats-modernize-tmp",
                   help="disk-backed scratch dir for the Go toolchain (must not be tmpfs)")
    p.add_argument("--teams", help="comma-separated team slugs to branch (others are reported only)")
    p.add_argument("--skip-fix", action="store_true", help="reuse the worktree as-is instead of running the fixers")
    p.add_argument("--from-snapshot", action="store_true", help=f"reuse {SNAPSHOT_REF} instead of the worktree")
    p.add_argument("--no-split", action="store_true", help="stop after the fixers, leaving the worktree dirty")
    p.add_argument("--verify", action="store_true", help="type-check the host platform before splitting")
    p.add_argument("--no-leftovers", dest="leftovers", action="store_false",
                   help="skip the `unused` diff that lists symbols the rewrites orphaned")
    p.add_argument("--keep-dirty", action="store_true", help="do not restore the worktree at the end")
    p.add_argument("--push", metavar="REMOTE", help="force-with-lease push every touched branch")
    p.add_argument("--golangci-lint", default="golangci-lint")
    p.add_argument("--codeowners", default="codeowners")
    return p.parse_args()


def main() -> int:
    args = parse_args()
    root = Path(git("rev-parse", "--show-toplevel"))
    os.chdir(root)

    for tool in [args.golangci_lint, args.codeowners, "go", "git"]:
        if not shutil.which(tool):
            print(f"error: {tool} not found on PATH", file=sys.stderr)
            return 1

    base = git("rev-parse", f"{args.base}^{{commit}}")
    if not args.from_snapshot:
        if git("rev-parse", "HEAD") != base:
            print(f"error: HEAD is not {args.base}; check it out first", file=sys.stderr)
            return 1
        if not args.skip_fix and git("status", "--porcelain", "-uno"):
            print("error: worktree has uncommitted changes to tracked files", file=sys.stderr)
            return 1

    args.tmpdir.mkdir(parents=True, exist_ok=True)
    sweep_tmpdir(args.tmpdir)
    configs = write_configs(root)
    restore = not args.keep_dirty and not args.from_snapshot
    try:
        if args.from_snapshot:
            snap = git("rev-parse", SNAPSHOT_REF)
            files = [f for f in git("diff", "--name-only", "--diff-filter=d", base, snap).splitlines() if f.endswith(".go")]
            log(f"reusing snapshot {snap[:12]} with {len(files)} files")
        else:
            files = modernize(root, args, configs, args.tmpdir) if not args.skip_fix else \
                [f for f in changed_files(root) if f.endswith(".go")]
            if not files:
                log("nothing to modernize")
                return 0
            if args.verify:
                log("verifying host build")
                failures = verify_build(root, platform_env(*host_platform(), args.tmpdir, args.memlimit))
                for failure in failures:
                    log(f"  {failure}")
                log("  ok" if not failures else "  BROKEN, not splitting")
                if failures:
                    restore = False
                    return 1
            if args.no_split:
                restore = False
                log(f"{len(files)} files changed, left in the worktree")
                return 0
            snap = snapshot(root, base)
            log(f"snapshot {snap[:12]} with {len(files)} files")

        by_team = split_by_team(root, files, args.codeowners)
        wanted = set(args.teams.split(",")) if args.teams else None
        busy = checked_out_branches()

        orphans: dict[str, list[str]] = defaultdict(list)
        if args.leftovers:
            log("looking for symbols the rewrites orphaned")
            found = leftovers(base, snap, args.tmpdir)
            owners = split_by_team(root, sorted({i.split(":", 1)[0] for i in found}), args.codeowners)
            team_of_file = {f: t for t, fs in owners.items() for f in fs}
            for item in found:
                orphans[team_of_file.get(item.split(":", 1)[0], "unowned")].append(item)
            log(f"  {len(found)} orphaned symbol(s)")

        results, skipped = [], []
        for team, team_files in by_team.items():
            if wanted is not None and team not in wanted:
                skipped.append(f"{team} ({len(team_files)})")
                continue
            outcome = update_branch(team, team_files, base, snap, busy, args.branch_prefix)
            outcome.leftovers = orphans.get(team, [])
            results.append(outcome)

        if args.push:
            for r in results:
                if r.action in ("created", "updated"):
                    rc, _, err = git_try("push", "--force-with-lease", args.push, f"{r.branch}:{r.branch}")
                    r.action += " pushed" if rc == 0 else f" PUSH FAILED: {err.strip().splitlines()[-1]}"

        report(results, base, skipped,
               stale_branches({r.branch for r in results}, args.branch_prefix),
               args.branch_prefix)
        return 0
    except BaseException:
        # Never throw away hours of fixing because of a late failure.
        restore = False
        raise
    finally:
        for cfg in configs.values():
            cfg.unlink(missing_ok=True)
        sweep_tmpdir(args.tmpdir)
        if restore and git("status", "--porcelain", "-uno"):
            git("checkout", "--", ".")


if __name__ == "__main__":
    sys.exit(main())
```

</details>

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.~~
- [ ] ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).~~ Labelled `skip-changelog`: no user-visible change.

## Disruptive User Impact

None.

## Review notes

Two commits, so the hand-written part is obvious:

1. `x-pack/osquerybeat,winlogbeat: fix modernize lint findings` is pure tool output, nothing in it was written by hand.
2. `x-pack/osquerybeat: drop helpers orphaned by modernize` is the part the tools could not produce:

   > `go fix` inlined the `//go:fix inline` pointer helpers at every call site,
   > leaving the helpers themselves unused. Deleting them is the one part of this
   > branch a tool could not do, so it lives in its own commit.

- `x-pack/osquerybeat/internal/config/config_test.go`
- `x-pack/osquerybeat/internal/config/osquery_test.go`
- `x-pack/osquerybeat/internal/scheduler/schedule_test.go`

## Related issues

- Relates https://github.com/elastic/beats/issues/52485
