### PR TITLE
Fix Heartbeat maintenance windows for Kibana byweekday, tzid, and until

### DIFF
--- a/changelog/fragments/1786463939-honor-nth-weekday-byweekday-in-maintenance-windows.yaml
+++ b/changelog/fragments/1786463939-honor-nth-weekday-byweekday-in-maintenance-windows.yaml
@@ -13,7 +13,7 @@ kind: bug-fix
 
 # REQUIRED for all kinds
 # Change summary; a 80ish characters long description of the change.
-summary: Honor nth-weekday maintenance window byweekday tokens such as +2TU and -1FR.
+summary: Honor Kibana maintenance-window byweekday nth-weekday tokens, tzid, and until.
 
 # REQUIRED for all kinds
 # Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.

--- a/changelog/fragments/1786463939-honor-nth-weekday-byweekday-in-maintenance-windows.yaml
+++ b/changelog/fragments/1786463939-honor-nth-weekday-byweekday-in-maintenance-windows.yaml
@@ -13,7 +13,7 @@ kind: bug-fix
 
 # REQUIRED for all kinds
 # Change summary; a 80ish characters long description of the change.
-summary: Honor Kibana maintenance-window byweekday nth-weekday tokens, tzid, and until.
+summary: Match Kibana maintenance windows for nth-weekday, tzid, until, hourly, inclusive duration, and old dtstart.
 
 # REQUIRED for all kinds
 # Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.

--- a/changelog/fragments/1786463939-honor-nth-weekday-byweekday-in-maintenance-windows.yaml
+++ b/changelog/fragments/1786463939-honor-nth-weekday-byweekday-in-maintenance-windows.yaml
@@ -1,0 +1,26 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: Honor nth-weekday maintenance window byweekday tokens such as +2TU and -1FR.
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: heartbeat
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: https://github.com/elastic/beats/issues/52571

--- a/heartbeat/monitors/maintwin/kibana_parity_test.go
+++ b/heartbeat/monitors/maintwin/kibana_parity_test.go
@@ -343,11 +343,187 @@ func TestKibanaRRuleParity(t *testing.T) {
 				"2023-04-12T00:00:00Z",
 			},
 		},
+		{
+			name: "hourly interval 1 from Kibana @kbn/rrule",
+			mw: MaintWin{
+				Freq:     "hourly",
+				Dtstart:  "2019-01-01T00:00:00.000Z",
+				Tzid:     "UTC",
+				Interval: 1,
+				Duration: time.Hour,
+				Count:    10,
+			},
+			wantISO: []string{
+				"2019-01-01T00:00:00Z",
+				"2019-01-01T01:00:00Z",
+				"2019-01-01T02:00:00Z",
+				"2019-01-01T03:00:00Z",
+				"2019-01-01T04:00:00Z",
+				"2019-01-01T05:00:00Z",
+				"2019-01-01T06:00:00Z",
+				"2019-01-01T07:00:00Z",
+				"2019-01-01T08:00:00Z",
+				"2019-01-01T09:00:00Z",
+			},
+		},
+		{
+			name: "Kibana UI monthly default +4WE from convertToRRule",
+			mw: MaintWin{
+				Freq:      "monthly",
+				Dtstart:   "2023-03-22T00:00:00.000Z",
+				Tzid:      "UTC",
+				Interval:  1,
+				Duration:  time.Hour,
+				Byweekday: []string{"+4WE"},
+				Count:     4,
+			},
+			wantISO: []string{
+				"2023-03-22T00:00:00Z",
+				"2023-04-26T00:00:00Z",
+				"2023-05-24T00:00:00Z",
+				"2023-06-28T00:00:00Z",
+			},
+		},
+		{
+			name: "Kibana UI yearly default bymonth+bymonthday",
+			mw: MaintWin{
+				Freq:       "yearly",
+				Dtstart:    "2023-03-22T00:00:00.000Z",
+				Tzid:       "UTC",
+				Interval:   1,
+				Duration:   time.Hour,
+				Bymonth:    []int{3},
+				Bymonthday: []int{22},
+				Count:      3,
+			},
+			wantISO: []string{
+				"2023-03-22T00:00:00Z",
+				"2024-03-22T00:00:00Z",
+				"2025-03-22T00:00:00Z",
+			},
+		},
+		{
+			name: "Kibana UI custom weekly WE+TH",
+			mw: MaintWin{
+				Freq:      "weekly",
+				Dtstart:   "2023-03-22T00:00:00.000Z",
+				Tzid:      "UTC",
+				Interval:  1,
+				Duration:  time.Hour,
+				Byweekday: []string{"WE", "TH"},
+				Count:     6,
+			},
+			wantISO: []string{
+				"2023-03-22T00:00:00Z",
+				"2023-03-23T00:00:00Z",
+				"2023-03-29T00:00:00Z",
+				"2023-03-30T00:00:00Z",
+				"2023-04-05T00:00:00Z",
+				"2023-04-06T00:00:00Z",
+			},
+		},
+		{
+			name: "Kibana UI custom monthly by day 22",
+			mw: MaintWin{
+				Freq:       "monthly",
+				Dtstart:    "2023-03-22T00:00:00.000Z",
+				Tzid:       "UTC",
+				Interval:   1,
+				Duration:   time.Hour,
+				Bymonthday: []int{22},
+				Count:      4,
+			},
+			wantISO: []string{
+				"2023-03-22T00:00:00Z",
+				"2023-04-22T00:00:00Z",
+				"2023-05-22T00:00:00Z",
+				"2023-06-22T00:00:00Z",
+			},
+		},
+		{
+			name: "Kibana UI daily WE count 3 (ends after x)",
+			mw: MaintWin{
+				Freq:      "daily",
+				Dtstart:   "2023-03-22T00:00:00.000Z",
+				Tzid:      "UTC",
+				Interval:  1,
+				Duration:  time.Hour,
+				Byweekday: []string{"WE"},
+				Count:     3,
+			},
+			wantISO: []string{
+				"2023-03-22T00:00:00Z",
+				"2023-03-29T00:00:00Z",
+				"2023-04-05T00:00:00Z",
+			},
+		},
+		{
+			name: "monthly bymonthday 31 skips short months like Kibana",
+			mw: MaintWin{
+				Freq:       "monthly",
+				Dtstart:    "2025-01-31T00:00:00.000Z",
+				Tzid:       "UTC",
+				Interval:   1,
+				Duration:   time.Hour,
+				Bymonthday: []int{31},
+				Count:      4,
+			},
+			wantISO: []string{
+				"2025-01-31T00:00:00Z",
+				"2025-03-31T00:00:00Z",
+				"2025-05-31T00:00:00Z",
+				"2025-07-31T00:00:00Z",
+			},
+		},
+		{
+			name: "weekly Saturday Europe/Madrid keeps local midnight across DST",
+			mw: MaintWin{
+				Freq:      "weekly",
+				Dtstart:   "2023-01-06T23:00:00Z",
+				Tzid:      "Europe/Madrid",
+				Interval:  1,
+				Duration:  time.Hour,
+				Byweekday: []string{"SA"},
+				Count:     13,
+			},
+			wantISO: []string{
+				"2023-01-06T23:00:00Z",
+				"2023-01-13T23:00:00Z",
+				"2023-01-20T23:00:00Z",
+				"2023-01-27T23:00:00Z",
+				"2023-02-03T23:00:00Z",
+				"2023-02-10T23:00:00Z",
+				"2023-02-17T23:00:00Z",
+				"2023-02-24T23:00:00Z",
+				"2023-03-03T23:00:00Z",
+				"2023-03-10T23:00:00Z",
+				"2023-03-17T23:00:00Z",
+				"2023-03-24T23:00:00Z",
+				"2023-03-31T22:00:00Z",
+			},
+		},
+		{
+			name: "weekly Saturday Europe/Madrid keeps local midnight across fall-back",
+			mw: MaintWin{
+				Freq:      "weekly",
+				Dtstart:   "2023-10-20T22:00:00Z",
+				Tzid:      "Europe/Madrid",
+				Interval:  1,
+				Duration:  time.Hour,
+				Byweekday: []string{"SA"},
+				Count:     3,
+			},
+			wantISO: []string{
+				"2023-10-20T22:00:00Z",
+				"2023-10-27T22:00:00Z",
+				"2023-11-03T23:00:00Z",
+			},
+		},
 	}
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			r, err := c.mw.Parse(false)
+			r, err := c.mw.Parse()
 			require.NoError(t, err, "Parse should succeed for Kibana-shaped rule")
 			got := r.All()
 			require.Equal(t, len(c.wantISO), len(got), "occurrence count: got %v", isoTimes(got))
