### PR TITLE
Fix max_mesage_bytes typo in Kafka oversize log

### DIFF
--- a/libbeat/outputs/kafka/client.go
+++ b/libbeat/outputs/kafka/client.go
@@ -427,7 +427,7 @@ func (r *msgRef) fail(msg *message, err error) {
 
 	// drop event if it exceeds size larger than max_message_bytes
 	case strings.Contains(err.Error(), "Attempt to produce message larger than configured Producer.MaxMessageBytes"):
-		r.client.log.Errorf("Kafka (topic=%v): dropping message as it exceeds max_mesage_bytes:", msg.topic)
+		r.client.log.Errorf("Kafka (topic=%v): dropping message as it exceeds max_message_bytes:", msg.topic)
 		r.client.observer.PermanentErrors(1)
 
 	case isAuthError(err):


### PR DESCRIPTION
## Summary
Corrects the Kafka oversize drop log from `max_mesage_bytes` to `max_message_bytes` so it matches the real config key.

This finishes the remaining Kafka item from #52480. #52481 already covers the diskqueue `cound not` typos.

Related to #52480

## Checklist
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard to understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's checklist
- [x] Confirmed the log string now uses `max_message_bytes`