### PR TITLE
Fix Kerberos and ILM documentation text errors

### DIFF
--- a/docs/reference/auditbeat/auditbeat-reference-yml.md
+++ b/docs/reference/auditbeat/auditbeat-reference-yml.md
@@ -1016,7 +1016,7 @@ output.elasticsearch:
   # Path to the Kerberos configuration.
   #kerberos.config_path: /etc/krb5.conf
 
-  # The service name. Service principal name is contructed from
+  # The service name. Service principal name is constructed from
   # service_name/hostname@realm.
   #kerberos.service_name: kafka
 

--- a/docs/reference/auditbeat/configuration-kerberos.md
+++ b/docs/reference/auditbeat/configuration-kerberos.md
@@ -32,7 +32,7 @@ output.elasticsearch.kerberos.config_path: "/etc/krb5.conf"
 output.elasticsearch.kerberos.realm: "ELASTIC.CO"
 ```
 
-The service principal name for the Elasticsearch instance is contructed from these options. Based on this configuration it is going to be `HTTP/my-elasticsearch.elastic.co@ELASTIC.CO`.
+The service principal name for the Elasticsearch instance is constructed from these options. Based on this configuration it is going to be `HTTP/my-elasticsearch.elastic.co@ELASTIC.CO`.
 
 
 ## Configuration options [_configuration_options_9]
@@ -42,7 +42,7 @@ You can specify the following options in the `kerberos` section of the `auditbea
 
 ### `enabled` [_enabled_8]
 
-The `enabled` setting can be used to enable the kerberos configuration by setting it to `false`. The default value is `true`.
+The `enabled` setting can be used to enable the kerberos configuration by setting it to `true`. The default value is `true`.
 
 ::::{note}
 Kerberos settings are disabled if either `enabled` is set to `false` or the `kerberos` section is missing.

--- a/docs/reference/auditbeat/ilm.md
+++ b/docs/reference/auditbeat/ilm.md
@@ -10,9 +10,9 @@ applies_to:
 # Configure index lifecycle management [ilm]
 
 
