### PR TITLE
auditbeat: adapt to quark 0.8 backend flags and since-boot times

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -12629,11 +12629,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 --------------------------------------------------------------------------------
 Dependency : github.com/elastic/go-quark
-Version: v0.6.0
+Version: v0.6.1-0.20260813141718-5aae20e3103c
 Licence type (autodetected): Apache-2.0
 --------------------------------------------------------------------------------
 
-Contents of probable licence file $GOMODCACHE/github.com/elastic/go-quark@v0.6.0/LICENSE.txt:
+Contents of probable licence file $GOMODCACHE/github.com/elastic/go-quark@v0.6.1-0.20260813141718-5aae20e3103c/LICENSE.txt:
 
 
                                  Apache License

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -12629,11 +12629,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 --------------------------------------------------------------------------------
 Dependency : github.com/elastic/go-quark
-Version: v0.6.1-0.20260813141718-5aae20e3103c
+Version: v0.8.0
 Licence type (autodetected): Apache-2.0
 --------------------------------------------------------------------------------
 
-Contents of probable licence file $GOMODCACHE/github.com/elastic/go-quark@v0.6.1-0.20260813141718-5aae20e3103c/LICENSE.txt:
+Contents of probable licence file $GOMODCACHE/github.com/elastic/go-quark@v0.8.0/LICENSE.txt:
 
 
                                  Apache License

--- a/changelog/fragments/1786630989-auditbeat-quark-0.8.yaml
+++ b/changelog/fragments/1786630989-auditbeat-quark-0.8.yaml
@@ -1,0 +1,10 @@
+kind: upgrade
+summary: Update go-quark for quark 0.8 since-boot timestamps
+description: >
+  quark 0.8 hands out process timestamps as nanoseconds since boot instead
+  of since the epoch. Auditbeat now converts process.start/process.end to
+  wallclock with quark.TimeToWallclock() and keeps quark's boottime epoch
+  fresh, so timestamps stay correct even when the system clock is stepped,
+  as when NTP corrects a clock that was wrong at boot. Emitted events are
+  unchanged.
+component: auditbeat

