### PR TITLE
Fix README grammar typos in Filebeat and Kubernetes apiserver docs

### DIFF
--- a/filebeat/README.md
+++ b/filebeat/README.md
@@ -1,6 +1,6 @@
 # Filebeat
 
-Filebeat is an open source file harvester, mostly used to fetch logs files and feed them into logstash.
+Filebeat is an open source file harvester, mostly used to fetch log files and feed them into Logstash.
 Together with the libbeat lumberjack output is a replacement for [logstash-forwarder](https://github.com/elastic/logstash-forwarder).
 
 To learn more about Filebeat, check out https://www.elastic.co/beats/filebeat.

--- a/metricbeat/module/kubernetes/apiserver/README.md
+++ b/metricbeat/module/kubernetes/apiserver/README.md
@@ -10,7 +10,7 @@
 - June 2019, `v1.14.3`
 
     `apiserver_request_total` will be used in spite of `apiserver_request_count`.
-    An _ugly trick_ has been put in place that will read both values, using `apiserver_request_total` if exists. The deprecated value is being configured under the bogus name `request.beforev14.count` and renamed to `request.count` if the newer does not exists.
+    An _ugly trick_ has been put in place that will read both values, using `apiserver_request_total` if it exists. The deprecated value is being configured under the bogus name `request.beforev14.count` and renamed to `request.count` if the newer one does not exist.
 
 ## Resources
 


### PR DESCRIPTION
## Summary
- Fix Filebeat README wording (`logs files` -> `log files`) and Logstash casing
- Fix grammar in the Kubernetes apiserver module README (`if exists` / `does not exists`)

Fixes #52534

## Test plan
- [ ] Confirm the two README lines match the corrected wording
- [ ] Docs-only change; no runtime behavior impact