### PR TITLE
Fix add_resource_metadata docs: deployment and cronjob default to false

### DIFF
--- a/docs/reference/auditbeat/add-kubernetes-metadata.md
+++ b/docs/reference/auditbeat/add-kubernetes-metadata.md
@@ -105,8 +105,8 @@ The `add_kubernetes_metadata` processor has the following configuration settings
 :   (Optional) Specify filters and configuration for the extra metadata, that will be added to the event. Configuration parameters:
 
     * `node` or `namespace`: Specify labels and annotations filters for the extra metadata coming from node and namespace. By default all labels are included while annotations are not. To change default behaviour `include_labels`, `exclude_labels` and `include_annotations` can be defined. Those settings are useful when storing labels and annotations that require special handling to avoid overloading the storage output. Note: wildcards are not supported for those settings. The enrichment of `node` or `namespace` metadata can be individually disabled by setting `enabled: false`.
-    * `deployment`: If resource is `pod` and it is created from a `deployment`, by default the deployment name is added, this can be disabled by setting `deployment: false`.
-    * `cronjob`: If resource is `pod` and it is created from a `cronjob`, by default the cronjob name is added, this can be disabled by setting `cronjob: false`.
+    * `deployment`: If resource is `pod` and it is created from a `deployment`, the deployment name is added. This is disabled by default and can be enabled by setting `deployment: true`.
+    * `cronjob`: If resource is `pod` and it is created from a `cronjob`, the cronjob name is added. This is disabled by default and can be enabled by setting `cronjob: true`.
 
         Example:
 
@@ -122,8 +122,8 @@ The `add_kubernetes_metadata` processor has the following configuration settings
           include_annotations: ["nodeannotation1"]
           #labels.dedot: true
           #annotations.dedot: true
-        deployment: false
-        cronjob: false
+        deployment: true
+        cronjob: true
 ```
 
 `kube_config`

--- a/docs/reference/filebeat/add-kubernetes-metadata.md
+++ b/docs/reference/filebeat/add-kubernetes-metadata.md
@@ -101,8 +101,8 @@ The `add_kubernetes_metadata` processor has the following configuration settings
 `add_resource_metadata`
 :   (Optional) Specify filters and configuration for the extra metadata, that will be added to the event. Configuration parameters:
     * `node` or `namespace`: Specify labels and annotations filters for the extra metadata coming from node and namespace. By default all labels are included while annotations are not. To change default behaviour `include_labels`, `exclude_labels` and `include_annotations` can be defined. Those settings are useful when storing labels and annotations that require special handling to avoid overloading the storage output. Note: wildcards are not supported for those settings. The enrichment of `node` or `namespace` metadata can be individually disabled by setting `enabled: false`.
-    * `deployment`: If resource is `pod` and it is created from a `deployment`, by default the deployment name is added, this can be disabled by setting `deployment: false`.
-    * `cronjob`: If resource is `pod` and it is created from a `cronjob`, by default the cronjob name is added, this can be disabled by setting `cronjob: false`.
+    * `deployment`: If resource is `pod` and it is created from a `deployment`, the deployment name is added. This is disabled by default and can be enabled by setting `deployment: true`.
+    * `cronjob`: If resource is `pod` and it is created from a `cronjob`, the cronjob name is added. This is disabled by default and can be enabled by setting `cronjob: true`.
 
     Example:
 
@@ -117,8 +117,8 @@ The `add_kubernetes_metadata` processor has the following configuration settings
               include_annotations: ["nodeannotation1"]
               #labels.dedot: true
               #annotations.dedot: true
-            deployment: false
-            cronjob: false
+            deployment: true
+            cronjob: true
     ```
 
 `kube_config`

