### PR TITLE
add string type to event.created conversion

### DIFF
--- a/libbeat/otel/otelconsumer/otelconsumer.go
+++ b/libbeat/otel/otelconsumer/otelconsumer.go
@@ -224,6 +224,12 @@ func fillLogRecordFromEvent(logRecord plog.LogRecord, event publisher.Event, bea
 			observedTimestamp = pcommon.NewTimestampFromTime(created)
 		case common.Time:
 			observedTimestamp = pcommon.NewTimestampFromTime(time.Time(created))
+		case string:
+			t, err := time.Parse(time.RFC3339, created)
+			if err != nil {
+				t = time.Now()
+			}
+			observedTimestamp = pcommon.NewTimestampFromTime(t)
 		case nil:
 			// not set
 		default:

--- a/libbeat/otel/otelconsumer/otelconsumer.go
+++ b/libbeat/otel/otelconsumer/otelconsumer.go
@@ -225,7 +225,7 @@ func fillLogRecordFromEvent(logRecord plog.LogRecord, event publisher.Event, bea
 		case common.Time:
 			observedTimestamp = pcommon.NewTimestampFromTime(time.Time(created))
 		case string:
-			t, err := time.Parse(time.RFC3339, created)
+			t, err := time.Parse(time.RFC3339Nano, created)
 			if err != nil {
 				t = time.Now()
 			}

--- a/libbeat/otel/otelconsumer/otelconsumer_test.go
+++ b/libbeat/otel/otelconsumer/otelconsumer_test.go
@@ -558,6 +558,18 @@ func TestFillLogRecordFromEventCreated(t *testing.T) {
 		assert.Equal(t, want.UTC(), logRecord.ObservedTimestamp().AsTime().UTC())
 	})
 
+	t.Run("valid RFC3339Nano string parses correctly", func(t *testing.T) {
+		want, err := time.Parse(time.RFC3339Nano, "2022-11-22T19:16:32.440123456Z")
+		require.NoError(t, err)
+
+		event := publisher.Event{Content: beat.Event{
+			Fields: mapstr.M{"event": mapstr.M{"created": "2022-11-22T19:16:32.440123456Z"}},
+		}}
+		logRecord := plog.NewLogRecord()
+		require.NoError(t, fillLogRecordFromEvent(logRecord, event, beatInfo, logger, false))
+		assert.Equal(t, want.UTC(), logRecord.ObservedTimestamp().AsTime().UTC())
+	})
+
 	t.Run("invalid string falls back to current time", func(t *testing.T) {
 		before := time.Now()
 		event := publisher.Event{Content: beat.Event{

--- a/libbeat/otel/otelconsumer/otelconsumer_test.go
+++ b/libbeat/otel/otelconsumer/otelconsumer_test.go
@@ -43,6 +43,7 @@ import (
 	"go.opentelemetry.io/collector/receiver/receivertest"
 
 	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/otel/otelctx"
 	"github.com/elastic/beats/v7/libbeat/otel/otelmap"
 	"github.com/elastic/beats/v7/libbeat/outputs"
@@ -520,6 +521,56 @@ func TestFillLogRecordFromEventDoesNotError(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestFillLogRecordFromEventCreated(t *testing.T) {
+	logger := logp.NewNopLogger()
+	beatInfo := beat.Info{}
+	want := time.Date(2022, 11, 22, 19, 16, 32, 0, time.UTC)
+
+	t.Run("time.Time sets observed timestamp", func(t *testing.T) {
+		event := publisher.Event{Content: beat.Event{
+			Fields: mapstr.M{"event": mapstr.M{"created": want}},
+		}}
+		logRecord := plog.NewLogRecord()
+		require.NoError(t, fillLogRecordFromEvent(logRecord, event, beatInfo, logger, false))
+		assert.Equal(t, want.UTC(), logRecord.ObservedTimestamp().AsTime().UTC())
+	})
+
+	t.Run("common.Time sets observed timestamp", func(t *testing.T) {
+		event := publisher.Event{Content: beat.Event{
+			Fields: mapstr.M{"event": mapstr.M{"created": common.Time(want)}},
+		}}
+		logRecord := plog.NewLogRecord()
+		require.NoError(t, fillLogRecordFromEvent(logRecord, event, beatInfo, logger, false))
+		assert.Equal(t, want.UTC(), logRecord.ObservedTimestamp().AsTime().UTC())
+	})
+
+	t.Run("valid RFC3339 string parses correctly", func(t *testing.T) {
+		want, err := time.Parse(time.RFC3339, "2022-11-22T19:16:32.440Z")
+		require.NoError(t, err)
+
+		event := publisher.Event{Content: beat.Event{
+			Fields: mapstr.M{"event": mapstr.M{"created": "2022-11-22T19:16:32.440Z"}},
+		}}
+		logRecord := plog.NewLogRecord()
+		require.NoError(t, fillLogRecordFromEvent(logRecord, event, beatInfo, logger, false))
+		assert.Equal(t, want.UTC(), logRecord.ObservedTimestamp().AsTime().UTC())
+	})
+
+	t.Run("invalid string falls back to current time", func(t *testing.T) {
+		before := time.Now()
+		event := publisher.Event{Content: beat.Event{
+			Fields: mapstr.M{"event": mapstr.M{"created": "not-a-timestamp"}},
+		}}
+		logRecord := plog.NewLogRecord()
+		require.NoError(t, fillLogRecordFromEvent(logRecord, event, beatInfo, logger, false))
+		after := time.Now()
+
+		observed := logRecord.ObservedTimestamp().AsTime()
+		assert.False(t, observed.Before(before), "observed timestamp should not be before test start")
+		assert.False(t, observed.After(after), "observed timestamp should not be after test end")
+	})
 }
 
 // TestElasticsearchOutputVsExporterSerialization verifies that Beat events are


### PR DESCRIPTION
## Proposed commit message

Handle event.created as a string when building OTel log records.

WHAT: In fillLogRecordFromEvent, the switch on eventMap["created"] already handled time.Time and common.Time. This adds a string case that attempts to parse the value using time.RFC3339. If parsing fails, it falls back to time.Now() so that the observed timestamp is always set to a reasonable value rather than left as the log record timestamp.

WHY: event.created can arrive as a string (e.g. "2022-11-22T19:16:32.440Z"). Without this case the field was silently dropped and the code fell through to the default warning branch, causing the observed timestamp to be wrong.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

None. Previously a string event.created triggered a warning log.

## How to test this PR locally

```
go test ./libbeat/otel/otelconsumer/ -run TestFillLogRecordFromEventCreated -v
```

## Related issues

- Closes #52602

## Use cases


## Screenshots


## Logs


