### PR TITLE
[Heartbeat] Forward certificate_error_spki_allowlist to synthetics

### DIFF
--- a/changelog/fragments/1786440000-heartbeat-browser-certificate-spki-allowlist.yaml
+++ b/changelog/fragments/1786440000-heartbeat-browser-certificate-spki-allowlist.yaml
@@ -1,0 +1,3 @@
+kind: enhancement
+summary: Allow browser monitors to bypass certificate errors for configured SPKIs
+component: heartbeat

--- a/x-pack/heartbeat/monitors/browser/config.go
+++ b/x-pack/heartbeat/monitors/browser/config.go
@@ -43,12 +43,7 @@ type Config struct {
 	SyntheticsArgs    []string                      `config:"synthetics_args"`
 	PlaywrightOpts    map[string]any                `config:"playwright_options"`
 	FilterJourneys    synthexec.FilterJourneyConfig `config:"filter_journeys"`
-	IgnoreHTTPSErrors bool                          `config:"ignore_https_errors"`
-	// CertificateErrorSpkiAllowlist is a list of PEM certificates (inline or
-	// file paths). Heartbeat forwards them to synthetics as
-	// --certificate-error-spki-allowlist so Chromium can bypass certificate
-	// errors for matching presented SPKIs. This does not install a CA into
-	// Chromium's NSS trust store.
+	IgnoreHTTPSErrors             bool          `config:"ignore_https_errors"`
 	CertificateErrorSpkiAllowlist []string      `config:"certificate_error_spki_allowlist"`
 	Timeout                       time.Duration `config:"timeout"`
 }

--- a/x-pack/heartbeat/monitors/browser/config.go
+++ b/x-pack/heartbeat/monitors/browser/config.go
@@ -36,16 +36,16 @@ type Config struct {
 	// Name is optional for lightweight checks but required for browsers
 	Name string `config:"name"`
 	// Id is optional for lightweight checks but required for browsers
-	Id                string                        `config:"id"`
-	Sandbox           bool                          `config:"sandbox"`
-	Throttling        any                           `config:"throttling"`
-	Screenshots       string                        `config:"screenshots"`
-	SyntheticsArgs    []string                      `config:"synthetics_args"`
-	PlaywrightOpts    map[string]any                `config:"playwright_options"`
-	FilterJourneys    synthexec.FilterJourneyConfig `config:"filter_journeys"`
-	IgnoreHTTPSErrors             bool          `config:"ignore_https_errors"`
-	CertificateErrorSpkiAllowlist []string      `config:"certificate_error_spki_allowlist"`
-	Timeout                       time.Duration `config:"timeout"`
+	Id                            string                        `config:"id"`
+	Sandbox                       bool                          `config:"sandbox"`
+	Throttling                    any                           `config:"throttling"`
+	Screenshots                   string                        `config:"screenshots"`
+	SyntheticsArgs                []string                      `config:"synthetics_args"`
+	PlaywrightOpts                map[string]any                `config:"playwright_options"`
+	FilterJourneys                synthexec.FilterJourneyConfig `config:"filter_journeys"`
+	IgnoreHTTPSErrors             bool                          `config:"ignore_https_errors"`
+	CertificateErrorSpkiAllowlist []string                      `config:"certificate_error_spki_allowlist"`
+	Timeout                       time.Duration                 `config:"timeout"`
 }
 
 // IsAPI reports whether this is the `api` monitor type (or its alias), which

--- a/x-pack/heartbeat/monitors/browser/config.go
+++ b/x-pack/heartbeat/monitors/browser/config.go
@@ -44,7 +44,13 @@ type Config struct {
 	PlaywrightOpts    map[string]any                `config:"playwright_options"`
 	FilterJourneys    synthexec.FilterJourneyConfig `config:"filter_journeys"`
 	IgnoreHTTPSErrors bool                          `config:"ignore_https_errors"`
-	Timeout           time.Duration                 `config:"timeout"`
+	// CertificateErrorSpkiAllowlist is a list of PEM certificates (inline or
+	// file paths). Heartbeat forwards them to synthetics as
+	// --certificate-error-spki-allowlist so Chromium can bypass certificate
+	// errors for matching presented SPKIs. This does not install a CA into
+	// Chromium's NSS trust store.
+	CertificateErrorSpkiAllowlist []string      `config:"certificate_error_spki_allowlist"`
+	Timeout                       time.Duration `config:"timeout"`
 }
 
 // IsAPI reports whether this is the `api` monitor type (or its alias), which

--- a/x-pack/heartbeat/monitors/browser/sourcejob.go
+++ b/x-pack/heartbeat/monitors/browser/sourcejob.go
@@ -165,6 +165,10 @@ func (sj *SourceJob) extraArgs(uiOrigin bool) []string {
 	}
 	// The remaining flags require Chromium, so skip them for API journeys.
 	if !sj.browserCfg.IsAPI() {
+		if len(sj.browserCfg.CertificateErrorSpkiAllowlist) > 0 {
+			extraArgs = append(extraArgs, "--certificate-error-spki-allowlist")
+			extraArgs = append(extraArgs, sj.browserCfg.CertificateErrorSpkiAllowlist...)
+		}
 		if sj.browserCfg.Sandbox {
 			extraArgs = append(extraArgs, "--sandbox")
 		}

--- a/x-pack/heartbeat/monitors/browser/sourcejob_test.go
+++ b/x-pack/heartbeat/monitors/browser/sourcejob_test.go
@@ -184,6 +184,19 @@ func TestExtraArgs(t *testing.T) {
 			false,
 		},
 		{
+			"certificate_error_spki_allowlist",
+			&Config{CertificateErrorSpkiAllowlist: []string{
+				"-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----",
+				"/path/to/server.crt",
+			}},
+			[]string{
+				"--certificate-error-spki-allowlist",
+				"-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----",
+				"/path/to/server.crt",
+			},
+			false,
+		},
+		{
 			"screenshots",
 			&Config{Screenshots: "off"},
 			[]string{"--screenshots", "off"},

--- a/x-pack/heartbeat/monitors/browser/sourcejob_test.go
+++ b/x-pack/heartbeat/monitors/browser/sourcejob_test.go
@@ -197,6 +197,15 @@ func TestExtraArgs(t *testing.T) {
 			false,
 		},
 		{
+			"certificate_error_spki_allowlist is omitted for API journeys",
+			&Config{
+				Type:                          "api",
+				CertificateErrorSpkiAllowlist: []string{"/path/to/server.crt"},
+			},
+			[]string{},
+			false,
+		},
+		{
 			"screenshots",
 			&Config{Screenshots: "off"},
 			[]string{"--screenshots", "off"},


### PR DESCRIPTION
## Summary

- Accept `certificate_error_spki_allowlist` on browser monitor config
- Forward PEMs to synthetics as `--certificate-error-spki-allowlist` for Chromium journeys
- Keep the Chromium-only flag out of API journeys
- Add unit coverage and a Heartbeat changelog fragment

Closes #52553

Companion to:
- https://github.com/elastic/synthetics/issues/1170
- https://github.com/elastic/synthetics/pull/1149
- https://github.com/elastic/kibana/issues/284093
- https://github.com/elastic/integrations/issues/20640

The synthetics CLI support landed in elastic/synthetics#1149.

## Test plan

- [x] `go test -v -race -tags synthetics -run '^TestExtraArgs$' ./monitors/browser`
- [x] Beats x-pack Heartbeat CI
- [ ] Manual private-location run after the Kibana configuration path lands
