### PR TITLE
filebeat: correct the outdated README description and doc links

### DIFF
--- a/filebeat/README.md
+++ b/filebeat/README.md
@@ -1,19 +1,20 @@
 # Filebeat
 
-Filebeat is an open source file harvester, mostly used to fetch log files and feed them into Logstash.
-Together with the libbeat lumberjack output is a replacement for [logstash-forwarder](https://github.com/elastic/logstash-forwarder).
+Filebeat is an open source shipper for logs and other event data.
+It reads from files, journals, network protocols, message queues, and cloud service APIs.
+It then sends the events to Elasticsearch, Logstash, Kafka, Redis, or a file.
 
 To learn more about Filebeat, check out https://www.elastic.co/beats/filebeat.
 
 
 ## Quick start
 
-Please follow the [quick start](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-installation-configuration.html)
+Please follow the [quick start](https://www.elastic.co/docs/reference/beats/filebeat/filebeat-installation-configuration)
 guide from the docs.
 
 ## Documentation
 
-Please visit [elastic.co](https://www.elastic.co/guide/en/beats/filebeat/current/index.html)
+Please visit [elastic.co](https://www.elastic.co/docs/reference/beats/filebeat)
  for the documentation.
 
 


### PR DESCRIPTION
## Proposed commit message

```
filebeat: correct the outdated README description and doc links


Filebeat has about 40 inputs and most of them do not read files.
Elasticsearch is the default output.

The documentation links now point to elastic.co/docs. The old /guide/
URLs redirect there with a 301.
```

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.~~
- [ ] ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).~~

## Disruptive User Impact

None.
