### PR TITLE
[Heartbeat] Add allowScripts to generated browser project package.json

### DIFF
--- a/changelog/fragments/1786990556-heartbeat-project-allow-scripts.yaml
+++ b/changelog/fragments/1786990556-heartbeat-project-allow-scripts.yaml
@@ -1,0 +1,45 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: Add allowScripts to browser project package.json for npm 11.16+/12
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# description:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: heartbeat
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: https://github.com/elastic/elastic-agent/issues/16225

--- a/x-pack/heartbeat/monitors/browser/source/project.go
+++ b/x-pack/heartbeat/monitors/browser/source/project.go
@@ -103,6 +103,25 @@ type PackageJSON struct {
 	Name         string   `json:"name"`
 	Private      bool     `json:"private"`
 	Dependencies mapstr.M `json:"dependencies"`
+	AllowScripts mapstr.M `json:"allowScripts,omitempty"`
+}
+
+func newProjectPackageJSON(symlinkPath string) PackageJSON {
+	return PackageJSON{
+		Name:    "project-journey",
+		Private: true,
+		Dependencies: mapstr.M{
+			"@elastic/synthetics": symlinkPath,
+		},
+		// npm 11.16+ warns and npm 12 blocks unlisted install/prepare scripts.
+		AllowScripts: mapstr.M{
+			"@elastic/synthetics": true,
+			symlinkPath:           true,
+			"esbuild":             true,
+			"playwright-chromium": true,
+			"sharp":               true,
+		},
+	}
 }
 
 // setupProjectDir sets ups the required package.json file and
@@ -120,13 +139,7 @@ func setupProjectDir(workdir string) error {
 
 	globalPath := strings.Replace(fname, "bin/elastic-synthetics", "lib/node_modules/@elastic/synthetics", 1)
 	symlinkPath := fmt.Sprintf("file:%s", globalPath)
-	pkgJson := PackageJSON{
-		Name:    "project-journey",
-		Private: true,
-		Dependencies: mapstr.M{
-			"@elastic/synthetics": symlinkPath,
-		},
-	}
+	pkgJson := newProjectPackageJSON(symlinkPath)
 	pkgJsonContent, err := json.MarshalIndent(pkgJson, "", "  ")
 	if err != nil {
 		return err

--- a/x-pack/heartbeat/monitors/browser/source/project_package_json_test.go
+++ b/x-pack/heartbeat/monitors/browser/source/project_package_json_test.go
@@ -1,0 +1,40 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+//go:build linux || darwin || synthetics
+
+package source
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewProjectPackageJSONIncludesAllowScripts(t *testing.T) {
+	symlinkPath := "file:/usr/share/elastic-agent/.node/node/lib/node_modules/@elastic/synthetics"
+	pkg := newProjectPackageJSON(symlinkPath)
+
+	raw, err := json.Marshal(pkg)
+	require.NoError(t, err)
+
+	var decoded map[string]interface{}
+	require.NoError(t, json.Unmarshal(raw, &decoded))
+
+	assert.Equal(t, "project-journey", decoded["name"])
+	assert.Equal(t, true, decoded["private"])
+
+	deps, ok := decoded["dependencies"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, symlinkPath, deps["@elastic/synthetics"])
+
+	allow, ok := decoded["allowScripts"].(map[string]interface{})
+	require.True(t, ok, "package.json must include allowScripts for npm >= 11.16")
+	assert.Equal(t, true, allow["@elastic/synthetics"])
+	assert.Equal(t, true, allow[symlinkPath])
+	assert.Equal(t, true, allow["esbuild"])
+	assert.Equal(t, true, allow["playwright-chromium"])
+	assert.Equal(t, true, allow["sharp"])
+}


### PR DESCRIPTION
## Proposed commit message

Heartbeat writes a temporary `package.json` to link the globally baked `@elastic/synthetics` package. npm 11.16+ warns, and npm 12 blocks, install/prepare scripts that are not listed in `allowScripts`. Without that field, synthetics journey setup on `elastic-agent-complete` can fail after the npm bump.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

None. Journey setup continues to link the baked-in synthetics package; install scripts that already ran are now explicitly allowed.

## How to test this PR locally

```bash
go test -count=1 -run TestNewProjectPackageJSONIncludesAllowScripts ./x-pack/heartbeat/monitors/browser/source
```

Generated `package.json` should include:

```json
"allowScripts": {
  "@elastic/synthetics": true,
  "file:<global-synthetics-path>": true,
  "esbuild": true,
  "playwright-chromium": true,
  "sharp": true
}
```

## Related issues

- Relates https://github.com/elastic/elastic-agent/issues/16225

## Use cases

Fleet/private-location browser monitors on `elastic-agent-complete` after npm 11.17 / npm 12.
