### PR TITLE
filebeat: Only start the registrar when needed instead of always

### DIFF
--- a/filebeat/beater/channels.go
+++ b/filebeat/beater/channels.go
@@ -24,12 +24,16 @@ import (
 	"github.com/elastic/beats/v7/filebeat/registrar"
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/publisher/pipetool"
+	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/monitoring"
 )
 
 type registrarLogger struct {
-	done chan struct{}
-	ch   chan<- []file.State
+	log       *logp.Logger
+	done      chan struct{}
+	closeOnce sync.Once
+	start     func() error
+	ch        chan<- []file.State
 }
 
 type finishedLogger struct {
@@ -56,15 +60,29 @@ type countingClientListener struct {
 	wgEvents *eventCounter
 }
 
-func newRegistrarLogger(reg *registrar.Registrar) *registrarLogger {
+func newRegistrarLogger(reg *registrar.Registrar, log *logp.Logger) *registrarLogger {
 	return &registrarLogger{
-		done: make(chan struct{}),
-		ch:   reg.Channel,
+		log:   log,
+		done:  make(chan struct{}),
+		start: reg.Start,
+		ch:    reg.Channel,
 	}
 }
 
-func (l *registrarLogger) Close() { close(l.done) }
+func (l *registrarLogger) Close() { l.closeOnce.Do(func() { close(l.done) }) }
 func (l *registrarLogger) Published(states []file.State) {
+	select {
+	case <-l.done:
+		l.ch = nil
+		return
+	default:
+	}
+
+	if err := l.start(); err != nil {
+		l.log.Errorf("Could not start registrar: %v; dropping file state updates", err)
+		l.Close()
+	}
+
 	select {
 	case <-l.done:
 		// set ch to nil, so no more events will be send after channel close signal

--- a/filebeat/beater/filebeat.go
+++ b/filebeat/beater/filebeat.go
@@ -395,7 +395,7 @@ func (fb *Filebeat) Run(b *beat.Beat) error {
 	}
 
 	// Make sure all events that were published in
-	registrarChannel := newRegistrarLogger(registrar)
+	registrarChannel := newRegistrarLogger(registrar, fb.logger)
 
 	// setup event counting for startup and a global common ACKer, such that all events will be
 	// routed to the reigstrar after they've been ACKed.
@@ -472,13 +472,13 @@ func (fb *Filebeat) Run(b *beat.Beat) error {
 	// The current order is: registrar, publisher, spooler, crawler
 	// That means, crawler is stopped first.
 
-	// Start the registrar
-	err = registrar.Start()
-	if err != nil {
-		return fmt.Errorf("Could not start registrar: %w", err) //nolint:staticcheck //Keep old behavior
-	}
-
-	// Stopping registrar will write last state
+	// The registrar is started by the first log-family input to be created (see
+	// input.RunnerFactory.Create), because those inputs are the only source of
+	// the states it persists. When configured with none of them (eg. filestream),
+	// never starts it and never scans the registry for state that cannot arrive.
+	//
+	// Stopping registrar will write last state in cases where a registrar was actually
+	// started. When nothing is started this is a no-op.
 	defer registrar.Stop()
 
 	// Stopping publisher (might potentially drop items)

--- a/filebeat/input/runnerfactory.go
+++ b/filebeat/input/runnerfactory.go
@@ -52,6 +52,10 @@ func (r *RunnerFactory) Create(
 	pipeline beat.PipelineConnector,
 	c *conf.C,
 ) (cfgfile.Runner, error) {
+	if err := r.registrar.Start(); err != nil {
+		return nil, err
+	}
+
 	connector := r.outlet(pipeline)
 	p, err := New(c, connector, r.beatDone, r.info, r.registrar.GetStates())
 	if err != nil {

--- a/filebeat/registrar/registrar.go
+++ b/filebeat/registrar/registrar.go
@@ -42,6 +42,13 @@ type Registrar struct {
 	done chan struct{}
 	wg   sync.WaitGroup
 
+	// he first log-family input to be created can start the registrar
+	// without knowing whether another already did.
+	startOnce sync.Once
+	// started reports whether startOnce ran Run rather than being claimed by
+	// Stop, which is what tells Stop whether anything will close the store.
+	started bool
+
 	// state storage
 	states       *file.States      // Map with all file paths inside and the corresponding state
 	store        *statestore.Store // Store keeps states in memory and on disk
@@ -105,18 +112,25 @@ func (r *Registrar) loadStates() error {
 	return nil
 }
 
+// Start loads the previous log file locations and runs the registrar. It is
+// called when the first input that produces file.State values is created, and
+// is safe to call any number of times: only the first call does anything.
 func (r *Registrar) Start() error {
-	// Load the previous log file locations now, for use in input
-	err := r.loadStates()
-	if err != nil {
-		return fmt.Errorf("error loading state: %w", err)
-	}
+	var err error
+	r.startOnce.Do(func() {
+		// Load the previous log file locations now, for use in input
+		if err = r.loadStates(); err != nil {
+			err = fmt.Errorf("error loading state: %w", err)
+			return
+		}
 
-	r.wg.Go(func() {
-		r.Run()
+		r.started = true
+		r.wg.Go(func() {
+			r.Run()
+		})
 	})
 
-	return nil
+	return err
 }
 
 // Stop stops the registry. It waits until Run function finished.
@@ -124,8 +138,18 @@ func (r *Registrar) Stop() {
 	r.log.Info("Stopping Registrar")
 	defer r.log.Info("Registrar stopped")
 
+	// Claim startOnce so an input created concurrently with shutdown cannot
+	// start a registrar after this point.
+	r.startOnce.Do(func() {})
+
 	close(r.done)
 	r.wg.Wait()
+
+	if !r.started {
+		if err := r.store.Close(); err != nil {
+			r.log.Errorf("Error closing the registry store: %v", err)
+		}
+	}
 }
 
 func (r *Registrar) Run() {

--- a/filebeat/registrar/registrar_lazy_test.go
+++ b/filebeat/registrar/registrar_lazy_test.go
@@ -1,0 +1,135 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package registrar
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/beats/v7/filebeat/input/file"
+	"github.com/elastic/beats/v7/libbeat/statestore"
+	"github.com/elastic/beats/v7/libbeat/statestore/storetest"
+	"github.com/elastic/beats/v7/libbeat/tests/resources"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
+)
+
+// TestRegistrarNotStarted covers the Beat that configures no log-family input —
+// filestream only, say. Nothing calls Start, so the registrar must cost nothing:
+// no goroutine, no registry scan, and no statestore handle left open once the
+// Beat shuts down.
+func TestRegistrarNotStarted(t *testing.T) {
+	goroutines := resources.NewGoroutinesChecker()
+
+	memBackend, r := newLazyTestRegistrar(t, file.State{Id: "on-disk", Source: "/a.log", TTL: -1})
+
+	assert.Empty(t, r.GetStates(),
+		"a registrar that was never started must not have scanned the registry")
+
+	r.Stop()
+
+	assert.True(t, memBackend.Stores[testStoreName].IsClosed(),
+		"Stop must close the store when Run never ran to close it")
+	requireNoLeakedGoroutines(t, goroutines)
+}
+
+// TestRegistrarStartIsIdempotent covers the trigger: every log-family input
+// calls Start as it is created, and only the first may run the registrar.
+func TestRegistrarStartIsIdempotent(t *testing.T) {
+	goroutines := resources.NewGoroutinesChecker()
+
+	memBackend, r := newLazyTestRegistrar(t, file.State{Id: "on-disk", Source: "/a.log", TTL: -1})
+
+	var wg sync.WaitGroup
+	for range 8 {
+		wg.Go(func() { assert.NoError(t, r.Start()) })
+	}
+	wg.Wait()
+
+	assert.Len(t, r.GetStates(), 1, "the registry must be loaded exactly once")
+
+	r.Stop()
+
+	assert.True(t, memBackend.Stores[testStoreName].IsClosed(), "Run must close the store")
+	requireNoLeakedGoroutines(t, goroutines)
+}
+
+// TestRegistrarStartAfterStop pins that Stop claims the start, so an input
+// created concurrently with shutdown cannot leave a registrar running behind a
+// Stop that has already returned.
+func TestRegistrarStartAfterStop(t *testing.T) {
+	goroutines := resources.NewGoroutinesChecker()
+
+	_, r := newLazyTestRegistrar(t)
+	r.Stop()
+
+	require.NoError(t, r.Start(), "a Start after Stop must be a no-op, not an error")
+	assert.Empty(t, r.GetStates(), "a Start after Stop must not load the registry")
+
+	requireNoLeakedGoroutines(t, goroutines)
+}
+
+// TestRegistrarStartedStillPersists is the other half of TestRegistrarNotStarted:
+// once an input starts it, the registrar behaves exactly as it did when it was
+// started unconditionally.
+func TestRegistrarStartedStillPersists(t *testing.T) {
+	memBackend, r := newLazyTestRegistrar(t)
+
+	require.NoError(t, r.Start())
+
+	state := file.State{Id: "published", Source: "/b.log", TTL: -1}
+	r.Channel <- []file.State{state}
+	r.Stop()
+
+	assert.Contains(t, memBackend.Stores[testStoreName].Table, fileStatePrefix+state.Id,
+		"a started registrar must persist the states it is sent")
+}
+
+// requireNoLeakedGoroutines fails the test if the goroutine count does not
+// return to what it was before, which is the whole point of not starting a
+// registrar nothing needs.
+func requireNoLeakedGoroutines(t *testing.T, c *resources.GoroutinesChecker) {
+	t.Helper()
+
+	_, err := c.WaitUntilOriginalCount()
+	require.NoError(t, err, "the registrar must not leave a goroutine behind")
+}
+
+// newLazyTestRegistrar returns a registrar over a memory-backed store
+// pre-populated with states, so a test can tell whether the registry was
+// scanned. The registrar is not started.
+func newLazyTestRegistrar(t *testing.T, states ...file.State) (*storetest.MemoryStore, *Registrar) {
+	t.Helper()
+
+	memBackend := storetest.NewMemoryStoreBackend()
+	stateStore := &testStateStore{registry: statestore.NewRegistry(memBackend)}
+
+	if len(states) > 0 {
+		store, err := stateStore.StoreFor("")
+		require.NoError(t, err)
+		require.NoError(t, writeStates(store, states))
+		store.Close()
+	}
+
+	r, err := New(stateStore, &spyLogger{}, time.Second, logptest.NewTestingLogger(t, ""))
+	require.NoError(t, err)
+	return memBackend, r
+}


### PR DESCRIPTION
## Proposed commit message

filebeat: start the registrar only when an input needs it

The registrar was nonetheless started unconditionally at `filebeat/beater/filebeat.go:476`, so a beat configured with no log-family input scanned the whole registry at startup for state that cannot arrive, held a statestore handle open, and left a goroutine parked on `Run`'s select for the life of the process. That is per beat, and elastic-agent runs one filebeatreceiver per input stream.

`Registrar.Start` is now idempotent and is called from `input.RunnerFactory.Create`, the factory for the log input family and the only producer of those states. Creating an input is the one trigger that covers static configuration, config reload and autodiscovery alike, unlike inspecting configuration at startup.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

None

## Related issues

- Closes #52355