--- a/go.mod
+++ b/go.mod
@@ -174,7 +174,7 @@ require (
 	github.com/elastic/elastic-agent-system-metrics v0.14.5
 	github.com/elastic/go-elasticsearch/v8 v8.19.0
 	github.com/elastic/go-freelru v0.16.0
-	github.com/elastic/go-quark v0.6.0
+	github.com/elastic/go-quark v0.6.1-0.20260813141718-5aae20e3103c
 	github.com/elastic/go-sfdc v0.0.0-20260504130806-a46e22d049d9
 	github.com/elastic/mito v1.27.0
 	github.com/elastic/mock-es v0.0.0-20250530054253-8c3b6053f9b6

--- a/go.mod
+++ b/go.mod
@@ -174,7 +174,7 @@ require (
 	github.com/elastic/elastic-agent-system-metrics v0.14.5
 	github.com/elastic/go-elasticsearch/v8 v8.19.0
 	github.com/elastic/go-freelru v0.16.0
-	github.com/elastic/go-quark v0.6.1-0.20260813141718-5aae20e3103c
+	github.com/elastic/go-quark v0.8.0
 	github.com/elastic/go-sfdc v0.0.0-20260504130806-a46e22d049d9
 	github.com/elastic/mito v1.27.0
 	github.com/elastic/mock-es v0.0.0-20250530054253-8c3b6053f9b6

--- a/go.sum
+++ b/go.sum
@@ -410,8 +410,8 @@ github.com/elastic/go-lumber v0.2.0 h1:BVGh+jq6tmp5ajAQ4QaPLcwC8vYqQ0yzt0tmWfuz7
 github.com/elastic/go-lumber v0.2.0/go.mod h1:HHaWnZamYKWsR9/eZNHqRHob8iQDKnchHmmskT/SKko=
 github.com/elastic/go-perf v0.0.0-20260224073651-af0ee0c731b7 h1:fGi5uudj7m5O1RgQl+bSZmwlqvuUMEi97X7TzWBOMGk=
 github.com/elastic/go-perf v0.0.0-20260224073651-af0ee0c731b7/go.mod h1:ucTo2u8JvFyIPQOaRlX7aVF0d3wwmF1dy/PVp5GUHZI=
-github.com/elastic/go-quark v0.6.1-0.20260813141718-5aae20e3103c h1:+S9u54BiMlCthWAKXMJu3vn4253qgFHPUzYcepJUXCM=
-github.com/elastic/go-quark v0.6.1-0.20260813141718-5aae20e3103c/go.mod h1:bO/XIGZBUJGxyiJ9FTsSYn9YlfOTRJnmOP+iBE2FyjA=
+github.com/elastic/go-quark v0.8.0 h1:UYH5fpSvnrHonqo/5KLTKwkWT3bJV784+gGhOC6axOg=
+github.com/elastic/go-quark v0.8.0/go.mod h1:bO/XIGZBUJGxyiJ9FTsSYn9YlfOTRJnmOP+iBE2FyjA=
 github.com/elastic/go-seccomp-bpf v1.5.0 h1:gJV+U1iP+YC70ySyGUUNk2YLJW5/IkEw4FZBJfW8ZZY=
 github.com/elastic/go-seccomp-bpf v1.5.0/go.mod h1:umdhQ/3aybliBF2jjiZwS492I/TOKz+ZRvsLT3hVe1o=
 github.com/elastic/go-sfdc v0.0.0-20260504130806-a46e22d049d9 h1:UbquKP8gHTRugCZQ/KoVQrz8XnHzncsrHFfgTa+PfTg=

--- a/go.sum
+++ b/go.sum
@@ -410,8 +410,8 @@ github.com/elastic/go-lumber v0.2.0 h1:BVGh+jq6tmp5ajAQ4QaPLcwC8vYqQ0yzt0tmWfuz7
 github.com/elastic/go-lumber v0.2.0/go.mod h1:HHaWnZamYKWsR9/eZNHqRHob8iQDKnchHmmskT/SKko=
 github.com/elastic/go-perf v0.0.0-20260224073651-af0ee0c731b7 h1:fGi5uudj7m5O1RgQl+bSZmwlqvuUMEi97X7TzWBOMGk=
 github.com/elastic/go-perf v0.0.0-20260224073651-af0ee0c731b7/go.mod h1:ucTo2u8JvFyIPQOaRlX7aVF0d3wwmF1dy/PVp5GUHZI=
-github.com/elastic/go-quark v0.6.0 h1:ESbcnjLheNn3QNSCdwTcqV+z+IRKt5+UQ3LaoKv5DJs=
-github.com/elastic/go-quark v0.6.0/go.mod h1:bO/XIGZBUJGxyiJ9FTsSYn9YlfOTRJnmOP+iBE2FyjA=
+github.com/elastic/go-quark v0.6.1-0.20260813141718-5aae20e3103c h1:+S9u54BiMlCthWAKXMJu3vn4253qgFHPUzYcepJUXCM=
+github.com/elastic/go-quark v0.6.1-0.20260813141718-5aae20e3103c/go.mod h1:bO/XIGZBUJGxyiJ9FTsSYn9YlfOTRJnmOP+iBE2FyjA=
 github.com/elastic/go-seccomp-bpf v1.5.0 h1:gJV+U1iP+YC70ySyGUUNk2YLJW5/IkEw4FZBJfW8ZZY=
 github.com/elastic/go-seccomp-bpf v1.5.0/go.mod h1:umdhQ/3aybliBF2jjiZwS492I/TOKz+ZRvsLT3hVe1o=
 github.com/elastic/go-sfdc v0.0.0-20260504130806-a46e22d049d9 h1:UbquKP8gHTRugCZQ/KoVQrz8XnHzncsrHFfgTa+PfTg=

--- a/x-pack/auditbeat/module/system/process/quark_provider_linux.go
+++ b/x-pack/auditbeat/module/system/process/quark_provider_linux.go
@@ -206,7 +206,7 @@ func (ms *QuarkMetricSet) toEvent(quarkEvent quark.Event, snap bool) (mb.Event, 
 
 	// Ids
 	event.RootFields.Put("process.parent.pid", process.Proc.Ppid)
-	startTime := time.Unix(0, int64(process.Proc.TimeBoot)) //nolint:gosec // TimeBoot is a nanosecond timestamp that fits in int64
+	startTime := time.Unix(0, int64(quark.TimeToWallclock(process.Proc.TimeBoot))) //nolint:gosec // TimeBoot is a nanosecond timestamp that fits in int64
 	if ms.HostID() != "" {
 		// TODO unify with sessionview and guarantee loss of precision
 		event.RootFields.Put("process.entity_id",
@@ -345,6 +345,16 @@ func (ms *QuarkMetricSet) maybeUpdateMetrics(stamp *time.Time) {
 		quarkMetrics.backend.Set("kprobe")
 	default:
 		quarkMetrics.backend.Set("invalid")
+	}
+
+	// Quark hands out timestamps in nanoseconds since boot, converted
+	// at the last moment with quark.TimeToWallclock(). Refresh the
+	// boottime epoch so a system clock step (say NTP correcting a
+	// clock that was wrong at boot) doesn't leave every converted
+	// timestamp skewed by the step size. Quark only stores the epoch
+	// if btime actually changed, which happens only on a step.
+	if err := quark.UpdateBoottime(); err != nil {
+		ms.log.Warnf("can't update quark boottime: %v", err)
 	}
 
 	*stamp = time.Now()

--- a/x-pack/auditbeat/module/system/process/quark_provider_linux_test.go
+++ b/x-pack/auditbeat/module/system/process/quark_provider_linux_test.go
@@ -261,7 +261,7 @@ func makeSelfEvent(t *testing.T, qp quark.Process, be backend) mb.Event {
 			"process.pid":                           uint32(os.Getpid()), //nolint:gosec // PID values fit in uint32
 			"process.executable":                    exe,
 			"process.parent.pid":                    uint32(os.Getppid()), //nolint:gosec // PID values fit in uint32
-			"process.start":                         time.Unix(0, int64(qp.Proc.TimeBoot)),
+			"process.start":                         time.Unix(0, int64(quark.TimeToWallclock(qp.Proc.TimeBoot))), //nolint:gosec // TimeBoot is a nanosecond timestamp that fits in int64
 			"user.id":                               uint32(0),
 			"user.group.id":                         uint32(0),
 			"user.effective.id":                     uint32(0),
@@ -323,8 +323,8 @@ func makeEventOfCmd(t *testing.T, cmd *exec.Cmd, qev quark.Event, be backend) mb
 			"process.args_count":                    1,
 			"process.pid":                           uint32(cmd.Process.Pid), //nolint:gosec // PID values fit in uint32
 			"process.executable":                    "/usr/bin/true",
-			"process.parent.pid":                    uint32(os.Getpid()),                   //nolint:gosec // PID values fit in uint32
-			"process.start":                         time.Unix(0, int64(qp.Proc.TimeBoot)), //nolint:gosec // TimeBoot is a nanosecond timestamp that fits in int64
+			"process.parent.pid":                    uint32(os.Getpid()),                                          //nolint:gosec // PID values fit in uint32
+			"process.start":                         time.Unix(0, int64(quark.TimeToWallclock(qp.Proc.TimeBoot))), //nolint:gosec // TimeBoot is a nanosecond timestamp that fits in int64
 			"user.id":                               uint32(0),
 			"user.group.id":                         uint32(0),
 			"user.effective.id":                     uint32(0),

--- a/x-pack/auditbeat/module/system/process/quark_provider_linux_test.go
+++ b/x-pack/auditbeat/module/system/process/quark_provider_linux_test.go
@@ -260,7 +260,7 @@ func makeSelfEvent(t *testing.T, qp quark.Process, be backend) mb.Event {
 			"process.args_count":                    len(qp.Cmdline),
 			"process.pid":                           uint32(os.Getpid()), //nolint:gosec // PID values fit in uint32
 			"process.executable":                    exe,
-			"process.parent.pid":                    uint32(os.Getppid()), //nolint:gosec // PID values fit in uint32
+			"process.parent.pid":                    uint32(os.Getppid()),                                         //nolint:gosec // PID values fit in uint32
 			"process.start":                         time.Unix(0, int64(quark.TimeToWallclock(qp.Proc.TimeBoot))), //nolint:gosec // TimeBoot is a nanosecond timestamp that fits in int64
 			"user.id":                               uint32(0),
 			"user.group.id":                         uint32(0),

--- a/x-pack/auditbeat/processors/sessionmd/provider/kerneltracingprovider/kerneltracingprovider_linux.go
+++ b/x-pack/auditbeat/processors/sessionmd/provider/kerneltracingprovider/kerneltracingprovider_linux.go
@@ -130,6 +130,17 @@ func NewProvider(ctx context.Context, logger *logp.Logger, reg *monitoring.Regis
 				stats.Lost.Set(metrics.Lost)
 				stats.NonAggregations.Set(metrics.NonAggregations)
 				stats.Removals.Set(metrics.Removals)
+				// Quark hands out timestamps in nanoseconds since
+				// boot, converted at the last moment with
+				// quark.TimeToWallclock(). Refresh the boottime
+				// epoch so a system clock step (say NTP correcting
+				// a clock that was wrong at boot) doesn't leave
+				// every converted timestamp skewed by the step
+				// size. Quark only stores the epoch if btime
+				// actually changed, which happens only on a step.
+				if err := quark.UpdateBoottime(); err != nil {
+					logger.Warnf("can't update quark boottime: %v", err)
+				}
 				lastUpdate = time.Now()
 			}
 
@@ -261,7 +272,7 @@ func (p *prvdr) GetProcess(pid uint32) (*types.Process, error) {
 		Minor: proc.Proc.TtyMinor,
 	})
 
-	start := time.Unix(0, int64(proc.Proc.TimeBoot)) //nolint:gosec // TimeBoot is a nanosecond timestamp that fits in int64
+	start := time.Unix(0, int64(quark.TimeToWallclock(proc.Proc.TimeBoot))) //nolint:gosec // TimeBoot is a nanosecond timestamp that fits in int64
 
 	ret := types.Process{
 		PID:              proc.Pid,
@@ -288,7 +299,7 @@ func (p *prvdr) GetProcess(pid uint32) (*types.Process, error) {
 	ret.TTY.CharDevice.Major = uint16(proc.Proc.TtyMajor) //nolint:gosec // tty major/minor numbers fit in uint16
 	ret.TTY.CharDevice.Minor = uint16(proc.Proc.TtyMinor) //nolint:gosec // tty major/minor numbers fit in uint16
 	if proc.Exit.Valid {
-		end := time.Unix(0, int64(proc.Exit.ExitTimeProcess)) //nolint:gosec // ExitTimeProcess is a nanosecond timestamp that fits in int64
+		end := time.Unix(0, int64(quark.TimeToWallclock(proc.Exit.ExitTimeProcess))) //nolint:gosec // ExitTimeProcess is a nanosecond timestamp that fits in int64
 		ret.ExitCode = proc.Exit.ExitCode
 		ret.End = &end
 	}
@@ -317,7 +328,7 @@ func (p *prvdr) fillParent(process *types.Process, ppid uint32) {
 		return
 	}
 
-	start := time.Unix(0, int64(proc.Proc.TimeBoot)) //nolint:gosec // TimeBoot is a nanosecond timestamp that fits in int64
+	start := time.Unix(0, int64(quark.TimeToWallclock(proc.Proc.TimeBoot))) //nolint:gosec // TimeBoot is a nanosecond timestamp that fits in int64
 	interactive := tty.InteractiveFromTTY(tty.TTYDev{
 		Major: proc.Proc.TtyMajor,
 		Minor: proc.Proc.TtyMinor,
@@ -351,7 +362,7 @@ func (p *prvdr) fillGroupLeader(process *types.Process, pgid uint32) {
 		return
 	}
 
-	start := time.Unix(0, int64(proc.Proc.TimeBoot)) //nolint:gosec // TimeBoot is a nanosecond timestamp that fits in int64
+	start := time.Unix(0, int64(quark.TimeToWallclock(proc.Proc.TimeBoot))) //nolint:gosec // TimeBoot is a nanosecond timestamp that fits in int64
 
 	interactive := tty.InteractiveFromTTY(tty.TTYDev{
 		Major: proc.Proc.TtyMajor,
@@ -386,7 +397,7 @@ func (p *prvdr) fillSessionLeader(process *types.Process, sid uint32) {
 		return
 	}
 
-	start := time.Unix(0, int64(proc.Proc.TimeBoot)) //nolint:gosec // TimeBoot is a nanosecond timestamp that fits in int64
+	start := time.Unix(0, int64(quark.TimeToWallclock(proc.Proc.TimeBoot))) //nolint:gosec // TimeBoot is a nanosecond timestamp that fits in int64
 
 	interactive := tty.InteractiveFromTTY(tty.TTYDev{
 		Major: proc.Proc.TtyMajor,
@@ -421,7 +432,7 @@ func (p *prvdr) fillEntryLeader(process *types.Process, elid uint32) {
 		return
 	}
 
-	start := time.Unix(0, int64(proc.Proc.TimeBoot)) //nolint:gosec // TimeBoot is a nanosecond timestamp that fits in int64
+	start := time.Unix(0, int64(quark.TimeToWallclock(proc.Proc.TimeBoot))) //nolint:gosec // TimeBoot is a nanosecond timestamp that fits in int64
 
 	interactive := tty.InteractiveFromTTY(tty.TTYDev{
 		Major: proc.Proc.TtyMajor,


### PR DESCRIPTION
## Proposed commit message

quark 0.8 hands out `Proc.TimeBoot` and `Exit.ExitTimeProcess` as nanoseconds **since boot** instead of since the epoch (see [quark CHANGES](https://github.com/elastic/quark/blob/main/CHANGES), 0.7→0.8). Without conversion, `process.start`/`process.end` would be dated shortly after 1970. This PR:

- Converts with the new `quark.TimeToWallclock()` at every site that feeds `process.start`/`process.end`, in both auditbeat quark consumers (sessionmd kerneltracingprovider and the system/process quark provider). Emitted events are unchanged.
- Keeps the boottime epoch fresh across **system clock steps** (e.g. NTP correcting a clock that was wrong at boot): quark caches the epoch at `quark_queue_open()` and keeping it honest is the consumer's job. Both providers call `quark.UpdateBoottime()` on their existing 5-second stats cadence: it re-reads `/proc/stat` btime, which is stable between reads and only moves on a step, and quark stores it only when it actually changed. Corrections apply retroactively to anything translated afterwards.

The backend flag changes (`QQ_ALL_BACKENDS` removal, explicit ebpf→kprobe fallback) landed separately in #52574

## Why it is important

Once beats picks up a go-quark release with quark ≥ 0.8, timestamps would silently break; this PR makes the conversion explicit and step-proof ahead of that.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~ N/A
- [ ] ~~I have made corresponding change to the default configuration files~~ N/A
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~ (existing root-only integration tests cover both providers; updated in-place)
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool)

## Dependency

Resolved: elastic/go-quark#40 merged and [go-quark v0.8.0](https://github.com/elastic/go-quark/releases/tag/v0.8.0) is released; go.mod now pins `go-quark v0.8.0` (NOTICE regenerated).

## How to test this PR locally

```
cd x-pack/auditbeat/module/system/process
sudo go test -run 'TestQuarkMetricSet|TestForkExecExit|TestInitialSnapshot' ./...
```

Verified locally: `go vet` and `go test -c` (compile+link) of both packages against the rebuilt go-quark static lib.

## Related issues

- elastic/beats#52574 (backend flags, merged)
- elastic/go-quark#40
- elastic/quark#368 (the upstream timestamp change)

