### PR TITLE
fix(metricbeat): companion goroutine unblocks stuck initial fetch on shutdown

### DIFF
--- a/changelog/fragments/1786624957-drosiek-15666-wrapper-companion-goroutine.yaml
+++ b/changelog/fragments/1786624957-drosiek-15666-wrapper-companion-goroutine.yaml
@@ -1,0 +1,45 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: Unblock a metricset whose first Fetch() call is stuck when the wrapper shuts down
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# description:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: metricbeat
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+pr: https://github.com/elastic/beats/pull/52619
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+# issue: https://github.com/owner/repo/1234

--- a/metricbeat/mb/module/wrapper.go
+++ b/metricbeat/mb/module/wrapper.go
@@ -185,7 +185,7 @@ func (mw *Wrapper) Start(done <-chan struct{}) <-chan beat.Event {
 			go func() {
 				select {
 				case <-done:
-					msw.close() //nolint:errcheck // second call from defer is a no-op
+					msw.close()
 				case <-stopCompanion:
 				}
 			}()

--- a/metricbeat/mb/module/wrapper.go
+++ b/metricbeat/mb/module/wrapper.go
@@ -173,19 +173,22 @@ func (mw *Wrapper) Start(done <-chan struct{}) <-chan beat.Event {
 			defer registry.Remove(metricsPath)
 			defer releaseStats(mw.monitoring.StatsRegistry(), msw.stats)
 			defer wg.Done()
-			defer msw.close()
 
-			// startPeriodicFetching performs a synchronous fetch before entering
+			// ensure we call msw.close() once
+			var closeOnce sync.Once
+			closeMetricSet := func() { closeOnce.Do(func() { msw.close() }) }
+			defer closeMetricSet()
+
+			// startPeriodicFetching (called by msw.run) performs a synchronous fetch before entering
 			// its select loop, so closing done cannot interrupt a blocked first
-			// fetch. The companion goroutine below calls msw.close() when done
-			// fires, which gives the metricset a chance to unblock itself via
-			// its Close() method.
+			// Fetch(). The companion goroutine calls close() when done fires,
+			// giving the metricset a chance to unblock itself via Close().
 			stopCompanion := make(chan struct{})
 			defer close(stopCompanion)
 			go func() {
 				select {
 				case <-done:
-					msw.close()
+					closeMetricSet()
 				case <-stopCompanion:
 				}
 			}()

--- a/metricbeat/mb/module/wrapper.go
+++ b/metricbeat/mb/module/wrapper.go
@@ -175,6 +175,21 @@ func (mw *Wrapper) Start(done <-chan struct{}) <-chan beat.Event {
 			defer wg.Done()
 			defer msw.close()
 
+			// startPeriodicFetching performs a synchronous fetch before entering
+			// its select loop, so closing done cannot interrupt a blocked first
+			// fetch. The companion goroutine below calls msw.close() when done
+			// fires, which gives the metricset a chance to unblock itself via
+			// its Close() method.
+			stopCompanion := make(chan struct{})
+			defer close(stopCompanion)
+			go func() {
+				select {
+				case <-done:
+					msw.close() //nolint:errcheck // second call from defer is a no-op
+				case <-stopCompanion:
+				}
+			}()
+
 			registry.Add(metricsPath, msw.Metrics(), monitoring.Full)
 			monitoring.NewString(msw.Metrics(), "starttime").Set(common.Time(time.Now()).String())
 

--- a/metricbeat/mb/module/wrapper_test.go
+++ b/metricbeat/mb/module/wrapper_test.go
@@ -242,6 +242,69 @@ func TestDurationIsAddedToEvent(t *testing.T) {
 	assert.Falsef(t, ok, "received unexpected event: %+v", event)
 }
 
+// blockingFetcher blocks inside Fetch() until Close() is called.
+// It is used to test that the companion goroutine unblocks a stuck first fetch.
+type blockingFetcher struct {
+	mb.BaseMetricSet
+	started chan struct{} // closed by Fetch() once it starts blocking
+	unblock chan struct{} // closed by Close() to unblock Fetch()
+}
+
+func (f *blockingFetcher) Fetch(_ mb.ReporterV2) {
+	close(f.started)
+	<-f.unblock
+}
+
+func (f *blockingFetcher) Close() error {
+	select {
+	case <-f.unblock:
+	default:
+		close(f.unblock)
+	}
+	return nil
+}
+
+// TestWrapperCompanionUnblocksStuckFetch verifies that closing done unblocks a
+// metricset whose first Fetch() call is stuck. Without the companion goroutine,
+// the wrapper goroutine never reaches the select on done and Shutdown() blocks.
+func TestWrapperCompanionUnblocksStuckFetch(t *testing.T) {
+	started := make(chan struct{})
+	unblock := make(chan struct{})
+
+	r := mb.NewRegister()
+	err := r.AddMetricSet(moduleName, "BlockingFetcher", func(base mb.BaseMetricSet) (mb.MetricSet, error) {
+		return &blockingFetcher{BaseMetricSet: base, started: started, unblock: unblock}, nil
+	})
+	require.NoError(t, err)
+
+	c := newConfig(t, map[string]any{
+		"module":     moduleName,
+		"metricsets": []string{"BlockingFetcher"},
+		"hosts":      []string{"localhost"},
+	})
+	m, err := module.NewWrapper(c, r, &beat.Info{Logger: logptest.NewTestingLogger(t, "")}, beatmonitoring.NewMonitoring(), paths.New())
+	require.NoError(t, err)
+
+	done := make(chan struct{})
+	output := m.Start(done)
+
+	// Wait until Fetch() is actually blocking before closing done.
+	select {
+	case <-started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Fetch() did not start within 5s")
+	}
+
+	close(done)
+
+	select {
+	case _, ok := <-output:
+		assert.False(t, ok, "expected output channel to be closed")
+	case <-time.After(5 * time.Second):
+		t.Fatal("wrapper did not shut down within 5s; companion goroutine may not have unblocked Fetch()")
+	}
+}
+
 func TestNewWrapperForMetricSet(t *testing.T) {
 	hosts := []string{"alpha"}
 	c := newConfig(t, map[string]any{


### PR DESCRIPTION
## Problem

`startPeriodicFetching` performs a synchronous `fetch()` call before entering its `select` loop:

```go
func (msw *metricSetWrapper) startPeriodicFetching(...) {
    msw.fetch(ctx, reporter)   // ← blocks here
    for {
        select {
        case <-reporter.V2().Done():
            return
        ...
        }
    }
}
```

If that first `fetch()` blocks — because the metricset calls a blocking operation such as `WaitForCacheSync` inside `Fetch()` — closing `done` has no effect. The goroutine never reaches the `select`, so `Shutdown()` blocks indefinitely waiting for the goroutine to exit, and the component stays stuck in STOPPING permanently.

This was observed with the `kubernetes/state_deployment` metricset when LIST permission on `deployments.apps` is denied: `Fetch()` calls `enricher.Start()` → `watcher.Start()` → `WaitForCacheSync`, which blocks indefinitely. A partial OTel reload calls `Shutdown()` on the receiver, but with no way to interrupt the blocked goroutine, the reload never completes and the component never returns to HEALTHY.

## Fix

Add a companion goroutine that fires when `done` closes and calls `msw.close()` concurrently with the blocked `fetch()`. Any metricset implementing `mb.Closer` can unblock its `Fetch()` via `Close()`, allowing `fetch()` to return and the goroutine to exit cleanly.

The companion exits via `stopCompanion` when `fetch()` returns normally, so there is no goroutine leak in the common case. The `msw.close()` call is safe to make twice: the outer goroutine already has `defer msw.close()`, and `close()` is a no-op on the second call for any well-behaved `mb.Closer` implementation.

## Why not select on `done` before the first fetch?

The first `fetch()` is intentionally synchronous — it populates metrics before the ticker starts. Wrapping it in a goroutine with a select would change the startup contract and require each metricset to be safe for concurrent cancellation at the `Fetch()` level, which is a larger and riskier change. The companion goroutine limits the fix to the shutdown path only.

## Related

Companion to elastic/beats#52409 (kubernetes enricher lock fix) which releases `resourceWatchers.lock` before calling `watcher.Start()`. Both fixes are required to fully resolve https://github.com/elastic/elastic-agent/issues/15666: the enricher fix allows `enricher.Stop()` to run concurrently with `enricher.Start()`; this fix ensures `enricher.Stop()` is actually called while the goroutine is stuck.