@@ -365,13 +541,36 @@ func TestKibanaIsActiveMatchesOccurrences(t *testing.T) {
 		Duration:  time.Hour,
 		Byweekday: []string{"SA"},
 	}
-	r, err := mw.Parse(false)
+	r, err := mw.Parse()
 	require.NoError(t, err)
 	pmw := ParsedMaintWin{Rule: r, Duration: mw.Duration}
 
+	assert.True(t, pmw.IsActive(mustTime("2023-01-06T23:00:00Z")), "window start should be active")
 	assert.True(t, pmw.IsActive(mustTime("2023-01-06T23:30:00Z")), "first Saturday local occurrence should be active")
+	assert.True(t, pmw.IsActive(mustTime("2023-01-07T00:00:00Z")), "Kibana lte includes exact window end")
+	assert.False(t, pmw.IsActive(mustTime("2023-01-07T00:00:01Z")), "after window end should be inactive")
 	assert.False(t, pmw.IsActive(mustTime("2023-01-07T23:30:00Z")), "Saturday UTC (Sunday Madrid) should not be active")
 	assert.True(t, pmw.IsActive(mustTime("2023-01-13T23:30:00Z")), "next Saturday Madrid should be active")
+	assert.True(t, pmw.IsActive(mustTime("2023-03-31T22:30:00Z")), "Saturday midnight CEST after DST should be active")
+	assert.False(t, pmw.IsActive(mustTime("2023-03-31T23:00:01Z")), "after CEST Saturday window should be inactive")
+}
+
+func TestKibanaOneShotIsActiveOnlyForDuration(t *testing.T) {
+	mw := MaintWin{
+		Freq:     "yearly",
+		Dtstart:  "2025-06-10T11:40:29Z",
+		Tzid:     "Europe/Berlin",
+		Count:    1,
+		Duration: 30 * time.Minute,
+	}
+	r, err := mw.Parse()
+	require.NoError(t, err, "Parse should succeed for Kibana one-shot yearly count 1")
+	pmw := ParsedMaintWin{Rule: r, Duration: mw.Duration}
+
+	assert.True(t, pmw.IsActive(mustTime("2025-06-10T11:40:29Z")), "one-shot start should be active")
+	assert.True(t, pmw.IsActive(mustTime("2025-06-10T12:10:29Z")), "Kibana lte includes exact one-shot end")
+	assert.False(t, pmw.IsActive(mustTime("2025-06-10T12:10:30Z")), "after one-shot duration should be inactive")
+	assert.False(t, pmw.IsActive(mustTime("2026-06-10T11:40:29Z")), "count 1 must not recur the next year")
 }
 
 func isoTimes(ts []time.Time) []string {

--- a/heartbeat/monitors/maintwin/kibana_parity_test.go
+++ b/heartbeat/monitors/maintwin/kibana_parity_test.go
@@ -1,0 +1,391 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package maintwin
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Occurrences come from Kibana @kbn/rrule snapshots in
+// src/platform/packages/shared/kbn-rrule/rrule.test.ts — the library Kibana
+// uses to decide whether a maintenance window is running.
+func TestKibanaRRuleParity(t *testing.T) {
+	cases := []struct {
+		name     string
+		mw       MaintWin
+		wantISO []string
+	}{
+		{
+			name: "yearly interval 1",
+			mw: MaintWin{
+				Freq:     "yearly",
+				Dtstart:  "2019-01-01T00:00:00.000Z",
+				Tzid:     "UTC",
+				Interval: 1,
+				Duration: time.Hour,
+				Count:    10,
+			},
+			wantISO: []string{
+				"2019-01-01T00:00:00Z",
+				"2020-01-01T00:00:00Z",
+				"2021-01-01T00:00:00Z",
+				"2022-01-01T00:00:00Z",
+				"2023-01-01T00:00:00Z",
+				"2024-01-01T00:00:00Z",
+				"2025-01-01T00:00:00Z",
+				"2026-01-01T00:00:00Z",
+				"2027-01-01T00:00:00Z",
+				"2028-01-01T00:00:00Z",
+			},
+		},
+		{
+			name: "monthly interval 6 with bymonthday",
+			mw: MaintWin{
+				Freq:       "monthly",
+				Dtstart:    "2019-01-01T00:00:00.000Z",
+				Tzid:       "UTC",
+				Interval:   6,
+				Duration:   time.Hour,
+				Bymonthday: []int{10, 20},
+				Count:      6,
+			},
+			wantISO: []string{
+				"2019-01-10T00:00:00Z",
+				"2019-01-20T00:00:00Z",
+				"2019-07-10T00:00:00Z",
+				"2019-07-20T00:00:00Z",
+				"2020-01-10T00:00:00Z",
+				"2020-01-20T00:00:00Z",
+			},
+		},
+		{
+			name: "weekly interval 2",
+			mw: MaintWin{
+				Freq:     "weekly",
+				Dtstart:  "2019-12-19T00:00:00.000Z",
+				Tzid:     "UTC",
+				Interval: 2,
+				Duration: time.Hour,
+				Count:    14,
+			},
+			wantISO: []string{
+				"2019-12-19T00:00:00Z",
+				"2020-01-02T00:00:00Z",
+				"2020-01-16T00:00:00Z",
+				"2020-01-30T00:00:00Z",
+				"2020-02-13T00:00:00Z",
+				"2020-02-27T00:00:00Z",
+				"2020-03-12T00:00:00Z",
+				"2020-03-26T00:00:00Z",
+				"2020-04-09T00:00:00Z",
+				"2020-04-23T00:00:00Z",
+				"2020-05-07T00:00:00Z",
+				"2020-05-21T00:00:00Z",
+				"2020-06-04T00:00:00Z",
+				"2020-06-18T00:00:00Z",
+			},
+		},
+		{
+			name: "until is exclusive of the bound (Kibana uses current >= until)",
+			mw: MaintWin{
+				Freq:     "monthly",
+				Dtstart:  "2019-01-01T00:00:00.000Z",
+				Tzid:     "UTC",
+				Interval: 1,
+				Duration: time.Hour,
+				Until:    "2019-12-01T00:00:00.000Z",
+			},
+			wantISO: []string{
+				"2019-01-01T00:00:00Z",
+				"2019-02-01T00:00:00Z",
+				"2019-03-01T00:00:00Z",
+				"2019-04-01T00:00:00Z",
+				"2019-05-01T00:00:00Z",
+				"2019-06-01T00:00:00Z",
+				"2019-07-01T00:00:00Z",
+				"2019-08-01T00:00:00Z",
+				"2019-09-01T00:00:00Z",
+				"2019-10-01T00:00:00Z",
+				"2019-11-01T00:00:00Z",
+			},
+		},
+		{
+			name: "one-shot yearly count 1 as Kibana UI stores non-recurring windows",
+			mw: MaintWin{
+				Freq:     "yearly",
+				Dtstart:  "2025-06-10T11:40:29.124Z",
+				Tzid:     "Europe/Berlin",
+				Count:    1,
+				Duration: 30 * time.Minute,
+			},
+			wantISO: []string{"2025-06-10T11:40:29Z"},
+		},
+		{
+			name: "weekly SA/SU/MO",
+			mw: MaintWin{
+				Freq:      "weekly",
+				Dtstart:   "2019-01-01T00:00:00.000Z",
+				Tzid:      "UTC",
+				Interval:  1,
+				Duration:  time.Hour,
+				Byweekday: []string{"SA", "SU", "MO"},
+				Count:     9,
+			},
+			wantISO: []string{
+				"2019-01-05T00:00:00Z",
+				"2019-01-06T00:00:00Z",
+				"2019-01-07T00:00:00Z",
+				"2019-01-12T00:00:00Z",
+				"2019-01-13T00:00:00Z",
+				"2019-01-14T00:00:00Z",
+				"2019-01-19T00:00:00Z",
+				"2019-01-20T00:00:00Z",
+				"2019-01-21T00:00:00Z",
+			},
+		},
+		{
+			name: "monthly nth weekdays +1TU +2TU -1FR -2FR",
+			mw: MaintWin{
+				Freq:      "monthly",
+				Dtstart:   "2023-01-01T00:00:00.000Z",
+				Tzid:      "UTC",
+				Interval:  1,
+				Duration:  time.Hour,
+				Byweekday: []string{"+1TU", "+2TU", "-1FR", "-2FR"},
+				Count:     12,
+			},
+			wantISO: []string{
+				"2023-01-03T00:00:00Z",
+				"2023-01-10T00:00:00Z",
+				"2023-01-20T00:00:00Z",
+				"2023-01-27T00:00:00Z",
+				"2023-02-07T00:00:00Z",
+				"2023-02-14T00:00:00Z",
+				"2023-02-17T00:00:00Z",
+				"2023-02-24T00:00:00Z",
+				"2023-03-07T00:00:00Z",
+				"2023-03-14T00:00:00Z",
+				"2023-03-24T00:00:00Z",
+				"2023-03-31T00:00:00Z",
+			},
+		},
+		{
+			name: "weekly Saturday in Europe/Madrid from Friday 23:00 UTC",
+			mw: MaintWin{
+				Freq:      "weekly",
+				Dtstart:   "2023-01-06T23:00:00Z",
+				Tzid:      "Europe/Madrid",
+				Interval:  1,
+				Duration:  time.Hour,
+				Byweekday: []string{"SA"},
+				Count:     12,
+			},
+			wantISO: []string{
+				"2023-01-06T23:00:00Z",
+				"2023-01-13T23:00:00Z",
+				"2023-01-20T23:00:00Z",
+				"2023-01-27T23:00:00Z",
+				"2023-02-03T23:00:00Z",
+				"2023-02-10T23:00:00Z",
+				"2023-02-17T23:00:00Z",
+				"2023-02-24T23:00:00Z",
+				"2023-03-03T23:00:00Z",
+				"2023-03-10T23:00:00Z",
+				"2023-03-17T23:00:00Z",
+				"2023-03-24T23:00:00Z",
+			},
+		},
+		{
+			name: "weekly Saturday in UTC from Friday 23:00 UTC starts the following Saturday",
+			mw: MaintWin{
+				Freq:      "weekly",
+				Dtstart:   "2023-01-06T23:00:00Z",
+				Tzid:      "UTC",
+				Interval:  1,
+				Duration:  time.Hour,
+				Byweekday: []string{"SA"},
+				Count:     12,
+			},
+			wantISO: []string{
+				"2023-01-07T23:00:00Z",
+				"2023-01-14T23:00:00Z",
+				"2023-01-21T23:00:00Z",
+				"2023-01-28T23:00:00Z",
+				"2023-02-04T23:00:00Z",
+				"2023-02-11T23:00:00Z",
+				"2023-02-18T23:00:00Z",
+				"2023-02-25T23:00:00Z",
+				"2023-03-04T23:00:00Z",
+				"2023-03-11T23:00:00Z",
+				"2023-03-18T23:00:00Z",
+				"2023-03-25T23:00:00Z",
+			},
+		},
+		{
+			name: "yearly bymonth Feb and May",
+			mw: MaintWin{
+				Freq:     "yearly",
+				Dtstart:  "2019-12-19T00:00:00.000Z",
+				Tzid:     "UTC",
+				Interval: 1,
+				Duration: time.Hour,
+				Bymonth:  []int{2, 5},
+				Count:    14,
+			},
+			wantISO: []string{
+				"2020-02-19T00:00:00Z",
+				"2020-05-19T00:00:00Z",
+				"2021-02-19T00:00:00Z",
+				"2021-05-19T00:00:00Z",
+				"2022-02-19T00:00:00Z",
+				"2022-05-19T00:00:00Z",
+				"2023-02-19T00:00:00Z",
+				"2023-05-19T00:00:00Z",
+				"2024-02-19T00:00:00Z",
+				"2024-05-19T00:00:00Z",
+				"2025-02-19T00:00:00Z",
+				"2025-05-19T00:00:00Z",
+				"2026-02-19T00:00:00Z",
+				"2026-05-19T00:00:00Z",
+			},
+		},
+		{
+			name: "monthly bymonthday 1 and 15",
+			mw: MaintWin{
+				Freq:       "monthly",
+				Dtstart:    "2019-12-19T00:00:00.000Z",
+				Tzid:       "UTC",
+				Interval:   1,
+				Duration:   time.Hour,
+				Bymonthday: []int{1, 15},
+				Count:      14,
+			},
+			wantISO: []string{
+				"2020-01-01T00:00:00Z",
+				"2020-01-15T00:00:00Z",
+				"2020-02-01T00:00:00Z",
+				"2020-02-15T00:00:00Z",
+				"2020-03-01T00:00:00Z",
+				"2020-03-15T00:00:00Z",
+				"2020-04-01T00:00:00Z",
+				"2020-04-15T00:00:00Z",
+				"2020-05-01T00:00:00Z",
+				"2020-05-15T00:00:00Z",
+				"2020-06-01T00:00:00Z",
+				"2020-06-15T00:00:00Z",
+				"2020-07-01T00:00:00Z",
+				"2020-07-15T00:00:00Z",
+			},
+		},
+		{
+			name: "yearly bymonth and bymonthday",
+			mw: MaintWin{
+				Freq:       "yearly",
+				Dtstart:    "2019-12-19T00:00:00.000Z",
+				Tzid:       "UTC",
+				Interval:   1,
+				Duration:   time.Hour,
+				Bymonth:    []int{2, 5},
+				Bymonthday: []int{8},
+				Count:      14,
+			},
+			wantISO: []string{
+				"2020-02-08T00:00:00Z",
+				"2020-05-08T00:00:00Z",
+				"2021-02-08T00:00:00Z",
+				"2021-05-08T00:00:00Z",
+				"2022-02-08T00:00:00Z",
+				"2022-05-08T00:00:00Z",
+				"2023-02-08T00:00:00Z",
+				"2023-05-08T00:00:00Z",
+				"2024-02-08T00:00:00Z",
+				"2024-05-08T00:00:00Z",
+				"2025-02-08T00:00:00Z",
+				"2025-05-08T00:00:00Z",
+				"2026-02-08T00:00:00Z",
+				"2026-05-08T00:00:00Z",
+			},
+		},
+		{
+			name: "Kibana UI daily with byweekday WE",
+			mw: MaintWin{
+				Freq:      "daily",
+				Dtstart:   "2023-03-22T00:00:00.000Z",
+				Tzid:      "UTC",
+				Interval:  1,
+				Duration:  48 * time.Hour,
+				Byweekday: []string{"WE"},
+				Count:     4,
+			},
+			wantISO: []string{
+				"2023-03-22T00:00:00Z",
+				"2023-03-29T00:00:00Z",
+				"2023-04-05T00:00:00Z",
+				"2023-04-12T00:00:00Z",
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			r, err := c.mw.Parse(false)
+			require.NoError(t, err, "Parse should succeed for Kibana-shaped rule")
+			got := r.All()
+			require.Equal(t, len(c.wantISO), len(got), "occurrence count: got %v", isoTimes(got))
+			assert.Equal(t, c.wantISO, isoTimes(got), "occurrences should match Kibana @kbn/rrule")
+		})
+	}
+}
+
+func TestKibanaIsActiveMatchesOccurrences(t *testing.T) {
+	mw := MaintWin{
+		Freq:      "weekly",
+		Dtstart:   "2023-01-06T23:00:00Z",
+		Tzid:      "Europe/Madrid",
+		Interval:  1,
+		Duration:  time.Hour,
+		Byweekday: []string{"SA"},
+	}
+	r, err := mw.Parse(false)
+	require.NoError(t, err)
+	pmw := ParsedMaintWin{Rule: r, Duration: mw.Duration}
+
+	assert.True(t, pmw.IsActive(mustTime("2023-01-06T23:30:00Z")), "first Saturday local occurrence should be active")
+	assert.False(t, pmw.IsActive(mustTime("2023-01-07T23:30:00Z")), "Saturday UTC (Sunday Madrid) should not be active")
+	assert.True(t, pmw.IsActive(mustTime("2023-01-13T23:30:00Z")), "next Saturday Madrid should be active")
+}
+
+func isoTimes(ts []time.Time) []string {
+	out := make([]string, len(ts))
+	for i, t := range ts {
+		out[i] = t.UTC().Format(time.RFC3339)
+	}
+	return out
+}
+
+func mustTime(s string) time.Time {
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		panic(err)
+	}
+	return t
+}

