### PR TITLE
packetbeat/npcap: log installer diagnostics on failure

### DIFF
--- a/changelog/fragments/1787010547-npcap-log-installer-diagnostics.yaml
+++ b/changelog/fragments/1787010547-npcap-log-installer-diagnostics.yaml
@@ -1,0 +1,3 @@
+kind: enhancement
+summary: Log Npcap installer diagnostic files on installation failure.
+component: packetbeat

--- a/packetbeat/npcap/npcap.go
+++ b/packetbeat/npcap/npcap.go
@@ -23,9 +23,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 	"strings"
+	"time"
 
 	"github.com/google/gopacket/pcap"
 	"golang.org/x/mod/semver"
@@ -84,6 +87,7 @@ func install(ctx context.Context, log *logp.Logger, path, dst string, compat boo
 	cmd.Stdout = &outBuf
 	cmd.Stderr = &errBuf
 
+	before := time.Now()
 	err := cmd.Start()
 	if err != nil {
 		return fmt.Errorf("npcap: failed to start Npcap installer: %w", err)
@@ -95,10 +99,42 @@ func install(ctx context.Context, log *logp.Logger, path, dst string, compat boo
 	}
 	if err != nil {
 		log.Error(&errBuf)
+		logInstallDiagnostics(log, dst, before)
 		return fmt.Errorf("npcap: failed to install Npcap: %w", err)
 	}
 
 	return nil
+}
+
+// logInstallDiagnostics reads the Npcap installer log files and logs their
+// contents. The installer writes diagnostics to files in the install directory
+// rather than to stdout or stderr.
+// See https://npcap.com/guide/npcap-users-guide.html#npcap-qa.
+func logInstallDiagnostics(log *logp.Logger, dst string, since time.Time) {
+	if dst == "" {
+		dst = `C:\Program Files\Npcap`
+	}
+	// install.log records general installation activity.
+	// NPFInstall.log records driver installation commands via NPFInstall.exe.
+	for _, name := range []string{"install.log", "NPFInstall.log"} {
+		path := filepath.Join(dst, name)
+		fi, err := os.Stat(path)
+		if err != nil {
+			if !errors.Is(err, os.ErrNotExist) {
+				log.Warnf("npcap: could not stat %s: %v", path, err)
+			}
+			continue
+		}
+		if fi.ModTime().Before(since) {
+			continue
+		}
+		b, err := os.ReadFile(path)
+		if err != nil {
+			log.Warnf("npcap: could not read %s: %v", path, err)
+			continue
+		}
+		log.Errorf("npcap %s:\n%s", name, b)
+	}
 }
 
 // LoadNpcap loads the Npcap/WinPcap DLL into the current process. It is


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message
```
packetbeat/npcap: log installer diagnostics on failure

When the Npcap installer exits with a non-zero status, log the
contents of install.log and NPFInstall.log from the install
directory. The Npcap NSIS installer writes diagnostics to these
files rather than to stdout or stderr, so without this change the
only available signal is the exit code. The log file paths are
documented at https://npcap.com/guide/npcap-users-guide.html#npcap-qa.
```

> [!NOTE]
> Enhancement, but back-porting for benefits in debugging support cases.

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
-

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
