### PR TITLE
Improve documentation and variable names

### DIFF
--- a/metricbeat/module/kubernetes/util/kubernetes.go
+++ b/metricbeat/module/kubernetes/util/kubernetes.go
@@ -384,7 +384,9 @@ func hasCommittedClusterScopedUser(metaWatcher *metaWatcher) bool {
 	return false
 }
 
-// registerWatcherUser records ownership of one exact watched resource.
+// registerWatcherUser reserves one exact watched resource while the enricher is
+// initialized. This keeps a concurrently stopping owner from removing the
+// watcher while metadata generators are being created.
 // The resource watcher registry must be locked by the caller.
 func registerWatcherUser(resourceName string, metaWatcher *metaWatcher, e *enricher, primary, nodeScope bool) {
 	if addWatcherUser(metaWatcher, e, nodeScope) {
@@ -395,8 +397,10 @@ func registerWatcherUser(resourceName string, metaWatcher *metaWatcher, e *enric
 	}
 }
 
-// commitWatcherOwnership publishes a fully initialized enricher to Start and
-// watcher event handlers.
+// commitWatcherOwnership makes an enricher visible to Start and watcher event
+// handlers after its callbacks and indexes have been initialized. Registrations
+// are made earlier to reserve the shared watchers and rolled back if setup
+// fails.
 func commitWatcherOwnership(e *enricher, resourceWatchers *Watchers) {
 	resourceWatchers.lock.Lock()
 	defer resourceWatchers.lock.Unlock()

--- a/metricbeat/module/kubernetes/util/kubernetes.go
+++ b/metricbeat/module/kubernetes/util/kubernetes.go
@@ -111,9 +111,9 @@ type metaWatcher struct {
 	enrichers   map[*enricher]struct{}            // enrichers that use this watcher as their primary source
 	metricsRepo *MetricsRepo                      // used to update container metrics derived from metadata, like resource limits
 
-	nodeScope             bool                               // whether the active watcher watches resources in the current node or the whole cluster
-	restartWatcher        kubernetes.Watcher                 // whether this watcher needs a restart. Only relevant in leader nodes due to metricsets with different nodescope(pod, state_pod)
-	restartWatcherFactory func() (kubernetes.Watcher, error) // creates a fresh replacement after a failed one-shot watcher start
+	nodeScope                 bool                               // whether the active watcher watches resources in the current node or the whole cluster
+	replacementWatcher        kubernetes.Watcher                 // pending cluster-scoped watcher that replaces the active node-scoped watcher
+	replacementWatcherFactory func() (kubernetes.Watcher, error) // creates a fresh replacement after a failed one-shot watcher start
 }
 
 // getActiveWatcherByKey keeps the active watcher alive while its store is read.
@@ -455,18 +455,18 @@ func createWatcher(
 
 	// If the watcher exists, exit
 	if ok {
-		if resourceMetaWatcher.nodeScope && !nodeScope && resourceMetaWatcher.restartWatcher == nil {
+		if resourceMetaWatcher.nodeScope && !nodeScope && resourceMetaWatcher.replacementWatcher == nil {
 			// It might happen that the watcher already exists, but is only being used to monitor the resources
 			// of a single node(e.g. created by pod metricset). In that case, we need to check if we are trying to create a new watcher that will track
 			// the resources of whole cluster(e.g. in case of state_pod metricset).
 			// If it is the case, then we need to update the watcher by changing its watch options (removing options.Node)
 			// A running watcher cannot be updated directly. Instead, we must create a new one with the correct watch options.
-			// The new restartWatcher must be identical to the old watcher, including the same handler function, with the only difference being the watch options.
+			// The replacement watcher must be identical to the old watcher, including the same handler function, with the only difference being the watch options.
 
 			if isNamespaced(resourceName) {
 				options.Namespace = namespace
 			}
-			restartWatcherFactory := func() (kubernetes.Watcher, error) {
+			replacementWatcherFactory := func() (kubernetes.Watcher, error) {
 				restartWatcher, err := kubernetes.NewNamedWatcher(resourceName, client, resource, options, nil, logger)
 				if err != nil {
 					return nil, err
@@ -474,12 +474,12 @@ func createWatcher(
 				restartWatcher.AddEventHandler(resourceMetaWatcher.watcher.GetEventHandler())
 				return restartWatcher, nil
 			}
-			restartWatcher, err := restartWatcherFactory()
+			replacementWatcher, err := replacementWatcherFactory()
 			if err != nil {
 				return false, err
 			}
-			resourceMetaWatcher.restartWatcherFactory = restartWatcherFactory
-			resourceMetaWatcher.restartWatcher = restartWatcher
+			resourceMetaWatcher.replacementWatcherFactory = replacementWatcherFactory
+			resourceMetaWatcher.replacementWatcher = replacementWatcher
 		}
 		registerWatcherUser(resourceName, resourceMetaWatcher, e, !extraWatcher, nodeScope)
 		return false, nil
@@ -515,13 +515,13 @@ func createWatcher(
 	}
 
 	resourceMetaWatcher = &metaWatcher{
-		watcher:        watcher,
-		started:        false, // not started yet
-		users:          make(map[*enricher]watcherRegistration),
-		enrichers:      make(map[*enricher]struct{}),
-		metricsRepo:    metricsRepo,
-		restartWatcher: nil,
-		nodeScope:      nodeScope,
+		watcher:            watcher,
+		started:            false, // not started yet
+		users:              make(map[*enricher]watcherRegistration),
+		enrichers:          make(map[*enricher]struct{}),
+		metricsRepo:        metricsRepo,
+		replacementWatcher: nil,
+		nodeScope:          nodeScope,
 	}
 	resourceWatchers.metaWatchersMap[resourceName] = resourceMetaWatcher
 	registerWatcherUser(resourceName, resourceMetaWatcher, e, !extraWatcher, nodeScope)
@@ -737,8 +737,8 @@ func createMetadataGenSpecific(client k8sclient.Interface, commonConfig *conf.C,
 	mainWatcher := (*resourceMetaWatcher).watcher
 	if e != nil {
 		if registration, owned := resourceMetaWatcher.users[e]; owned &&
-			!registration.nodeScope && resourceMetaWatcher.nodeScope && resourceMetaWatcher.restartWatcher != nil {
-			mainWatcher = resourceMetaWatcher.restartWatcher
+			!registration.nodeScope && resourceMetaWatcher.nodeScope && resourceMetaWatcher.replacementWatcher != nil {
+			mainWatcher = resourceMetaWatcher.replacementWatcher
 		}
 	}
 
@@ -1150,27 +1150,27 @@ func (e *enricher) start(resourceWatchers *Watchers) kubernetes.Watcher {
 	// stopping the active watcher so a failed replacement does not interrupt
 	// metadata collection.
 	if resourceMetaWatcher.nodeScope && hasCommittedClusterScopedUser(resourceMetaWatcher) &&
-		resourceMetaWatcher.restartWatcher == nil && resourceMetaWatcher.restartWatcherFactory != nil {
-		restartWatcher, err := resourceMetaWatcher.restartWatcherFactory()
+		resourceMetaWatcher.replacementWatcher == nil && resourceMetaWatcher.replacementWatcherFactory != nil {
+		replacementWatcher, err := resourceMetaWatcher.replacementWatcherFactory()
 		if err != nil {
 			e.log.Warnf("Error recreating %s watcher: %s", e.resourceName, err)
 		} else {
-			resourceMetaWatcher.restartWatcher = restartWatcher
+			resourceMetaWatcher.replacementWatcher = replacementWatcher
 		}
 	}
-	if resourceMetaWatcher.restartWatcher != nil && hasCommittedClusterScopedUser(resourceMetaWatcher) {
-		if err := resourceMetaWatcher.restartWatcher.Start(); err != nil {
+	if resourceMetaWatcher.replacementWatcher != nil && hasCommittedClusterScopedUser(resourceMetaWatcher) {
+		if err := resourceMetaWatcher.replacementWatcher.Start(); err != nil {
 			e.log.Warnf("Error restarting %s watcher: %s", e.resourceName, err)
-			watcherToStop = resourceMetaWatcher.restartWatcher
-			resourceMetaWatcher.restartWatcher = nil
+			watcherToStop = resourceMetaWatcher.replacementWatcher
+			resourceMetaWatcher.replacementWatcher = nil
 		} else {
 			if resourceMetaWatcher.started {
-				watcherToStop = resourceMetaWatcher.replaceActiveWatcher(resourceMetaWatcher.restartWatcher)
+				watcherToStop = resourceMetaWatcher.replaceActiveWatcher(resourceMetaWatcher.replacementWatcher)
 			} else {
-				resourceMetaWatcher.replaceActiveWatcher(resourceMetaWatcher.restartWatcher)
+				resourceMetaWatcher.replaceActiveWatcher(resourceMetaWatcher.replacementWatcher)
 			}
-			resourceMetaWatcher.restartWatcher = nil
-			resourceMetaWatcher.restartWatcherFactory = nil
+			resourceMetaWatcher.replacementWatcher = nil
+			resourceMetaWatcher.replacementWatcherFactory = nil
 			resourceMetaWatcher.nodeScope = false
 			resourceMetaWatcher.started = true
 		}
@@ -1209,8 +1209,8 @@ func releaseWatcherOwnership(e *enricher, resourceWatchers *Watchers) {
 				watchersToStop = append(watchersToStop, activeWatcher)
 			}
 		} else if !hasClusterScopedUser(metaWatcher) {
-			metaWatcher.restartWatcher = nil
-			metaWatcher.restartWatcherFactory = nil
+			metaWatcher.replacementWatcher = nil
+			metaWatcher.replacementWatcherFactory = nil
 		}
 	}
 	e.watchedResources = nil

--- a/metricbeat/module/kubernetes/util/kubernetes_test.go
+++ b/metricbeat/module/kubernetes/util/kubernetes_test.go
@@ -680,8 +680,8 @@ func TestNewResourceMetadataEnricherRollbackDoesNotUpgradeNodeScopedOwner(t *tes
 
 	require.IsType(t, &nilEnricher{}, enricher, "metadata generator failure must disable enrichment")
 	resourceWatchers.lock.RLock()
-	require.Nil(t, metaWatcher.restartWatcher, "rolling back the last cluster-scoped registration must discard its pending replacement")
-	require.Nil(t, metaWatcher.restartWatcherFactory, "rollback must discard the replacement factory")
+	require.Nil(t, metaWatcher.replacementWatcher, "rolling back the last cluster-scoped registration must discard its pending replacement")
+	require.Nil(t, metaWatcher.replacementWatcherFactory, "rollback must discard the replacement factory")
 	require.True(t, metaWatcher.nodeScope, "rollback must preserve the active node-scoped watcher's scope")
 	resourceWatchers.lock.RUnlock()
 
@@ -697,13 +697,13 @@ func TestPendingScopeUpgradeRetainedForCommittedClusterScopedOwner(t *testing.T)
 	active := newMockWatcher()
 	pending := newMockWatcher()
 	metaWatcher := &metaWatcher{
-		watcher:        active,
-		started:        true,
-		users:          make(map[*enricher]watcherRegistration),
-		enrichers:      make(map[*enricher]struct{}),
-		nodeScope:      true,
-		restartWatcher: pending,
-		restartWatcherFactory: func() (kubernetes.Watcher, error) {
+		watcher:            active,
+		started:            true,
+		users:              make(map[*enricher]watcherRegistration),
+		enrichers:          make(map[*enricher]struct{}),
+		nodeScope:          true,
+		replacementWatcher: pending,
+		replacementWatcherFactory: func() (kubernetes.Watcher, error) {
 			return newMockWatcher(), nil
 		},
 	}
@@ -718,14 +718,14 @@ func TestPendingScopeUpgradeRetainedForCommittedClusterScopedOwner(t *testing.T)
 
 	firstClusterScoped.Stop(resourceWatchers)
 	resourceWatchers.lock.RLock()
-	require.Same(t, pending, metaWatcher.restartWatcher, "another committed cluster-scoped owner must retain the pending replacement")
-	require.NotNil(t, metaWatcher.restartWatcherFactory, "another committed cluster-scoped owner must retain the replacement factory")
+	require.Same(t, pending, metaWatcher.replacementWatcher, "another committed cluster-scoped owner must retain the pending replacement")
+	require.NotNil(t, metaWatcher.replacementWatcherFactory, "another committed cluster-scoped owner must retain the replacement factory")
 	resourceWatchers.lock.RUnlock()
 
 	secondClusterScoped.Stop(resourceWatchers)
 	resourceWatchers.lock.RLock()
-	require.Nil(t, metaWatcher.restartWatcher, "the last cluster-scoped owner must discard the pending replacement")
-	require.Nil(t, metaWatcher.restartWatcherFactory, "the last cluster-scoped owner must discard the replacement factory")
+	require.Nil(t, metaWatcher.replacementWatcher, "the last cluster-scoped owner must discard the pending replacement")
+	require.Nil(t, metaWatcher.replacementWatcherFactory, "the last cluster-scoped owner must discard the replacement factory")
 	require.True(t, metaWatcher.nodeScope, "discarding a pending replacement must preserve the active watcher scope")
 	resourceWatchers.lock.RUnlock()
 
@@ -752,7 +752,7 @@ func TestConcurrentNodeScopedStartDoesNotApplyProvisionalScopeUpgrade(t *testing
 	provisional := newMetadataEnricher("state_pod", PodResource, config, log)
 
 	resourceWatchers.lock.Lock()
-	metaWatcher.restartWatcher = pending
+	metaWatcher.replacementWatcher = pending
 	registerWatcherUser(PodResource, metaWatcher, provisional, true, false)
 	started := make(chan struct{})
 	go func() {
@@ -764,7 +764,7 @@ func TestConcurrentNodeScopedStartDoesNotApplyProvisionalScopeUpgrade(t *testing
 
 	require.Equal(t, 0, pending.startCalls, "Start must not apply a scope change required only by a provisional owner")
 	require.Equal(t, 0, active.stopCalls, "Start must leave the active watcher uninterrupted")
-	require.Same(t, pending, metaWatcher.restartWatcher, "the provisional owner's replacement must remain available during construction")
+	require.Same(t, pending, metaWatcher.replacementWatcher, "the provisional owner's replacement must remain available during construction")
 
 	releaseWatcherOwnership(provisional, resourceWatchers)
 	nodeScoped.Stop(resourceWatchers)
@@ -781,13 +781,13 @@ func TestFailedScopeUpgradeLeavesActiveWatcherRunning(t *testing.T) {
 	replacements := []kubernetes.Watcher{secondFailed, replacement}
 	factoryCalls := 0
 	metaWatcher := &metaWatcher{
-		watcher:        active,
-		started:        true,
-		users:          make(map[*enricher]watcherRegistration),
-		enrichers:      make(map[*enricher]struct{}),
-		nodeScope:      true,
-		restartWatcher: firstFailed,
-		restartWatcherFactory: func() (kubernetes.Watcher, error) {
+		watcher:            active,
+		started:            true,
+		users:              make(map[*enricher]watcherRegistration),
+		enrichers:          make(map[*enricher]struct{}),
+		nodeScope:          true,
+		replacementWatcher: firstFailed,
+		replacementWatcherFactory: func() (kubernetes.Watcher, error) {
 			watcher := replacements[factoryCalls]
 			factoryCalls++
 			return watcher, nil
@@ -806,7 +806,7 @@ func TestFailedScopeUpgradeLeavesActiveWatcherRunning(t *testing.T) {
 	require.Equal(t, 1, firstFailed.stopCalls, "failed replacement must be stopped")
 	require.Equal(t, 0, active.stopCalls, "failed replacement must not stop the active watcher")
 	require.Same(t, active, metaWatcher.watcher, "failed replacement must not replace the active watcher")
-	require.Nil(t, metaWatcher.restartWatcher, "failed replacement must be discarded")
+	require.Nil(t, metaWatcher.replacementWatcher, "failed replacement must be discarded")
 	require.True(t, metaWatcher.nodeScope, "failed replacement must preserve the active watcher scope")
 	require.True(t, metaWatcher.started, "failed replacement must preserve active watcher state")
 
@@ -821,25 +821,25 @@ func TestFailedScopeUpgradeLeavesActiveWatcherRunning(t *testing.T) {
 	require.Equal(t, 1, replacement.startCalls, "fresh replacement must be started")
 	require.Equal(t, 1, active.stopCalls, "active watcher must stop only after its replacement starts")
 	require.Same(t, replacement, metaWatcher.watcher, "successful replacement must become active")
-	require.Nil(t, metaWatcher.restartWatcher, "successful scope upgrade must clear the pending replacement")
-	require.Nil(t, metaWatcher.restartWatcherFactory, "successful scope upgrade must clear the replacement factory")
+	require.Nil(t, metaWatcher.replacementWatcher, "successful scope upgrade must clear the pending replacement")
+	require.Nil(t, metaWatcher.replacementWatcherFactory, "successful scope upgrade must clear the replacement factory")
 	require.False(t, metaWatcher.nodeScope, "successful replacement must restore cluster-scoped coverage")
 
 	clusterScoped.Stop(resourceWatchers)
 	nodeScoped.Stop(resourceWatchers)
 }
 
-func TestNodeScopeRestartWatcherLifecycle(t *testing.T) {
+func TestNodeScopeReplacementWatcherLifecycle(t *testing.T) {
 	resourceWatchers := NewWatchers()
 	active := newMockWatcher()
 	replacement := newMockWatcher()
 	metaWatcher := &metaWatcher{
-		watcher:        active,
-		started:        true,
-		users:          make(map[*enricher]watcherRegistration),
-		enrichers:      make(map[*enricher]struct{}),
-		nodeScope:      true,
-		restartWatcher: replacement,
+		watcher:            active,
+		started:            true,
+		users:              make(map[*enricher]watcherRegistration),
+		enrichers:          make(map[*enricher]struct{}),
+		nodeScope:          true,
+		replacementWatcher: replacement,
 	}
 	resourceWatchers.metaWatchersMap[PodResource] = metaWatcher
 
@@ -853,7 +853,7 @@ func TestNodeScopeRestartWatcherLifecycle(t *testing.T) {
 	require.Equal(t, 1, active.stopCalls, "scope upgrade must stop the old active watcher")
 	require.Equal(t, 1, replacement.startCalls, "scope upgrade must start the pending cluster-scoped watcher")
 	require.Same(t, replacement, metaWatcher.watcher, "replacement must become the active watcher")
-	require.Nil(t, metaWatcher.restartWatcher, "successful scope upgrade must clear the pending watcher")
+	require.Nil(t, metaWatcher.replacementWatcher, "successful scope upgrade must clear the pending watcher")
 
 	clusterScoped.Stop(resourceWatchers)
 	require.Equal(t, 0, replacement.stopCalls, "node-scoped owner must retain the replacement watcher")
@@ -864,17 +864,17 @@ func TestNodeScopeRestartWatcherLifecycle(t *testing.T) {
 	resourceWatchers.lock.RUnlock()
 }
 
-func TestFinalOwnerEvictionDiscardsPendingRestartWatcher(t *testing.T) {
+func TestFinalOwnerEvictionDiscardsPendingReplacementWatcher(t *testing.T) {
 	resourceWatchers := NewWatchers()
 	active := newMockWatcher()
 	pending := newMockWatcher()
 	metaWatcher := &metaWatcher{
-		watcher:        active,
-		started:        true,
-		users:          make(map[*enricher]watcherRegistration),
-		enrichers:      make(map[*enricher]struct{}),
-		nodeScope:      true,
-		restartWatcher: pending,
+		watcher:            active,
+		started:            true,
+		users:              make(map[*enricher]watcherRegistration),
+		enrichers:          make(map[*enricher]struct{}),
+		nodeScope:          true,
+		replacementWatcher: pending,
 	}
 	resourceWatchers.metaWatchersMap[PodResource] = metaWatcher
 
@@ -1074,12 +1074,12 @@ func TestActiveWatcherLookupBlocksScopeReplacement(t *testing.T) {
 	require.NoError(t, replacement.Store().Add(replacementResource), "replacement watcher store must contain the resource")
 
 	metaWatcher := &metaWatcher{
-		watcher:        active,
-		started:        true,
-		users:          make(map[*enricher]watcherRegistration),
-		enrichers:      make(map[*enricher]struct{}),
-		nodeScope:      true,
-		restartWatcher: replacement,
+		watcher:            active,
+		started:            true,
+		users:              make(map[*enricher]watcherRegistration),
+		enrichers:          make(map[*enricher]struct{}),
+		nodeScope:          true,
+		replacementWatcher: replacement,
 	}
 	resourceWatchers.metaWatchersMap[PodResource] = metaWatcher
 	e := newWatcherLookupTestEnricher(t, resourceWatchers, metaWatcher)


### PR DESCRIPTION
## Proposed commit message

```
This commit is a followup from https://github.com/elastic/beats/pull/52028 that contains non-fictional changes:
* refactored field names for clarity
* update comments for clarity
```

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.~~
- [ ] ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).v

~~## Disruptive User Impact~~


## How to test this PR locally

Run the tests:
```
go test -count=1 ./metricbeat/module/kubernetes/util/...
```

## Related issues

- Follow up from https://github.com/elastic/beats/pull/52028


~~## Use cases~~
~~## Screenshots~~
~~## Logs~~