--- a/docs/reference/heartbeat/add-kubernetes-metadata.md
+++ b/docs/reference/heartbeat/add-kubernetes-metadata.md
@@ -105,8 +105,8 @@ The `add_kubernetes_metadata` processor has the following configuration settings
 :   (Optional) Specify filters and configuration for the extra metadata, that will be added to the event. Configuration parameters:
 
     * `node` or `namespace`: Specify labels and annotations filters for the extra metadata coming from node and namespace. By default all labels are included while annotations are not. To change default behaviour `include_labels`, `exclude_labels` and `include_annotations` can be defined. Those settings are useful when storing labels and annotations that require special handling to avoid overloading the storage output. Note: wildcards are not supported for those settings. The enrichment of `node` or `namespace` metadata can be individually disabled by setting `enabled: false`.
-    * `deployment`: If resource is `pod` and it is created from a `deployment`, by default the deployment name is added, this can be disabled by setting `deployment: false`.
-    * `cronjob`: If resource is `pod` and it is created from a `cronjob`, by default the cronjob name is added, this can be disabled by setting `cronjob: false`.
+    * `deployment`: If resource is `pod` and it is created from a `deployment`, the deployment name is added. This is disabled by default and can be enabled by setting `deployment: true`.
+    * `cronjob`: If resource is `pod` and it is created from a `cronjob`, the cronjob name is added. This is disabled by default and can be enabled by setting `cronjob: true`.
 
         Example:
 
@@ -122,8 +122,8 @@ The `add_kubernetes_metadata` processor has the following configuration settings
           include_annotations: ["nodeannotation1"]
           #labels.dedot: true
           #annotations.dedot: true
-        deployment: false
-        cronjob: false
+        deployment: true
+        cronjob: true
 ```
 
 `kube_config`

--- a/docs/reference/metricbeat/add-kubernetes-metadata.md
+++ b/docs/reference/metricbeat/add-kubernetes-metadata.md
@@ -102,8 +102,8 @@ The `add_kubernetes_metadata` processor has the following configuration settings
 :   (Optional) Specify filters and configuration for the extra metadata, that will be added to the event. Configuration parameters:
 
     * `node` or `namespace`: Specify labels and annotations filters for the extra metadata coming from node and namespace. By default all labels are included while annotations are not. To change default behaviour `include_labels`, `exclude_labels` and `include_annotations` can be defined. Those settings are useful when storing labels and annotations that require special handling to avoid overloading the storage output. Note: wildcards are not supported for those settings. The enrichment of `node` or `namespace` metadata can be individually disabled by setting `enabled: false`.
-    * `deployment`: If resource is `pod` and it is created from a `deployment`, by default the deployment name is added, this can be disabled by setting `deployment: false`.
-    * `cronjob`: If resource is `pod` and it is created from a `cronjob`, by default the cronjob name is added, this can be disabled by setting `cronjob: false`.
+    * `deployment`: If resource is `pod` and it is created from a `deployment`, the deployment name is added. This is disabled by default and can be enabled by setting `deployment: true`.
+    * `cronjob`: If resource is `pod` and it is created from a `cronjob`, the cronjob name is added. This is disabled by default and can be enabled by setting `cronjob: true`.
 
         Example:
 
@@ -119,8 +119,8 @@ The `add_kubernetes_metadata` processor has the following configuration settings
           include_annotations: ["nodeannotation1"]
           #labels.dedot: true
           #annotations.dedot: true
-        deployment: false
-        cronjob: false
+        deployment: true
+        cronjob: true
 ```
 
 `kube_config`

--- a/docs/reference/packetbeat/add-kubernetes-metadata.md
+++ b/docs/reference/packetbeat/add-kubernetes-metadata.md
@@ -105,8 +105,8 @@ The `add_kubernetes_metadata` processor has the following configuration settings
 :   (Optional) Specify filters and configuration for the extra metadata, that will be added to the event. Configuration parameters:
 
     * `node` or `namespace`: Specify labels and annotations filters for the extra metadata coming from node and namespace. By default all labels are included while annotations are not. To change default behaviour `include_labels`, `exclude_labels` and `include_annotations` can be defined. Those settings are useful when storing labels and annotations that require special handling to avoid overloading the storage output. Note: wildcards are not supported for those settings. The enrichment of `node` or `namespace` metadata can be individually disabled by setting `enabled: false`.
