### PR TITLE
ci: lint only the lines that a pull request changes

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -48,13 +48,8 @@ jobs:
           version-file: .golangci-lint-version
 
           # Give the job more time to execute.
-          # Regarding `--whole-files`, the linter is supposed to support linting of changed a patch only but,
-          # for some reason, it's very unreliable this way - sometimes it does not report any or some
-          # issues without linting the whole files, so we have to use `--whole-files`
-          # which can lead to some frustration from developers who would like to
-          # fix a single line in an existing codebase and the linter would force them
-          # into fixing all linting issues in the whole file instead
-          args: --timeout=90m --whole-files
+          # Issues are reported only on the lines the pull request changed.
+          args: --timeout=90m
 
           # Optional: show only new issues if it's a pull request. The default value is `false`.
           only-new-issues: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,8 +75,8 @@ make check                   # Full check suite (lint, headers, go mod, python)
 ### Linting
 
 ```bash
-# Running golangci-lint for the whole codebase is slow, prefer running only on changed files by default
-golangci-lint run --max-issues-per-linter 0 --max-same-issues 0 --whole-files --new-from-merge-base upstream/main
+# Running golangci-lint for the whole codebase is slow, prefer running only on changed lines by default.
+golangci-lint run --max-issues-per-linter 0 --max-same-issues 0 --new-from-merge-base upstream/main
 ```
 
 ## Architecture


### PR DESCRIPTION
## Proposed commit message

```
ci: lint only the lines that a pull request changes

The linter ran with `--whole-files`. It reported every issue in a changed
file, not only the issues on the changed lines.

Timeline:

- Sep 2021: golangci-lint added the flag
  (https://github.com/golangci/golangci-lint/pull/2264).
- Mar 2022: Beats enabled the flag, because patch mode dropped issues at
  that time (https://github.com/elastic/beats/pull/30985).
- Aug 2022 to Apr 2024: upstream fixed the causes in the diff engine
  `revgrep`. Color codes and custom prefixes in `git diff` output made a
  patch unreadable, and the filter then dropped all issues.
- Jan 2025: upstream reworked `revgrep` and added `--new-from-merge-base`.

The flag now has more disadvantages than advantages. GitHub shows an
annotation in the diff only when the line is part of the diff. GitHub also
shows a maximum of 10 error annotations for each step. Issues on unchanged
lines are therefore invisible in the review UI, and they hide the new
issues.

One gap remains. The linter drops an issue when the position is not a
changed line e.g. dead code after the deletion of the last caller.
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works.~~
- [ ] ~~I have added an entry in `./changelog/fragments` using the changelog tool.~~

## Disruptive User Impact

None.

## How to test this PR locally

Run the linter with the same filter that CI uses:

```bash
golangci-lint run --max-issues-per-linter 0 --max-same-issues 0 --new-from-merge-base upstream/main
```

1. Add a lint issue on a new line in a file that has other lint issues.
2. Run the command. The output shows only the new issue.

## Related issues

- Relates https://github.com/elastic/beats/issues/52485