--- a/heartbeat/monitors/maintwin/kibana_parity_test.go
+++ b/heartbeat/monitors/maintwin/kibana_parity_test.go
@@ -30,8 +30,8 @@ import (
 // uses to decide whether a maintenance window is running.
 func TestKibanaRRuleParity(t *testing.T) {
 	cases := []struct {
-		name     string
-		mw       MaintWin
+		name    string
+		mw      MaintWin
 		wantISO []string
 	}{
 		{
@@ -526,7 +526,7 @@ func TestKibanaRRuleParity(t *testing.T) {
 			r, err := c.mw.Parse()
 			require.NoError(t, err, "Parse should succeed for Kibana-shaped rule")
 			got := r.All()
-			require.Equal(t, len(c.wantISO), len(got), "occurrence count: got %v", isoTimes(got))
+			require.Len(t, got, len(c.wantISO), "occurrence count: got %v", isoTimes(got))
 			assert.Equal(t, c.wantISO, isoTimes(got), "occurrences should match Kibana @kbn/rrule")
 		})
 	}

--- a/heartbeat/monitors/maintwin/maintwin.go
+++ b/heartbeat/monitors/maintwin/maintwin.go
@@ -22,6 +22,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	_ "time/tzdata"
 
 	"github.com/teambition/rrule-go"
 )
@@ -53,6 +54,8 @@ func parseByweekday(wd string) (rrule.Weekday, error) {
 type MaintWin struct {
 	Freq       string        `config:"freq" validate:"required"`
 	Dtstart    string        `config:"dtstart" validate:"required"`
+	Tzid       string        `config:"tzid"`
+	Until      string        `config:"until"`
 	Interval   int           `config:"interval"`
 	Duration   time.Duration `config:"duration" validate:"required"`
 	Wkst       rrule.Weekday `config:"wkst"`
@@ -100,12 +103,30 @@ func (mw *MaintWin) Parse(validateDtStart bool) (r *rrule.RRule, err error) {
 		weekdays = append(weekdays, weekday)
 	}
 
-	dtstart = dtstart.UTC()
+	loc := time.UTC
+	if mw.Tzid != "" {
+		loc, err = time.LoadLocation(mw.Tzid)
+		if err != nil {
+			return nil, fmt.Errorf("invalid tzid: %q", mw.Tzid)
+		}
+	}
+	// Kibana stores dtstart as a UTC instant and tzid as the calendar for later occurrences.
+	dtstart = dtstart.In(loc)
+
+	var until time.Time
+	if mw.Until != "" {
+		until, err = time.Parse(time.RFC3339, mw.Until)
+		if err != nil {
+			return nil, fmt.Errorf("invalid until: %q", mw.Until)
+		}
+		until = until.In(loc)
+	}
 
 	r, err = rrule.NewRRule(rrule.ROption{
 		Freq:       freq,
 		Count:      mw.Count,
 		Dtstart:    dtstart,
+		Until:      until,
 		Interval:   mw.Interval,
 		Byweekday:  weekdays,
 		Byhour:     mw.Byhour,

--- a/heartbeat/monitors/maintwin/maintwin.go
+++ b/heartbeat/monitors/maintwin/maintwin.go
@@ -72,26 +72,19 @@ type MaintWin struct {
 	Byeaster   []int         `config:"byeaster"`
 }
 
-func (mw *MaintWin) Parse(validateDtStart bool) (r *rrule.RRule, err error) {
+// Parse converts a Kibana-shaped maintenance window into an rrule.
+// dtstart may be arbitrarily old: Kibana keeps the original start on recurring windows.
+func (mw *MaintWin) Parse() (r *rrule.RRule, err error) {
 
-	// validate the frequency, we don't support less than daily
+	// Kibana MW request schema allows yearly (0) through hourly (4).
 	freq, err := rrule.StrToFreq(strings.ToUpper(mw.Freq))
-	if err != nil || freq > rrule.DAILY {
-		return nil, fmt.Errorf("invalid frequency %s: only yearly, monthly, weekly, and daily are supported", mw.Freq)
+	if err != nil || freq > rrule.HOURLY {
+		return nil, fmt.Errorf("invalid frequency %s: only yearly, monthly, weekly, daily, and hourly are supported", mw.Freq)
 	}
 
 	dtstart, err := time.Parse(time.RFC3339, mw.Dtstart)
 	if err != nil {
 		return nil, err
-	}
-
-	// validate DTSTART and make sure it's not older than 2 years
-	if dtstart.Before(time.Now().AddDate(-2, 0, 0)) && validateDtStart {
-		return nil, fmt.Errorf(
-			"invalid dtstart: %s is more than 2 years in the past; "+
-				"to prevent excessive iterations, please use a more recent date",
-			dtstart.Format(time.RFC3339),
-		)
 	}
 
 	weekdays := make([]rrule.Weekday, 0, len(mw.Byweekday))
@@ -154,11 +147,13 @@ type ParsedMaintWin struct {
 	Duration time.Duration
 }
 
+// IsActive reports whether tOrig falls in [occurrence, occurrence+duration].
+// The end is inclusive to match Kibana alerting (`eventTimeMs <= event.lteMs`).
 func (pmw ParsedMaintWin) IsActive(tOrig time.Time) bool {
 	if pmw.Rule == nil {
 		return false
 	}
 	tOrig = tOrig.UTC()
 	window := pmw.Rule.Before(tOrig, true)
-	return !window.IsZero() && tOrig.Before(window.Add(pmw.Duration))
+	return !window.IsZero() && !tOrig.After(window.Add(pmw.Duration))
 }

--- a/heartbeat/monitors/maintwin/maintwin.go
+++ b/heartbeat/monitors/maintwin/maintwin.go
@@ -19,6 +19,7 @@ package maintwin
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -27,6 +28,26 @@ import (
 
 var weekdayLookup = map[string]rrule.Weekday{
 	"MO": rrule.MO, "TU": rrule.TU, "WE": rrule.WE, "TH": rrule.TH, "FR": rrule.FR, "SA": rrule.SA, "SU": rrule.SU,
+}
+
+// parseByweekday parses RRule BYDAY tokens such as "MO", "+2TU", or "-1FR".
+func parseByweekday(wd string) (rrule.Weekday, error) {
+	wd = strings.ToUpper(strings.TrimSpace(wd))
+	if len(wd) < 2 {
+		return rrule.Weekday{}, fmt.Errorf("invalid byweekday: %q", wd)
+	}
+	day, ok := weekdayLookup[wd[len(wd)-2:]]
+	if !ok {
+		return rrule.Weekday{}, fmt.Errorf("invalid byweekday: %q", wd)
+	}
+	if len(wd) == 2 {
+		return day, nil
+	}
+	n, err := strconv.Atoi(wd[:len(wd)-2])
+	if err != nil {
+		return rrule.Weekday{}, fmt.Errorf("invalid byweekday: %q", wd)
+	}
+	return day.Nth(n), nil
 }
 
 type MaintWin struct {
@@ -53,7 +74,7 @@ func (mw *MaintWin) Parse(validateDtStart bool) (r *rrule.RRule, err error) {
 	// validate the frequency, we don't support less than daily
 	freq, err := rrule.StrToFreq(strings.ToUpper(mw.Freq))
 	if err != nil || freq > rrule.DAILY {
-		return nil, fmt.Errorf("Invalid frequency %s: only yearly, monthly, weekly, and daily are supported", mw.Freq)
+		return nil, fmt.Errorf("invalid frequency %s: only yearly, monthly, weekly, and daily are supported", mw.Freq)
 	}
 
 	dtstart, err := time.Parse(time.RFC3339, mw.Dtstart)
@@ -64,18 +85,19 @@ func (mw *MaintWin) Parse(validateDtStart bool) (r *rrule.RRule, err error) {
 	// validate DTSTART and make sure it's not older than 2 years
 	if dtstart.Before(time.Now().AddDate(-2, 0, 0)) && validateDtStart {
 		return nil, fmt.Errorf(
-			"invalid dtstart: %s is more than 2 years in the past. "+
-				"To prevent excessive iterations, please use a more recent date.",
+			"invalid dtstart: %s is more than 2 years in the past; "+
+				"to prevent excessive iterations, please use a more recent date",
 			dtstart.Format(time.RFC3339),
 		)
 	}
 
-	// Convert the string weekdays to rrule.Weekday
-	weekdays := []rrule.Weekday{}
+	weekdays := make([]rrule.Weekday, 0, len(mw.Byweekday))
 	for _, wd := range mw.Byweekday {
-		if weekday, exists := weekdayLookup[wd]; exists {
-			weekdays = append(weekdays, weekday)
+		weekday, err := parseByweekday(wd)
+		if err != nil {
+			return nil, err
 		}
+		weekdays = append(weekdays, weekday)
 	}
 
 	dtstart = dtstart.UTC()

--- a/heartbeat/monitors/maintwin/maintwin.go
+++ b/heartbeat/monitors/maintwin/maintwin.go
@@ -120,6 +120,8 @@ func (mw *MaintWin) Parse(validateDtStart bool) (r *rrule.RRule, err error) {
 			return nil, fmt.Errorf("invalid until: %q", mw.Until)
 		}
 		until = until.In(loc)
+		// Kibana @kbn/rrule skips occurrences at or after until (current >= until).
+		until = until.Add(-time.Nanosecond)
 	}
 
 	r, err = rrule.NewRRule(rrule.ROption{

--- a/heartbeat/monitors/maintwin/maintwin_test.go
+++ b/heartbeat/monitors/maintwin/maintwin_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/teambition/rrule-go"
 )
 
 func TestMaintWin(t *testing.T) {
@@ -93,6 +94,51 @@ func TestMaintWin(t *testing.T) {
 			},
 			positiveMatches: []string{"2025-03-07T12:30:00Z"},
 			negativeMatches: []string{"2025-02-14T12:30:00Z", "2025-04-14T13:00:00Z"},
+		},
+
+		{
+			name: "Second Tuesday of every month via +2TU",
+			mw: MaintWin{
+				Freq:      "monthly",
+				Dtstart:   "2025-01-01T10:00:00Z",
+				Duration:  mustParseDuration("2h"),
+				Byweekday: []string{"+2TU"},
+			},
+			// 2026-08-11 and 2025-02-11 are 2nd Tuesdays; dtstart day-of-month alone would not match.
+			positiveMatches: []string{"2026-08-11T10:30:00Z", "2025-02-11T11:00:00Z"},
+			negativeMatches: []string{
+				"2026-08-04T10:30:00Z", // 1st Tuesday
+				"2026-08-18T10:30:00Z", // 3rd Tuesday
+				"2026-08-11T12:01:00Z", // after duration
+			},
+		},
+
+		{
+			name: "Last Friday of every month via -1FR",
+			mw: MaintWin{
+				Freq:      "monthly",
+				Dtstart:   "2025-01-01T12:00:00Z",
+				Duration:  mustParseDuration("2h"),
+				Byweekday: []string{"-1FR"},
+			},
+			positiveMatches: []string{"2025-02-28T12:30:00Z", "2025-08-29T13:00:00Z"},
+			negativeMatches: []string{
+				"2025-02-21T12:30:00Z", // 3rd Friday
+				"2025-08-22T12:30:00Z", // earlier Friday
+				"2025-02-28T14:01:00Z", // after duration
+			},
+		},
+
+		{
+			name: "First Monday via +1MO",
+			mw: MaintWin{
+				Freq:      "monthly",
+				Dtstart:   "2025-01-15T08:00:00Z",
+				Duration:  mustParseDuration("3h"),
+				Byweekday: []string{"+1MO"},
+			},
+			positiveMatches: []string{"2025-03-03T08:30:00Z", "2025-09-01T09:00:00Z"},
+			negativeMatches: []string{"2025-03-10T08:30:00Z", "2025-09-08T08:30:00Z"},
 		},
 
 		{
@@ -184,4 +230,49 @@ func mustParseDuration(s string) time.Duration {
 		panic(fmt.Sprintf("could not parse duration %s: %s", s, err))
 	}
 	return d
+}
+
+func TestParseByweekday(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   string
+		wantDay int
+		wantN   int
+	}{
+		{name: "bare Tuesday", input: "TU", wantDay: rrule.TU.Day(), wantN: 0},
+		{name: "lowercase bare", input: "fr", wantDay: rrule.FR.Day(), wantN: 0},
+		{name: "second Tuesday", input: "+2TU", wantDay: rrule.TU.Day(), wantN: 2},
+		{name: "last Friday", input: "-1FR", wantDay: rrule.FR.Day(), wantN: -1},
+		{name: "first Monday lowercase", input: "+1mo", wantDay: rrule.MO.Day(), wantN: 1},
+		{name: "third without plus", input: "3WE", wantDay: rrule.WE.Day(), wantN: 3},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := parseByweekday(c.input)
+			require.NoError(t, err, "parseByweekday(%q) should succeed", c.input)
+			assert.Equal(t, c.wantDay, got.Day(), "weekday day for %q", c.input)
+			assert.Equal(t, c.wantN, got.N(), "weekday N for %q", c.input)
+		})
+	}
+}
+
+func TestParseInvalidByweekday(t *testing.T) {
+	invalid := []string{"", "T", "XQ", "+MO", "++2TU", "2XX", "MO TU"}
+	for _, wd := range invalid {
+		t.Run(fmt.Sprintf("%q", wd), func(t *testing.T) {
+			_, err := parseByweekday(wd)
+			assert.Error(t, err, "parseByweekday(%q) should fail", wd)
+		})
+	}
+
+	mw := MaintWin{
+		Freq:      "monthly",
+		Dtstart:   "2025-01-01T10:00:00Z",
+		Duration:  mustParseDuration("1h"),
+		Byweekday: []string{"+2TU", "NOTADAY"},
+	}
+	_, err := mw.Parse(false)
+	require.Error(t, err, "Parse should reject invalid byweekday tokens")
+	assert.Contains(t, err.Error(), "invalid byweekday", "error should mention invalid byweekday")
 }

--- a/heartbeat/monitors/maintwin/maintwin_test.go
+++ b/heartbeat/monitors/maintwin/maintwin_test.go
@@ -55,8 +55,9 @@ func TestMaintWin(t *testing.T) {
 				Dtstart:  "2025-02-06T21:00:00Z",
 				Duration: mustParseDuration("2h"),
 			},
-			positiveMatches: []string{"2025-02-06T21:30:00Z", "2025-02-06T22:45:00Z"},
-			negativeMatches: []string{"2025-02-06T23:01:00Z", "2025-02-07T00:00:00Z"},
+			// Kibana alerting uses inclusive lte (start+duration).
+			positiveMatches: []string{"2025-02-06T21:30:00Z", "2025-02-06T22:45:00Z", "2025-02-06T23:00:00Z"},
+			negativeMatches: []string{"2025-02-06T23:00:01Z", "2025-02-07T00:00:00Z"},
 		},
 
 		{
@@ -243,11 +244,37 @@ func TestMaintWin(t *testing.T) {
 			positiveMatches: []string{"2025-02-01T10:30:00Z", "2025-02-02T10:30:00Z"},
 			negativeMatches: []string{"2025-02-03T10:00:00Z", "2025-02-03T10:30:00Z"},
 		},
+
+		{
+			name: "Hourly interval 1 as Kibana MW UI convertToRRule emits",
+			mw: MaintWin{
+				Freq:     "hourly",
+				Dtstart:  "2025-02-01T10:00:00Z",
+				Tzid:     "UTC",
+				Interval: 1,
+				Duration: mustParseDuration("30m"),
+			},
+			positiveMatches: []string{"2025-02-01T10:00:00Z", "2025-02-01T10:15:00Z", "2025-02-01T10:30:00Z", "2025-02-01T11:00:00Z"},
+			negativeMatches: []string{"2025-02-01T10:30:01Z", "2025-02-01T11:30:01Z"},
+		},
+
+		{
+			name: "Hourly interval 3 as Kibana custom hourly schedule",
+			mw: MaintWin{
+				Freq:     "hourly",
+				Dtstart:  "2025-02-01T10:00:00Z",
+				Tzid:     "UTC",
+				Interval: 3,
+				Duration: mustParseDuration("1h"),
+			},
+			positiveMatches: []string{"2025-02-01T10:30:00Z", "2025-02-01T11:00:00Z", "2025-02-01T13:00:00Z"},
+			negativeMatches: []string{"2025-02-01T11:00:01Z", "2025-02-01T11:30:00Z", "2025-02-01T12:30:00Z"},
+		},
 	}
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			r, err := c.mw.Parse(false)
+			r, err := c.mw.Parse()
 			require.NoError(t, err)
 			pmw := ParsedMaintWin{Rule: r, Duration: c.mw.Duration}
 			for _, m := range c.positiveMatches {
@@ -316,7 +343,7 @@ func TestParseInvalidByweekday(t *testing.T) {
 		Duration:  mustParseDuration("1h"),
 		Byweekday: []string{"+2TU", "NOTADAY"},
 	}
-	_, err := mw.Parse(false)
+	_, err := mw.Parse()
 	require.Error(t, err, "Parse should reject invalid byweekday tokens")
 	assert.Contains(t, err.Error(), "invalid byweekday", "error should mention invalid byweekday")
 }
@@ -327,7 +354,7 @@ func TestParseInvalidTzidAndUntil(t *testing.T) {
 		Dtstart:  "2025-02-01T10:00:00Z",
 		Tzid:     "Not/AZone",
 		Duration: mustParseDuration("1h"),
-	}).Parse(false)
+	}).Parse()
 	require.Error(t, err, "Parse should reject unknown tzid")
 	assert.Contains(t, err.Error(), "invalid tzid", "error should mention invalid tzid")
 
@@ -336,7 +363,28 @@ func TestParseInvalidTzidAndUntil(t *testing.T) {
 		Dtstart:  "2025-02-01T10:00:00Z",
 		Until:    "not-a-date",
 		Duration: mustParseDuration("1h"),
-	}).Parse(false)
+	}).Parse()
 	require.Error(t, err, "Parse should reject invalid until")
 	assert.Contains(t, err.Error(), "invalid until", "error should mention invalid until")
+}
+
+func TestParseRejectsMinutely(t *testing.T) {
+	_, err := (&MaintWin{
+		Freq:     "minutely",
+		Dtstart:  "2025-02-01T10:00:00Z",
+		Duration: mustParseDuration("1m"),
+	}).Parse()
+	require.Error(t, err, "Parse should reject minutely; Kibana MW schema only allows yearly through hourly")
+	assert.Contains(t, err.Error(), "invalid frequency", "error should mention invalid frequency")
+}
+
+func TestParseAcceptsKibanaDtstartOlderThanTwoYears(t *testing.T) {
+	_, err := (&MaintWin{
+		Freq:      "weekly",
+		Dtstart:   "2023-03-22T00:00:00Z",
+		Tzid:      "UTC",
+		Duration:  mustParseDuration("1h"),
+		Byweekday: []string{"WE"},
+	}).Parse()
+	require.NoError(t, err, "Kibana keeps the original dtstart on recurring windows; Parse must not reject dates older than 2 years")
 }

--- a/heartbeat/monitors/maintwin/maintwin_test.go
+++ b/heartbeat/monitors/maintwin/maintwin_test.go
@@ -233,15 +233,15 @@ func TestMaintWin(t *testing.T) {
 		},
 
 		{
-			name: "Until stops recurrence after the bound",
+			name: "Until is exclusive of the bound like Kibana",
 			mw: MaintWin{
 				Freq:     "daily",
 				Dtstart:  "2025-02-01T10:00:00Z",
-				Until:    "2025-02-03T00:00:00Z",
-				Duration: mustParseDuration("2h"),
+				Until:    "2025-02-03T10:00:00Z",
+				Duration: mustParseDuration("1h"),
 			},
 			positiveMatches: []string{"2025-02-01T10:30:00Z", "2025-02-02T10:30:00Z"},
-			negativeMatches: []string{"2025-02-03T10:30:00Z", "2025-02-04T10:30:00Z"},
+			negativeMatches: []string{"2025-02-03T10:00:00Z", "2025-02-03T10:30:00Z"},
 		},
 	}
 

--- a/heartbeat/monitors/maintwin/maintwin_test.go
+++ b/heartbeat/monitors/maintwin/maintwin_test.go
@@ -199,6 +199,50 @@ func TestMaintWin(t *testing.T) {
 			positiveMatches: []string{"2025-02-08T08:30:00Z"},
 			negativeMatches: []string{"2025-02-07T09:30:00Z"},
 		},
+
+		{
+			name: "Daily 09:00 Europe/Berlin keeps local time across DST",
+			mw: MaintWin{
+				Freq:     "daily",
+				Dtstart:  "2025-03-28T08:00:00Z", // 09:00 CET
+				Tzid:     "Europe/Berlin",
+				Duration: mustParseDuration("1h"),
+			},
+			positiveMatches: []string{
+				"2025-03-28T08:30:00Z", // 09:30 CET
+				"2025-03-31T07:30:00Z", // 09:30 CEST after spring-forward
+			},
+			negativeMatches: []string{
+				"2025-03-31T08:30:00Z", // 10:30 CEST; UTC-only recurrence would still match
+			},
+		},
+
+		{
+			name: "Weekly Monday evening America/Los_Angeles via byweekday",
+			mw: MaintWin{
+				Freq:      "weekly",
+				Dtstart:   "2025-02-04T01:00:00Z", // Monday 17:00 PST
+				Tzid:      "America/Los_Angeles",
+				Duration:  mustParseDuration("2h"),
+				Byweekday: []string{"MO"},
+			},
+			positiveMatches: []string{"2025-02-11T01:30:00Z"}, // next Monday 17:30 PST
+			negativeMatches: []string{
+				"2025-02-10T01:30:00Z", // Monday 01:30 UTC = Sunday evening PST
+			},
+		},
+
+		{
+			name: "Until stops recurrence after the bound",
+			mw: MaintWin{
+				Freq:     "daily",
+				Dtstart:  "2025-02-01T10:00:00Z",
+				Until:    "2025-02-03T00:00:00Z",
+				Duration: mustParseDuration("2h"),
+			},
+			positiveMatches: []string{"2025-02-01T10:30:00Z", "2025-02-02T10:30:00Z"},
+			negativeMatches: []string{"2025-02-03T10:30:00Z", "2025-02-04T10:30:00Z"},
+		},
 	}
 
 	for _, c := range cases {
@@ -275,4 +319,24 @@ func TestParseInvalidByweekday(t *testing.T) {
 	_, err := mw.Parse(false)
 	require.Error(t, err, "Parse should reject invalid byweekday tokens")
 	assert.Contains(t, err.Error(), "invalid byweekday", "error should mention invalid byweekday")
+}
+
+func TestParseInvalidTzidAndUntil(t *testing.T) {
+	_, err := (&MaintWin{
+		Freq:     "daily",
+		Dtstart:  "2025-02-01T10:00:00Z",
+		Tzid:     "Not/AZone",
+		Duration: mustParseDuration("1h"),
+	}).Parse(false)
+	require.Error(t, err, "Parse should reject unknown tzid")
+	assert.Contains(t, err.Error(), "invalid tzid", "error should mention invalid tzid")
+
+	_, err = (&MaintWin{
+		Freq:     "daily",
+		Dtstart:  "2025-02-01T10:00:00Z",
+		Until:    "not-a-date",
+		Duration: mustParseDuration("1h"),
+	}).Parse(false)
+	require.Error(t, err, "Parse should reject invalid until")
+	assert.Contains(t, err.Error(), "invalid until", "error should mention invalid until")
 }

--- a/heartbeat/monitors/stdfields/stdfields.go
+++ b/heartbeat/monitors/stdfields/stdfields.go
@@ -112,7 +112,7 @@ func ConfigToStdMonitorFields(conf *config.C) (StdMonitorFields, error) {
 	}
 
 	for _, mw := range sFields.MaintenanceWindows {
-		parsed, err := mw.Parse(true)
+		parsed, err := mw.Parse()
 		if err != nil {
 			return StdMonitorFields{}, fmt.Errorf("could not parse maintenance window for monitor (id:%s name:%s): %w", sFields.ID, sFields.Name, err)
 		}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

Heartbeat maintenance-window parsing dropped Kibana RRule fields that the agent needs to match Kibana MW status:

- `byweekday` nth-weekday tokens (`+2TU`, `-1FR`) were silently ignored
- `tzid` was ignored, so recurrence ran in UTC instead of the user's timezone
- `until` was ignored, so bounded windows never ended; Kibana also treats `until` as exclusive (`current >= until`)

Parse optional `±N` prefixes with `rrule.Weekday.Nth`, expand the UTC `dtstart` instant in `tzid`, map `until` into `rrule.ROption` as exclusive, and reject invalid tokens instead of ignoring them.

Parity tests compare Heartbeat occurrences to Kibana `@kbn/rrule` snapshots (nth-weekdays, Madrid/UTC Saturday boundary, bymonth, bymonthday, until).

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

None for valid configs. Invalid `byweekday`, `tzid`, or `until` values that were previously ignored now cause maintenance-window parse failures (fail loud instead of silent no-op).

## How to test this PR locally

```bash
go test -v -race ./heartbeat/monitors/maintwin/
```

## Related issues

- Closes #52571

## Use cases

- Monthly windows configured as “2nd Tuesday” / “last Friday” (`byweekday: ["+2TU"]`, `["-1FR"]`) now suppress checks
- Recurring windows with a non-UTC `tzid` keep local wall-clock time across DST
- Windows with `until` stop recurring after the bound (exclusive, matching Kibana)