-    * `deployment`: If resource is `pod` and it is created from a `deployment`, by default the deployment name is added, this can be disabled by setting `deployment: false`.
-    * `cronjob`: If resource is `pod` and it is created from a `cronjob`, by default the cronjob name is added, this can be disabled by setting `cronjob: false`.
+    * `deployment`: If resource is `pod` and it is created from a `deployment`, the deployment name is added. This is disabled by default and can be enabled by setting `deployment: true`.
+    * `cronjob`: If resource is `pod` and it is created from a `cronjob`, the cronjob name is added. This is disabled by default and can be enabled by setting `cronjob: true`.
 
         Example:
 
@@ -122,8 +122,8 @@ The `add_kubernetes_metadata` processor has the following configuration settings
           include_annotations: ["nodeannotation1"]
           #labels.dedot: true
           #annotations.dedot: true
-        deployment: false
-        cronjob: false
+        deployment: true
+        cronjob: true
 ```
 
 `kube_config`

--- a/docs/reference/winlogbeat/add-kubernetes-metadata.md
+++ b/docs/reference/winlogbeat/add-kubernetes-metadata.md
@@ -105,8 +105,8 @@ The `add_kubernetes_metadata` processor has the following configuration settings
 :   (Optional) Specify filters and configuration for the extra metadata, that will be added to the event. Configuration parameters:
 
     * `node` or `namespace`: Specify labels and annotations filters for the extra metadata coming from node and namespace. By default all labels are included while annotations are not. To change default behaviour `include_labels`, `exclude_labels` and `include_annotations` can be defined. Those settings are useful when storing labels and annotations that require special handling to avoid overloading the storage output. Note: wildcards are not supported for those settings. The enrichment of `node` or `namespace` metadata can be individually disabled by setting `enabled: false`.
-    * `deployment`: If resource is `pod` and it is created from a `deployment`, by default the deployment name is added, this can be disabled by setting `deployment: false`.
-    * `cronjob`: If resource is `pod` and it is created from a `cronjob`, by default the cronjob name is added, this can be disabled by setting `cronjob: false`.
+    * `deployment`: If resource is `pod` and it is created from a `deployment`, the deployment name is added. This is disabled by default and can be enabled by setting `deployment: true`.
+    * `cronjob`: If resource is `pod` and it is created from a `cronjob`, the cronjob name is added. This is disabled by default and can be enabled by setting `cronjob: true`.
 
         Example:
 
@@ -122,8 +122,8 @@ The `add_kubernetes_metadata` processor has the following configuration settings
           include_annotations: ["nodeannotation1"]
           #labels.dedot: true
           #annotations.dedot: true
-        deployment: false
-        cronjob: false
+        deployment: true
+        cronjob: true
 ```
 
 `kube_config`


### PR DESCRIPTION
## Proposed commit message

Fix add_resource_metadata docs: deployment and cronjob default to false

Docs for `add_resource_metadata.deployment` and `add_resource_metadata.cronjob` still say these enrichments are enabled by default. They have been disabled by default since 8.11.0.

**WHAT**

Correct the described defaults in the `add_kubernetes_metadata` reference docs for all six Beats. Update examples to show `deployment: true` / `cronjob: true` (how to enable enrichment).

Docs only; no behavior change.

**WHY**

The defaults flipped from `true` to `false` in elastic/elastic-agent-autodiscover#62 (8.11.0). The docs were never updated.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~ — documentation only
- [x] I have made corresponding changes to the documentation
- [ ] ~~I have made corresponding change to the default configuration files~~ — no behavior or config change
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~ — documentation only
- [ ] ~~I have added an entry in `./changelog/fragments`~~ — documentation only

## Related issues

- Supersedes https://github.com/elastic/beats/pull/52486


Made with [Cursor](https://cursor.com)