-Use the [index lifecycle management](docs-content://manage-data/lifecycle/index-lifecycle-management/tutorial-automate-rollover.md) (ILM) feature in {{es}} to manage your Auditbeat their backing indices of your data streams as they age. Auditbeat loads the default policy automatically and applies it to any data streams created by Auditbeat.
+Use the [index lifecycle management](docs-content://manage-data/lifecycle/index-lifecycle-management/tutorial-automate-rollover.md) (ILM) feature in {{es}} to manage the backing indices of your Auditbeat data streams as they age. Auditbeat loads the default policy automatically and applies it to any data streams created by Auditbeat.
 
-You can view and edit the policy in the **Index lifecycle policies** UI in {{kib}}. For more information about working with the UI, see [Index lifecyle policies](docs-content://manage-data/lifecycle/index-lifecycle-management.md).
+You can view and edit the policy in the **Index lifecycle policies** UI in {{kib}}. For more information about working with the UI, see [Index lifecycle policies](docs-content://manage-data/lifecycle/index-lifecycle-management.md).
 
 Example configuration:
 

--- a/docs/reference/filebeat/configuration-kerberos.md
+++ b/docs/reference/filebeat/configuration-kerberos.md
@@ -32,7 +32,7 @@ output.elasticsearch.kerberos.config_path: "/etc/krb5.conf"
 output.elasticsearch.kerberos.realm: "ELASTIC.CO"
 ```
 
-The service principal name for the Elasticsearch instance is contructed from these options. Based on this configuration it is going to be `HTTP/my-elasticsearch.elastic.co@ELASTIC.CO`.
+The service principal name for the Elasticsearch instance is constructed from these options. Based on this configuration it is going to be `HTTP/my-elasticsearch.elastic.co@ELASTIC.CO`.
 
 
 ## Configuration options [_configuration_options_32]
@@ -42,7 +42,7 @@ You can specify the following options in the `kerberos` section of the `filebeat
 
 ### `enabled` [_enabled_37]
 
-The `enabled` setting can be used to enable the kerberos configuration by setting it to `false`. The default value is `true`.
+The `enabled` setting can be used to enable the kerberos configuration by setting it to `true`. The default value is `true`.
 
 ::::{note}
 Kerberos settings are disabled if either `enabled` is set to `false` or the `kerberos` section is missing.

--- a/docs/reference/filebeat/filebeat-reference-yml.md
+++ b/docs/reference/filebeat/filebeat-reference-yml.md
@@ -2217,7 +2217,7 @@ output.elasticsearch:
   # Path to the Kerberos configuration.
   #kerberos.config_path: /etc/krb5.conf
 
-  # The service name. Service principal name is contructed from
+  # The service name. Service principal name is constructed from
   # service_name/hostname@realm.
   #kerberos.service_name: kafka
 

--- a/docs/reference/filebeat/ilm.md
+++ b/docs/reference/filebeat/ilm.md
@@ -10,9 +10,9 @@ applies_to:
 # Configure index lifecycle management [ilm]
 
 
-Use the [index lifecycle management](docs-content://manage-data/lifecycle/index-lifecycle-management/tutorial-automate-rollover.md) (ILM) feature in {{es}} to manage your Filebeat their backing indices of your data streams as they age. Filebeat loads the default policy automatically and applies it to any data streams created by Filebeat.
+Use the [index lifecycle management](docs-content://manage-data/lifecycle/index-lifecycle-management/tutorial-automate-rollover.md) (ILM) feature in {{es}} to manage the backing indices of your Filebeat data streams as they age. Filebeat loads the default policy automatically and applies it to any data streams created by Filebeat.
 
-You can view and edit the policy in the **Index lifecycle policies** UI in {{kib}}. For more information about working with the UI, see [Index lifecyle policies](docs-content://manage-data/lifecycle/index-lifecycle-management.md).
+You can view and edit the policy in the **Index lifecycle policies** UI in {{kib}}. For more information about working with the UI, see [Index lifecycle policies](docs-content://manage-data/lifecycle/index-lifecycle-management.md).
 
 Example configuration:
 

--- a/docs/reference/heartbeat/configuration-kerberos.md
+++ b/docs/reference/heartbeat/configuration-kerberos.md
@@ -32,7 +32,7 @@ output.elasticsearch.kerberos.config_path: "/etc/krb5.conf"
 output.elasticsearch.kerberos.realm: "ELASTIC.CO"
 ```
 
-The service principal name for the Elasticsearch instance is contructed from these options. Based on this configuration it is going to be `HTTP/my-elasticsearch.elastic.co@ELASTIC.CO`.
+The service principal name for the Elasticsearch instance is constructed from these options. Based on this configuration it is going to be `HTTP/my-elasticsearch.elastic.co@ELASTIC.CO`.
 
 
 ## Configuration options [_configuration_options_9]
@@ -42,7 +42,7 @@ You can specify the following options in the `kerberos` section of the `heartbea
 
 ### `enabled` [_enabled_8]
 
-The `enabled` setting can be used to enable the kerberos configuration by setting it to `false`. The default value is `true`.
+The `enabled` setting can be used to enable the kerberos configuration by setting it to `true`. The default value is `true`.
 
 ::::{note}
 Kerberos settings are disabled if either `enabled` is set to `false` or the `kerberos` section is missing.

--- a/docs/reference/heartbeat/heartbeat-reference-yml.md
+++ b/docs/reference/heartbeat/heartbeat-reference-yml.md
@@ -1103,7 +1103,7 @@ output.elasticsearch:
   # Path to the Kerberos configuration.
   #kerberos.config_path: /etc/krb5.conf
 
-  # The service name. Service principal name is contructed from
+  # The service name. Service principal name is constructed from
   # service_name/hostname@realm.
   #kerberos.service_name: kafka
 

--- a/docs/reference/heartbeat/ilm.md
+++ b/docs/reference/heartbeat/ilm.md
@@ -10,9 +10,9 @@ applies_to:
 # Configure index lifecycle management [ilm]
 
 
-Use the [index lifecycle management](docs-content://manage-data/lifecycle/index-lifecycle-management/tutorial-automate-rollover.md) (ILM) feature in {{es}} to manage your Heartbeat their backing indices of your data streams as they age. Heartbeat loads the default policy automatically and applies it to any data streams created by Heartbeat.
+Use the [index lifecycle management](docs-content://manage-data/lifecycle/index-lifecycle-management/tutorial-automate-rollover.md) (ILM) feature in {{es}} to manage the backing indices of your Heartbeat data streams as they age. Heartbeat loads the default policy automatically and applies it to any data streams created by Heartbeat.
 
-You can view and edit the policy in the **Index lifecycle policies** UI in {{kib}}. For more information about working with the UI, see [Index lifecyle policies](docs-content://manage-data/lifecycle/index-lifecycle-management.md).
+You can view and edit the policy in the **Index lifecycle policies** UI in {{kib}}. For more information about working with the UI, see [Index lifecycle policies](docs-content://manage-data/lifecycle/index-lifecycle-management.md).
 
 Example configuration:
 

--- a/docs/reference/metricbeat/configuration-kerberos.md
+++ b/docs/reference/metricbeat/configuration-kerberos.md
@@ -32,7 +32,7 @@ output.elasticsearch.kerberos.config_path: "/etc/krb5.conf"
 output.elasticsearch.kerberos.realm: "ELASTIC.CO"
 ```
 
-The service principal name for the Elasticsearch instance is contructed from these options. Based on this configuration it is going to be `HTTP/my-elasticsearch.elastic.co@ELASTIC.CO`.
+The service principal name for the Elasticsearch instance is constructed from these options. Based on this configuration it is going to be `HTTP/my-elasticsearch.elastic.co@ELASTIC.CO`.
 
 
 ## Configuration options [_configuration_options_9]
@@ -42,7 +42,7 @@ You can specify the following options in the `kerberos` section of the `metricbe
 
 ### `enabled` [_enabled_9]
 
-The `enabled` setting can be used to enable the kerberos configuration by setting it to `false`. The default value is `true`.
+The `enabled` setting can be used to enable the kerberos configuration by setting it to `true`. The default value is `true`.
 
 ::::{note}
 Kerberos settings are disabled if either `enabled` is set to `false` or the `kerberos` section is missing.

--- a/docs/reference/metricbeat/ilm.md
+++ b/docs/reference/metricbeat/ilm.md
@@ -10,9 +10,9 @@ applies_to:
 # Configure index lifecycle management [ilm]
 
 
-Use the [index lifecycle management](docs-content://manage-data/lifecycle/index-lifecycle-management/tutorial-automate-rollover.md) (ILM) feature in {{es}} to manage your Metricbeat their backing indices of your data streams as they age. Metricbeat loads the default policy automatically and applies it to any data streams created by Metricbeat.
+Use the [index lifecycle management](docs-content://manage-data/lifecycle/index-lifecycle-management/tutorial-automate-rollover.md) (ILM) feature in {{es}} to manage the backing indices of your Metricbeat data streams as they age. Metricbeat loads the default policy automatically and applies it to any data streams created by Metricbeat.
 
-You can view and edit the policy in the **Index lifecycle policies** UI in {{kib}}. For more information about working with the UI, see [Index lifecyle policies](docs-content://manage-data/lifecycle/index-lifecycle-management.md).
+You can view and edit the policy in the **Index lifecycle policies** UI in {{kib}}. For more information about working with the UI, see [Index lifecycle policies](docs-content://manage-data/lifecycle/index-lifecycle-management.md).
 
 Example configuration:
 

--- a/docs/reference/metricbeat/metricbeat-reference-yml.md
+++ b/docs/reference/metricbeat/metricbeat-reference-yml.md
@@ -1964,7 +1964,7 @@ output.elasticsearch:
   # Path to the Kerberos configuration.
   #kerberos.config_path: /etc/krb5.conf
 
-  # The service name. Service principal name is contructed from
+  # The service name. Service principal name is constructed from
   # service_name/hostname@realm.
   #kerberos.service_name: kafka
 

--- a/docs/reference/packetbeat/configuration-kerberos.md
+++ b/docs/reference/packetbeat/configuration-kerberos.md
@@ -32,7 +32,7 @@ output.elasticsearch.kerberos.config_path: "/etc/krb5.conf"
 output.elasticsearch.kerberos.realm: "ELASTIC.CO"
 ```
 
-The service principal name for the Elasticsearch instance is contructed from these options. Based on this configuration it is going to be `HTTP/my-elasticsearch.elastic.co@ELASTIC.CO`.
+The service principal name for the Elasticsearch instance is constructed from these options. Based on this configuration it is going to be `HTTP/my-elasticsearch.elastic.co@ELASTIC.CO`.
 
 
 ## Configuration options [_configuration_options_23]
@@ -42,7 +42,7 @@ You can specify the following options in the `kerberos` section of the `packetbe
 
 ### `enabled` [_enabled_11]
 
-The `enabled` setting can be used to enable the kerberos configuration by setting it to `false`. The default value is `true`.
+The `enabled` setting can be used to enable the kerberos configuration by setting it to `true`. The default value is `true`.
 
 ::::{note}
 Kerberos settings are disabled if either `enabled` is set to `false` or the `kerberos` section is missing.

--- a/docs/reference/packetbeat/ilm.md
+++ b/docs/reference/packetbeat/ilm.md
@@ -10,9 +10,9 @@ applies_to:
 # Configure index lifecycle management [ilm]
 
 
-Use the [index lifecycle management](docs-content://manage-data/lifecycle/index-lifecycle-management/tutorial-automate-rollover.md) (ILM) feature in {{es}} to manage your Packetbeat their backing indices of your data streams as they age. Packetbeat loads the default policy automatically and applies it to any data streams created by Packetbeat.
+Use the [index lifecycle management](docs-content://manage-data/lifecycle/index-lifecycle-management/tutorial-automate-rollover.md) (ILM) feature in {{es}} to manage the backing indices of your Packetbeat data streams as they age. Packetbeat loads the default policy automatically and applies it to any data streams created by Packetbeat.
 
-You can view and edit the policy in the **Index lifecycle policies** UI in {{kib}}. For more information about working with the UI, see [Index lifecyle policies](docs-content://manage-data/lifecycle/index-lifecycle-management.md).
+You can view and edit the policy in the **Index lifecycle policies** UI in {{kib}}. For more information about working with the UI, see [Index lifecycle policies](docs-content://manage-data/lifecycle/index-lifecycle-management.md).
 
 Example configuration:
 

--- a/docs/reference/packetbeat/packetbeat-reference-yml.md
+++ b/docs/reference/packetbeat/packetbeat-reference-yml.md
@@ -1482,7 +1482,7 @@ output.elasticsearch:
   # Path to the Kerberos configuration.
   #kerberos.config_path: /etc/krb5.conf
 
-  # The service name. Service principal name is contructed from
+  # The service name. Service principal name is constructed from
   # service_name/hostname@realm.
   #kerberos.service_name: kafka
 

--- a/docs/reference/winlogbeat/configuration-kerberos.md
+++ b/docs/reference/winlogbeat/configuration-kerberos.md
@@ -32,7 +32,7 @@ output.elasticsearch.kerberos.config_path: "/etc/krb5.conf"
 output.elasticsearch.kerberos.realm: "ELASTIC.CO"
 ```
 
-The service principal name for the Elasticsearch instance is contructed from these options. Based on this configuration it is going to be `HTTP/my-elasticsearch.elastic.co@ELASTIC.CO`.
+The service principal name for the Elasticsearch instance is constructed from these options. Based on this configuration it is going to be `HTTP/my-elasticsearch.elastic.co@ELASTIC.CO`.
 
 
 ## Configuration options [_configuration_options_10]
@@ -42,7 +42,7 @@ You can specify the following options in the `kerberos` section of the `winlogbe
 
 ### `enabled` [_enabled_8]
 
-The `enabled` setting can be used to enable the kerberos configuration by setting it to `false`. The default value is `true`.
+The `enabled` setting can be used to enable the kerberos configuration by setting it to `true`. The default value is `true`.
 
 ::::{note}
 Kerberos settings are disabled if either `enabled` is set to `false` or the `kerberos` section is missing.

--- a/docs/reference/winlogbeat/ilm.md
+++ b/docs/reference/winlogbeat/ilm.md
@@ -10,9 +10,9 @@ applies_to:
 # Configure index lifecycle management [ilm]
 
 
-Use the [index lifecycle management](docs-content://manage-data/lifecycle/index-lifecycle-management/tutorial-automate-rollover.md) (ILM) feature in {{es}} to manage your Winlogbeat their backing indices of your data streams as they age. Winlogbeat loads the default policy automatically and applies it to any data streams created by Winlogbeat.
+Use the [index lifecycle management](docs-content://manage-data/lifecycle/index-lifecycle-management/tutorial-automate-rollover.md) (ILM) feature in {{es}} to manage the backing indices of your Winlogbeat data streams as they age. Winlogbeat loads the default policy automatically and applies it to any data streams created by Winlogbeat.
 
-You can view and edit the policy in the **Index lifecycle policies** UI in {{kib}}. For more information about working with the UI, see [Index lifecyle policies](docs-content://manage-data/lifecycle/index-lifecycle-management.md).
+You can view and edit the policy in the **Index lifecycle policies** UI in {{kib}}. For more information about working with the UI, see [Index lifecycle policies](docs-content://manage-data/lifecycle/index-lifecycle-management.md).
 
 Example configuration:
 

--- a/docs/reference/winlogbeat/winlogbeat-reference-yml.md
+++ b/docs/reference/winlogbeat/winlogbeat-reference-yml.md
@@ -894,7 +894,7 @@ output.elasticsearch:
   # Path to the Kerberos configuration.
   #kerberos.config_path: /etc/krb5.conf
 
-  # The service name. Service principal name is contructed from
+  # The service name. Service principal name is constructed from
   # service_name/hostname@realm.
   #kerberos.service_name: kafka
 


### PR DESCRIPTION
## Summary
- Fix the Kerberos `enabled` description so it says set to `true` (not `false`)
- Correct `contructed` to `constructed` in Kerberos docs and reference YAML pages
- Repair the broken ILM intro sentence across Beat docs
- Fix `lifecyle` to `lifecycle` in ILM policy links

Fixes #52495

## Test plan
- [ ] Spot-check Kerberos and ILM pages for Filebeat and Metricbeat
- [ ] Confirm no remaining `contructed` or `lifecyle` in `docs/reference`
- [ ] Docs-only change; no runtime behavior impact