### PR TITLE
x-pack/osquerybeat: Avoid dependency on glibc 2.28

### DIFF
--- a/changelog/fragments/1786952482-osquery-extension-glibc-228.yaml
+++ b/changelog/fragments/1786952482-osquery-extension-glibc-228.yaml
@@ -1,0 +1,48 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: Restore osquery-extension compatibility with Linux systems on glibc before 2.28.
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+description: |
+  Building SQLite with SQLITE_DISABLE_LFS on 64-bit Linux avoids a dependeny
+  on glibc 2.28. Functionality is unchanged but compatibility is restored for
+  glibc 2.27 systems, such as Ubuntu 18.04.
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: osquerybeat
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+# issue: https://github.com/owner/repo/1234

--- a/changelog/fragments/1786952482-osquery-extension-glibc-228.yaml
+++ b/changelog/fragments/1786952482-osquery-extension-glibc-228.yaml
@@ -19,7 +19,7 @@ summary: Restore osquery-extension compatibility with Linux systems on glibc bef
 # Long description; in case the summary is not enough to describe the change
 # this field accommodate a description without length limits.
 description: |
-  Building SQLite with SQLITE_DISABLE_LFS on 64-bit Linux avoids a dependeny
+  Building SQLite with SQLITE_DISABLE_LFS on 64-bit Linux avoids a dependency
   on glibc 2.28. Functionality is unchanged but compatibility is restored for
   glibc 2.27 systems, such as Ubuntu 18.04.
 

--- a/x-pack/osquerybeat/magefile.go
+++ b/x-pack/osquerybeat/magefile.go
@@ -213,6 +213,7 @@ func BuildExt() error {
 	params.InputFiles = []string{"./ext/osquery-extension/."}
 	params.Name = "osquery-extension"
 	params.CGO = true
+	disableSqliteLFS(params.Env)
 	err := devtools.Build(params)
 	if err != nil {
 		return err
@@ -226,6 +227,30 @@ func BuildExt() error {
 		}
 	}
 	return nil
+}
+
+// disableSqliteLFS adds -DSQLITE_DISABLE_LFS to CGO_CFLAGS on 64-bit Linux.
+// The SQLite amalgamation (github.com/mattn/go-sqlite3, used by the
+// osquery-extension) enables POSIX large file support (_FILE_OFFSET_BITS=64),
+// which makes glibc >= 2.28 headers redirect fcntl calls to the
+// fcntl64@GLIBC_2.28 symbol, raising the minimum glibc required at runtime
+// and breaking supported distributions with older glibc, such as Ubuntu
+// 18.04 (glibc 2.27). On 64-bit platforms off_t is 64 bits regardless, so
+// disabling LFS only removes the fcntl64 reference; it does not limit the
+// SQLite database file size. It must not be applied to 32-bit platforms,
+// where it would cap SQLite files at 2 GiB. In builds that compile no SQLite
+// C code (osquerybeat itself) the macro is defined but unused.
+func disableSqliteLFS(env map[string]string) {
+	if devtools.GOOS != "linux" || (devtools.GOARCH != "amd64" && devtools.GOARCH != "arm64") {
+		return
+	}
+	// Setting CGO_CFLAGS discards cgo's default "-O2 -g", so preserve any
+	// existing flags or restate the defaults.
+	cflags := os.Getenv("CGO_CFLAGS")
+	if cflags == "" {
+		cflags = "-O2 -g"
+	}
+	env["CGO_CFLAGS"] = cflags + " -DSQLITE_DISABLE_LFS"
 }
 
 // Clean cleans all generated files and build artifacts.
@@ -315,7 +340,9 @@ func GolangCrossBuild() error {
 		return err
 	}
 
-	return devtools.GolangCrossBuild(devtools.DefaultGolangCrossBuildArgs())
+	args := devtools.DefaultGolangCrossBuildArgs()
+	disableSqliteLFS(args.Env)
+	return devtools.GolangCrossBuild(args)
 }
 
 // CrossBuild cross-builds the beat for all target platforms.


### PR DESCRIPTION
## Proposed commit message

```
x-pack/osquerybeat: Avoid dependency on glibc 2.28

For browser history tables support (#47117) SQLite C code (via
mattn/go-sqlite3) is compiled into into osquery-extension.

SQLite enables POSIX large file support by defining
_FILE_OFFSET_BITS=64, which on glibc >= 2.28 build systems makes the
fcntl.h headers redirect fcntl calls to the fcntl64@GLIBC_2.28 symbol.

The Linux crossbuild image is Debian 11 (glibc 2.31), so the released
extension requires glibc 2.28 at runtime and fails to start on supported
distributions with older glibc, such as Ubuntu 18.04 (glibc 2.27).

Pass -DSQLITE_DISABLE_LFS in CGO_CFLAGS when building the extension for
64-bit Linux. SQLITE_DISABLE_LFS is a documented SQLite compile option
that suppresses the large file support defines and with them the fcntl64
reference. On 64-bit platforms off_t is 64 bits regardless, so the flag
causes no functional difference and does not limit readable SQLite
database file sizes; its remaining effects (O_LARGEFILE forced to 0, an
EOVERFLOW error mapping) are no-ops on 64-bit ABIs.

The flag is not applied to 32-bit platforms, where it would cap SQLite
files at 2 GiB. osquerybeat ships no 32-bit Linux targets.
```

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

None.

## How to test this PR locally

Cross-build the extension for Linux and check its glibc symbol version requirements:

```sh
cd x-pack/osquerybeat
PLATFORMS=linux/amd64 mage crossBuildExt
readelf -V ext/osquery-extension/build/golang-crossbuild/osquery-extension-linux-amd64 \
  | grep -oE 'GLIBC_[0-9.]+' | sort -uV
```

Before this change the list ends at `GLIBC_2.28` and the binary contains an undefined `fcntl64` symbol (`objdump -T ... | grep fcntl64`). With this change the list ends at `GLIBC_2.14` and there is no `fcntl64` reference. The binary starts successfully on Ubuntu 18.04.

The browser history tables still work with the flag:

```sh
cd x-pack/osquerybeat
CGO_CFLAGS="-O2 -g -DSQLITE_DISABLE_LFS" CGO_ENABLED=1 \
  go test ./ext/osquery-extension/pkg/browserhistory/
```

## Related issues

- Relates #47117 (Introduced the SQLite dependency in osquery-extension)
- Relates #34921 (Moved crossbuilding to Debian 10)
- Relates #41402 (Moved crossbuilding to Debian 11)