### PR TITLE
Fix CLI error and dashboard help grammar

### DIFF
--- a/filebeat/cmd/modules.go
+++ b/filebeat/cmd/modules.go
@@ -36,7 +36,7 @@ func buildModulesManager(beat *beat.Beat) (cmd.ModulesManager, error) {
 	}
 
 	if !strings.HasSuffix(glob, "*.yml") {
-		return nil, fmt.Errorf("wrong settings for config.modules.path, it is expected to end with *.yml. Got: %s", glob)
+		return nil, fmt.Errorf("invalid config.modules.path setting: expected a value ending in *.yml; got: %s", glob)
 	}
 
 	modulesManager, err := cfgfile.NewGlobManager(glob, ".yml", ".disabled", beat.Info.Logger)

--- a/filebeat/input/registry.go
+++ b/filebeat/input/registry.go
@@ -61,7 +61,7 @@ func Register(name string, factory Factory) error {
 
 func GetFactory(name string) (Factory, error) {
 	if _, exists := registry[name]; !exists {
-		return nil, fmt.Errorf("Error creating input. No such input type exist: '%v'", name) //nolint:staticcheck //Keep old behavior
+		return nil, fmt.Errorf("Error creating input. No such input type exists: '%v'", name) //nolint:staticcheck //Keep old behavior
 	}
 	return registry[name], nil
 }

--- a/filebeat/input/registry_test.go
+++ b/filebeat/input/registry_test.go
@@ -69,6 +69,6 @@ func TestGetNonExistentFactory(t *testing.T) {
 	f, err := GetFactory("noSuchFactory")
 	assert.Nil(t, f)
 	if assert.Error(t, err) {
-		assert.Equal(t, "Error creating input. No such input type exist: 'noSuchFactory'", err.Error())
+		assert.Equal(t, "Error creating input. No such input type exists: 'noSuchFactory'", err.Error())
 	}
 }

--- a/libbeat/api/make_listener_posix.go
+++ b/libbeat/api/make_listener_posix.go
@@ -34,7 +34,7 @@ func makeListener(cfg Config) (net.Listener, error) {
 	}
 
 	if len(cfg.SecurityDescriptor) > 0 {
-		return nil, errors.New("security_descriptor option for the HTTP endpoint only work on Windows")
+		return nil, errors.New("the security_descriptor option for the HTTP endpoint only works on Windows")
 	}
 
 	if npipe.IsNPipe(cfg.Host) {

--- a/libbeat/cmd/export/dashboard.go
+++ b/libbeat/cmd/export/dashboard.go
@@ -33,7 +33,7 @@ import (
 func GenDashboardCmd(settings instance.Settings) *cobra.Command {
 	genTemplateConfigCmd := &cobra.Command{
 		Use:   "dashboard",
-		Short: "Export defined dashboard to stdout",
+		Short: "Export dashboards to files",
 		Run: func(cmd *cobra.Command, args []string) {
 			dashboard, _ := cmd.Flags().GetString("id")
 			yml, _ := cmd.Flags().GetString("yml")
@@ -101,7 +101,7 @@ func GenDashboardCmd(settings instance.Settings) *cobra.Command {
 	}
 
 	genTemplateConfigCmd.Flags().String("id", "", "Dashboard id")
-	genTemplateConfigCmd.Flags().String("yml", "", "Yaml file containing list of dashboard ID and filename pairs")
+	genTemplateConfigCmd.Flags().String("yml", "", "YAML file containing dashboard ID and filename pairs")
 	genTemplateConfigCmd.Flags().String("folder", "", "Target folder to save exported assets")
 
 	return genTemplateConfigCmd

--- a/metricbeat/cmd/modules.go
+++ b/metricbeat/cmd/modules.go
@@ -36,7 +36,7 @@ func BuildModulesManager(beat *beat.Beat) (cmd.ModulesManager, error) {
 	}
 
 	if !strings.HasSuffix(glob, "*.yml") {
-		return nil, fmt.Errorf("wrong settings for config.modules.path, it is expected to end with *.yml. Got: %s", glob)
+		return nil, fmt.Errorf("invalid config.modules.path setting: expected a value ending in *.yml; got: %s", glob)
 	}
 
 	modulesManager, err := cfgfile.NewGlobManager(glob, ".yml", ".disabled", beat.Info.Logger)


### PR DESCRIPTION
## Summary

Fixes the user facing grammar and help text issues from #52012:

1. Filebeat and Metricbeat `config.modules.path` validation message
2. HTTP `security_descriptor` platform error on non Windows
3. Unknown input type error (`exists`)
4. Dashboard export short help (exports to files, not stdout)
5. Dashboard `--yml` flag description capitalization and wording

Fixes #52012

## Test plan

1. Confirm the five old strings no longer appear in the touched files
2. Spot check `filebeat export dashboard --help` and modules path validation messaging