### PR TITLE
Upgrade osquery to 5.23.1

### DIFF
--- a/changelog/fragments/1786968000-upgrade-osquery-5.23.1.yaml
+++ b/changelog/fragments/1786968000-upgrade-osquery-5.23.1.yaml
@@ -1,0 +1,7 @@
+kind: upgrade
+
+summary: upgrade osquery version to 5.23.1
+
+description: osquery 5.23.1 fixes memory-safety issues in Windows process and Authenticode tables and Linux process file events, and hardens temporary carve directory permissions.
+
+component: osquerybeat

--- a/x-pack/osquerybeat/README.md
+++ b/x-pack/osquerybeat/README.md
@@ -90,6 +90,38 @@ To refresh those sources on demand:
 JUMPLISTS_REFRESH_SOURCES=true mage generate
 ```
 
+### Upgrade the bundled Osquery version
+
+The bundled release metadata is in `internal/distro/distro.go`. To upgrade it:
+
+```bash
+mage updateOsquery
+```
+
+The target selects the latest stable GitHub release, updates the version and
+official artifact checksums, and creates a changelog fragment. Set
+`OSQUERY_VERSION` to select a specific release:
+
+```bash
+OSQUERY_VERSION=5.23.1 mage updateOsquery
+```
+
+The target updates the Osquery version and all artifact checksums used by the
+branch.
+
+Review the generated fragment description, then verify the result:
+
+```bash
+go test ./internal/distro ./scripts/mage ./scripts/update_osquery
+mage fetchOsquerydForTesting
+```
+
+This verifies the current host artifact. The packaging jobs download and
+verify the complete supported platform matrix.
+
+Then run `mage updateOsqueryManager` in the integrations repository. Set
+`BEATS_PATH` to this checkout when the integrations schemas need unreleased
+osquerybeat extension specs.
 
 ### Cleanup
 

--- a/x-pack/osquerybeat/README.md
+++ b/x-pack/osquerybeat/README.md
@@ -92,7 +92,7 @@ JUMPLISTS_REFRESH_SOURCES=true mage generate
 
 ### Upgrade the bundled Osquery version
 
-The bundled release metadata is in `internal/distro/distro.go`. To upgrade it:
+The bundled release metadata is in `internal/distro/distro.json`. To upgrade it:
 
 ```bash
 mage updateOsquery

--- a/x-pack/osquerybeat/internal/distro/distro.go
+++ b/x-pack/osquerybeat/internal/distro/distro.go
@@ -42,15 +42,8 @@ const (
 
 	osqueryLensesDir = "lenses"
 
-	osqueryVersion = "5.23.1"
-	osqueryPkgExt  = ".pkg"
-	osqueryZipExt  = ".zip"
-
-	osqueryDistroDarwinSHA256        = "9f40cea0358759ab2ee871c577055657e3cc2c7cbe5c1247f764245941178aa6"
-	osqueryDistroLinuxSHA256         = "0f37a478a1dbda24b67c81551e32d734b392c5a2f5deb156bf1c41ca204cfa67"
-	osqueryDistroLinuxARMSHA256      = "9ae763820166f75f19970b5147b1930a308865a923ab127f4b8bbaea7b69962a"
-	osqueryDistroWindowsARMZipSHA256 = "0913d05cc3fc92dd9253c945caacde10a776408f267cc1cc853a05de24dba900"
-	osqueryDistroWindowsX86ZipSHA256 = "7bd411050ef6b5aae1b23956aec0dc5ce6e800c5656f0cd463ac70a6e1bdf30b"
+	osqueryPkgExt = ".pkg"
+	osqueryZipExt = ".zip"
 )
 
 type OSArch struct {
@@ -196,15 +189,6 @@ func (s Spec) URL(osname string) string {
 		return osqueryDownloadGithubBaseURL + "/" + osqueryVersion + "/" + s.DistroFilename()
 	}
 	return osqueryDownloadBaseURL + "/" + osname + "/" + s.DistroFilename()
-}
-
-var specs = map[OSArch]Spec{
-	{"linux", "amd64"}:   {"_1.linux_x86_64.tar.gz", osqueryDistroLinuxSHA256, true},
-	{"linux", "arm64"}:   {"_1.linux_aarch64.tar.gz", osqueryDistroLinuxARMSHA256, true},
-	{"darwin", "amd64"}:  {osqueryPkgExt, osqueryDistroDarwinSHA256, true},
-	{"darwin", "arm64"}:  {osqueryPkgExt, osqueryDistroDarwinSHA256, true},
-	{"windows", "amd64"}: {".windows_x86_64.zip", osqueryDistroWindowsX86ZipSHA256, true},
-	{"windows", "arm64"}: {osqueryZipExt, osqueryDistroWindowsARMZipSHA256, true},
 }
 
 func GetSpec(osarch OSArch) (spec Spec, err error) {

--- a/x-pack/osquerybeat/internal/distro/distro.go
+++ b/x-pack/osquerybeat/internal/distro/distro.go
@@ -21,7 +21,6 @@ var (
 	DataCacheDir   = filepath.Join(DataDir, "cache")
 )
 
-// Windows ARM URL: https://github.com/osquery/osquery/releases/download/{{osqueryVersion}}/osquery-{{osqueryVersion}}.windows_arm64.zip
 const (
 	osqueryDownloadBaseURL       = "https://pkg.osquery.io"
 	osqueryDownloadGithubBaseURL = "https://github.com/osquery/osquery/releases/download"
@@ -43,15 +42,15 @@ const (
 
 	osqueryLensesDir = "lenses"
 
-	osqueryVersion = "5.23.0"
+	osqueryVersion = "5.23.1"
 	osqueryPkgExt  = ".pkg"
 	osqueryZipExt  = ".zip"
 
-	osqueryDistroDarwinSHA256        = "2621179c334a6482fa822732f121409bbccc36784db18f576e2965dfc4f1845d"
-	osqueryDistroLinuxSHA256         = "0045739a68475760f7bc26ca493afda71cc02a8e4d29984717742d3e4c099296"
-	osqueryDistroLinuxARMSHA256      = "d9d4e5f6eeabda4949ae0ba6a8db424c789ec60ffef99269f479ff4b73f46e33"
-	osqueryDistroWindowsARMZipSHA256 = "92a820a39c12f7516040b62dc8e8546469c821f505eed0b7ff1eb7e43cc4b018"
-	osqueryDistroWindowsX86ZipSHA256 = "5ddb8e1c23fd870838ef4ff47c0d2e5a080f22a6944fc4870d726e7b20e962a4"
+	osqueryDistroDarwinSHA256        = "9f40cea0358759ab2ee871c577055657e3cc2c7cbe5c1247f764245941178aa6"
+	osqueryDistroLinuxSHA256         = "0f37a478a1dbda24b67c81551e32d734b392c5a2f5deb156bf1c41ca204cfa67"
+	osqueryDistroLinuxARMSHA256      = "9ae763820166f75f19970b5147b1930a308865a923ab127f4b8bbaea7b69962a"
+	osqueryDistroWindowsARMZipSHA256 = "0913d05cc3fc92dd9253c945caacde10a776408f267cc1cc853a05de24dba900"
+	osqueryDistroWindowsX86ZipSHA256 = "7bd411050ef6b5aae1b23956aec0dc5ce6e800c5656f0cd463ac70a6e1bdf30b"
 )
 
 type OSArch struct {
@@ -168,7 +167,7 @@ type Spec struct {
 
 func (s Spec) DistroFilename() string {
 	if s.PackSuffix == osqueryZipExt {
-		// Currently the only file whose source is a zip is the Windows ARM64 one
+		// The short suffix is used by the Windows ARM64 archive.
 		return osqueryName + "-" + osqueryVersion + ".windows_arm64" + s.PackSuffix
 	}
 	return osqueryName + "-" + osqueryVersion + s.PackSuffix

--- a/x-pack/osquerybeat/internal/distro/distro.json
+++ b/x-pack/osquerybeat/internal/distro/distro.json
@@ -1,0 +1,10 @@
+{
+  "version": "5.23.1",
+  "checksums": {
+    "darwin": "9f40cea0358759ab2ee871c577055657e3cc2c7cbe5c1247f764245941178aa6",
+    "linux_amd64": "0f37a478a1dbda24b67c81551e32d734b392c5a2f5deb156bf1c41ca204cfa67",
+    "linux_arm64": "9ae763820166f75f19970b5147b1930a308865a923ab127f4b8bbaea7b69962a",
+    "windows_arm64": "0913d05cc3fc92dd9253c945caacde10a776408f267cc1cc853a05de24dba900",
+    "windows_amd64": "7bd411050ef6b5aae1b23956aec0dc5ce6e800c5656f0cd463ac70a6e1bdf30b"
+  }
+}

--- a/x-pack/osquerybeat/internal/distro/metadata.go
+++ b/x-pack/osquerybeat/internal/distro/metadata.go
@@ -1,0 +1,148 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package distro
+
+import (
+	"bytes"
+	"crypto/sha256"
+	_ "embed"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// distroJSON is the bundled Osquery version and official artifact checksums.
+// Update it with `mage updateOsquery`.
+//
+//go:embed distro.json
+var distroJSON []byte
+
+var (
+	osqueryVersion string
+	specs          map[OSArch]Spec
+)
+
+// Metadata is the bundled Osquery release version and artifact checksums.
+type Metadata struct {
+	Version   string    `json:"version"`
+	Checksums Checksums `json:"checksums"`
+}
+
+// Checksums holds SHA-256 digests of the official Osquery artifacts.
+type Checksums struct {
+	// Darwin is the SHA-256 of osquery-<ver>.pkg (shared by amd64 and arm64).
+	Darwin string `json:"darwin"`
+	// LinuxAMD64 is the SHA-256 of osquery-<ver>_1.linux_x86_64.tar.gz.
+	LinuxAMD64 string `json:"linux_amd64"`
+	// LinuxARM64 is the SHA-256 of osquery-<ver>_1.linux_aarch64.tar.gz.
+	LinuxARM64 string `json:"linux_arm64"`
+	// WindowsARM64 is the SHA-256 of osquery-<ver>.windows_arm64.zip.
+	WindowsARM64 string `json:"windows_arm64"`
+	// WindowsAMD64 is the SHA-256 of osquery-<ver>.windows_x86_64.zip.
+	WindowsAMD64 string `json:"windows_amd64"`
+}
+
+func init() {
+	meta, err := ParseMetadata(distroJSON)
+	if err != nil {
+		panic("invalid distro.json: " + err.Error())
+	}
+	osqueryVersion = meta.Version
+	specs = specsFromChecksums(meta.Checksums)
+}
+
+func specsFromChecksums(c Checksums) map[OSArch]Spec {
+	return map[OSArch]Spec{
+		{"linux", "amd64"}:   {"_1.linux_x86_64.tar.gz", c.LinuxAMD64, true},
+		{"linux", "arm64"}:   {"_1.linux_aarch64.tar.gz", c.LinuxARM64, true},
+		{"darwin", "amd64"}:  {osqueryPkgExt, c.Darwin, true},
+		{"darwin", "arm64"}:  {osqueryPkgExt, c.Darwin, true},
+		{"windows", "amd64"}: {".windows_x86_64.zip", c.WindowsAMD64, true},
+		{"windows", "arm64"}: {osqueryZipExt, c.WindowsARM64, true},
+	}
+}
+
+func (m Metadata) validate() error {
+	if strings.TrimSpace(m.Version) == "" {
+		return errors.New("version is empty")
+	}
+	for _, field := range []struct {
+		name  string
+		value string
+	}{
+		{"darwin", m.Checksums.Darwin},
+		{"linux_amd64", m.Checksums.LinuxAMD64},
+		{"linux_arm64", m.Checksums.LinuxARM64},
+		{"windows_arm64", m.Checksums.WindowsARM64},
+		{"windows_amd64", m.Checksums.WindowsAMD64},
+	} {
+		if err := validateSHA256(field.value); err != nil {
+			return fmt.Errorf("checksums.%s: %w", field.name, err)
+		}
+	}
+	return nil
+}
+
+func validateSHA256(s string) error {
+	decoded, err := hex.DecodeString(s)
+	if err != nil || len(decoded) != sha256.Size {
+		return fmt.Errorf("not a SHA-256 hex digest: %q", s)
+	}
+	return nil
+}
+
+// ParseMetadata decodes and validates bundled Osquery metadata.
+func ParseMetadata(b []byte) (Metadata, error) {
+	dec := json.NewDecoder(bytes.NewReader(b))
+	dec.DisallowUnknownFields()
+	var meta Metadata
+	if err := dec.Decode(&meta); err != nil {
+		return Metadata{}, err
+	}
+	if err := meta.validate(); err != nil {
+		return Metadata{}, err
+	}
+	return meta, nil
+}
+
+func encodeMetadata(meta Metadata) ([]byte, error) {
+	if err := meta.validate(); err != nil {
+		return nil, err
+	}
+	b, err := json.MarshalIndent(meta, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return append(b, '\n'), nil
+}
+
+// ReadMetadataFile loads bundled Osquery metadata from path.
+func ReadMetadataFile(path string) (Metadata, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return Metadata{}, err
+	}
+	return ParseMetadata(b)
+}
+
+// WriteMetadataFile writes canonical metadata JSON to path.
+// It returns whether the file contents changed.
+func WriteMetadataFile(path string, meta Metadata) (bool, error) {
+	encoded, err := encodeMetadata(meta)
+	if err != nil {
+		return false, err
+	}
+	existing, err := os.ReadFile(path)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return false, err
+	}
+	if bytes.Equal(existing, encoded) {
+		return false, nil
+	}
+	return true, os.WriteFile(path, encoded, 0o644)
+}

--- a/x-pack/osquerybeat/internal/distro/metadata_test.go
+++ b/x-pack/osquerybeat/internal/distro/metadata_test.go
@@ -1,0 +1,106 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package distro
+
+import (
+	"bytes"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEmbeddedMetadata(t *testing.T) {
+	assert.NotEmpty(t, OsquerydVersion(), "embedded osquery version should be set")
+
+	platforms := []OSArch{
+		{OS: "linux", Arch: "amd64"},
+		{OS: "linux", Arch: "arm64"},
+		{OS: "darwin", Arch: "amd64"},
+		{OS: "darwin", Arch: "arm64"},
+		{OS: "windows", Arch: "amd64"},
+		{OS: "windows", Arch: "arm64"},
+	}
+	for _, osarch := range platforms {
+		spec, err := GetSpec(osarch)
+		require.NoError(t, err, "missing spec for %s", osarch)
+		assert.Len(t, spec.SHA256Hash, 64, "checksum for %s should be a SHA-256 hex digest", osarch)
+		assert.NotEmpty(t, spec.PackSuffix, "pack suffix for %s should be set", osarch)
+	}
+
+	_, err := GetSpec(OSArch{OS: "plan9", Arch: "amd64"})
+	assert.ErrorIs(t, err, ErrUnsupportedOS, "unsupported platform should return ErrUnsupportedOS")
+}
+
+func TestEmbeddedMetadataIsCanonical(t *testing.T) {
+	meta, err := ParseMetadata(distroJSON)
+	require.NoError(t, err, "embedded distro.json must parse")
+
+	encoded, err := encodeMetadata(meta)
+	require.NoError(t, err, "embedded metadata must encode")
+
+	got := bytes.ReplaceAll(distroJSON, []byte("\r\n"), []byte("\n"))
+	assert.Equal(t, string(encoded), string(got), "distro.json should use canonical encoding")
+}
+
+func TestParseMetadata(t *testing.T) {
+	valid := testMetadata("1.0.0", strings.Repeat("a", 64))
+	validJSON, err := encodeMetadata(valid)
+	require.NoError(t, err, "valid metadata should encode")
+
+	tests := []struct {
+		name    string
+		raw     string
+		wantErr string
+	}{
+		{name: "valid", raw: string(validJSON)},
+		{name: "invalid json", raw: `{`, wantErr: "unexpected EOF"},
+		{name: "unknown field", raw: `{"version":"1.0.0","extra":true}`, wantErr: "unknown field"},
+		{name: "empty version", raw: `{"version":"","checksums":{"darwin":"` + strings.Repeat("a", 64) + `","linux_amd64":"` + strings.Repeat("a", 64) + `","linux_arm64":"` + strings.Repeat("a", 64) + `","windows_arm64":"` + strings.Repeat("a", 64) + `","windows_amd64":"` + strings.Repeat("a", 64) + `"}}`, wantErr: "version is empty"},
+		{name: "bad checksum", raw: `{"version":"1.0.0","checksums":{"darwin":"notahash","linux_amd64":"` + strings.Repeat("a", 64) + `","linux_arm64":"` + strings.Repeat("a", 64) + `","windows_arm64":"` + strings.Repeat("a", 64) + `","windows_amd64":"` + strings.Repeat("a", 64) + `"}}`, wantErr: "checksums.darwin"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ParseMetadata([]byte(tc.raw))
+			if tc.wantErr == "" {
+				assert.NoError(t, err, "valid metadata should parse")
+				return
+			}
+			assert.ErrorContains(t, err, tc.wantErr, "expected parse error")
+		})
+	}
+}
+
+func TestWriteMetadataFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "distro.json")
+	meta := testMetadata("1.0.0", strings.Repeat("a", 64))
+
+	changed, err := WriteMetadataFile(path, meta)
+	require.NoError(t, err, "first write should succeed")
+	assert.True(t, changed, "first write should create the file")
+
+	changed, err = WriteMetadataFile(path, meta)
+	require.NoError(t, err, "second write should succeed")
+	assert.False(t, changed, "second write of the same metadata should be a no-op")
+
+	got, err := ReadMetadataFile(path)
+	require.NoError(t, err, "written metadata should parse")
+	assert.Equal(t, meta, got, "round-trip should preserve metadata")
+}
+
+func testMetadata(version, hash string) Metadata {
+	return Metadata{
+		Version: version,
+		Checksums: Checksums{
+			Darwin:       hash,
+			LinuxAMD64:   hash,
+			LinuxARM64:   hash,
+			WindowsARM64: hash,
+			WindowsAMD64: hash,
+		},
+	}
+}

--- a/x-pack/osquerybeat/magefile.go
+++ b/x-pack/osquerybeat/magefile.go
@@ -129,6 +129,20 @@ func FetchOsquerydForTesting() error {
 	return osquerybeat.FetchOsqueryDistros()
 }
 
+// UpdateOsquery updates the bundled osquery version and artifact checksums.
+// Set OSQUERY_VERSION to select a specific release; the latest stable release
+// is used by default.
+func UpdateOsquery() error {
+	args := []string{"run", "./scripts/update_osquery"}
+	if version := strings.TrimSpace(os.Getenv("OSQUERY_VERSION")); version != "" {
+		args = append(args, "-version", version)
+	}
+	cmd := exec.Command("go", args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
 // ensureExtensionInBinDir places osquery-extension in binDir, building it first if absent.
 func ensureExtensionInBinDir(binDir string) error {
 	extName := "osquery-extension.ext"

--- a/x-pack/osquerybeat/scripts/update_osquery/main.go
+++ b/x-pack/osquerybeat/scripts/update_osquery/main.go
@@ -1,0 +1,238 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+)
+
+const githubReleasesAPI = "https://api.github.com/repos/osquery/osquery/releases"
+
+type releaseAsset struct {
+	Name               string `json:"name"`
+	Digest             string `json:"digest"`
+	BrowserDownloadURL string `json:"browser_download_url"`
+}
+
+type release struct {
+	TagName string         `json:"tag_name"`
+	Draft   bool           `json:"draft"`
+	Assets  []releaseAsset `json:"assets"`
+}
+
+var artifactConstants = map[string]string{
+	"osquery-%s.pkg":                    "osqueryDistroDarwinSHA256",
+	"osquery-%s_1.linux_x86_64.tar.gz":  "osqueryDistroLinuxSHA256",
+	"osquery-%s_1.linux_aarch64.tar.gz": "osqueryDistroLinuxARMSHA256",
+	"osquery-%s.windows_arm64.zip":      "osqueryDistroWindowsARMZipSHA256",
+	"osquery-%s.windows_x86_64.zip":     "osqueryDistroWindowsX86ZipSHA256",
+}
+
+func main() {
+	version := flag.String("version", "latest", "Osquery release version, or latest")
+	distroFile := flag.String("distro-file", "internal/distro/distro.go", "Path to distro.go")
+	changelogDir := flag.String("changelog-dir", "../../changelog/fragments", "Path to changelog fragments")
+	flag.Parse()
+
+	rel, err := fetchRelease(http.DefaultClient, githubReleasesAPI, *version)
+	if err != nil {
+		fatal(err)
+	}
+	resolvedVersion := strings.TrimPrefix(rel.TagName, "v")
+	hashes, err := releaseHashes(http.DefaultClient, rel, resolvedVersion)
+	if err != nil {
+		fatal(err)
+	}
+	changed, err := updateDistroFile(*distroFile, resolvedVersion, hashes)
+	if err != nil {
+		fatal(err)
+	}
+	if changed {
+		if err := ensureChangelogFragment(*changelogDir, resolvedVersion, time.Now()); err != nil {
+			fatal(err)
+		}
+		fmt.Printf("Updated bundled Osquery metadata to %s.\n", resolvedVersion)
+		return
+	}
+	fmt.Printf("Bundled Osquery metadata is already at %s.\n", resolvedVersion)
+}
+
+func fetchRelease(client *http.Client, apiBase, requested string) (release, error) {
+	requested = strings.TrimSpace(requested)
+	url := strings.TrimRight(apiBase, "/") + "/latest"
+	if requested != "" && !strings.EqualFold(requested, "latest") {
+		url = strings.TrimRight(apiBase, "/") + "/tags/" + strings.TrimPrefix(requested, "v")
+	}
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return release{}, err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	if token := strings.TrimSpace(os.Getenv("GITHUB_TOKEN")); token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return release{}, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return release{}, fmt.Errorf("GitHub release request failed: %s", resp.Status)
+	}
+	var rel release
+	if err := json.NewDecoder(resp.Body).Decode(&rel); err != nil {
+		return release{}, err
+	}
+	if rel.Draft || strings.TrimSpace(rel.TagName) == "" {
+		return release{}, errors.New("GitHub returned an invalid or draft release")
+	}
+	return rel, nil
+}
+
+func releaseHashes(client *http.Client, rel release, version string) (map[string]string, error) {
+	assets := make(map[string]releaseAsset, len(rel.Assets))
+	for _, asset := range rel.Assets {
+		assets[asset.Name] = asset
+	}
+	hashes := make(map[string]string, len(artifactConstants))
+	for pattern, constantName := range artifactConstants {
+		name := fmt.Sprintf(pattern, version)
+		asset, ok := assets[name]
+		if !ok {
+			return nil, fmt.Errorf("release %s does not contain %s", version, name)
+		}
+		digest := strings.TrimPrefix(strings.TrimSpace(asset.Digest), "sha256:")
+		if decoded, err := hex.DecodeString(digest); err != nil || len(decoded) != sha256.Size {
+			if sidecar, ok := assets[name+".sha256"]; ok {
+				var err error
+				digest, err = fetchSidecarHash(client, sidecar.BrowserDownloadURL)
+				if err != nil {
+					return nil, fmt.Errorf("fetch sidecar hash for %s: %w", name, err)
+				}
+			} else {
+				var err error
+				digest, err = downloadSHA256(client, asset.BrowserDownloadURL)
+				if err != nil {
+					return nil, fmt.Errorf("calculate digest for %s: %w", name, err)
+				}
+			}
+		}
+		hashes[constantName] = digest
+	}
+	return hashes, nil
+}
+
+// fetchSidecarHash downloads a .sha256 sidecar file and returns the hex digest.
+// Sidecar files contain "hash  filename" (shasum format) or just "hash".
+func fetchSidecarHash(client *http.Client, url string) (string, error) {
+	if strings.TrimSpace(url) == "" {
+		return "", errors.New("sidecar asset has no download URL")
+	}
+	resp, err := client.Get(url)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("download failed: %s", resp.Status)
+	}
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	hash := strings.Fields(string(b))
+	if len(hash) == 0 {
+		return "", errors.New("sidecar file is empty")
+	}
+	digest := hash[0]
+	if decoded, err := hex.DecodeString(digest); err != nil || len(decoded) != sha256.Size {
+		return "", fmt.Errorf("sidecar file does not contain a valid SHA256: %q", digest)
+	}
+	return digest, nil
+}
+
+func downloadSHA256(client *http.Client, url string) (string, error) {
+	if strings.TrimSpace(url) == "" {
+		return "", errors.New("asset has no digest or download URL")
+	}
+	resp, err := client.Get(url)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("download failed: %s", resp.Status)
+	}
+	h := sha256.New()
+	if _, err := io.Copy(h, resp.Body); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+func updateDistroFile(path, version string, hashes map[string]string) (bool, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return false, err
+	}
+	updated := string(b)
+	values := make(map[string]string, len(hashes)+1)
+	values["osqueryVersion"] = version
+	for name, hash := range hashes {
+		values[name] = hash
+	}
+	for name, value := range values {
+		re := regexp.MustCompile(`(?m)^(\s*` + regexp.QuoteMeta(name) + `\s*=\s*)"[^"]+"`)
+		if !re.MatchString(updated) {
+			return false, fmt.Errorf("constant %s not found in %s", name, path)
+		}
+		updated = re.ReplaceAllString(updated, `${1}"`+value+`"`)
+	}
+	if updated == string(b) {
+		return false, nil
+	}
+	return true, os.WriteFile(path, []byte(updated), 0o644)
+}
+
+func ensureChangelogFragment(dir, version string, now time.Time) error {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return err
+	}
+	summary := "upgrade osquery version to " + version
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		b, err := os.ReadFile(filepath.Join(dir, entry.Name()))
+		if err != nil {
+			return err
+		}
+		if strings.Contains(string(b), "summary: "+summary) {
+			return nil
+		}
+	}
+	content := fmt.Sprintf("kind: upgrade\n\nsummary: %s\n\ndescription: Upgrade the bundled osquery runtime to version %s.\n\ncomponent: osquerybeat\n", summary, version)
+	name := fmt.Sprintf("%d-upgrade-osquery-%s.yaml", now.Unix(), version)
+	return os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644)
+}
+
+func fatal(err error) {
+	fmt.Fprintln(os.Stderr, err)
+	os.Exit(1)
+}

--- a/x-pack/osquerybeat/scripts/update_osquery/main.go
+++ b/x-pack/osquerybeat/scripts/update_osquery/main.go
@@ -15,9 +15,10 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
 	"time"
+
+	"github.com/elastic/beats/v7/x-pack/osquerybeat/internal/distro"
 )
 
 const githubReleasesAPI = "https://api.github.com/repos/osquery/osquery/releases"
@@ -34,17 +35,20 @@ type release struct {
 	Assets  []releaseAsset `json:"assets"`
 }
 
-var artifactConstants = map[string]string{
-	"osquery-%s.pkg":                    "osqueryDistroDarwinSHA256",
-	"osquery-%s_1.linux_x86_64.tar.gz":  "osqueryDistroLinuxSHA256",
-	"osquery-%s_1.linux_aarch64.tar.gz": "osqueryDistroLinuxARMSHA256",
-	"osquery-%s.windows_arm64.zip":      "osqueryDistroWindowsARMZipSHA256",
-	"osquery-%s.windows_x86_64.zip":     "osqueryDistroWindowsX86ZipSHA256",
+var artifactChecksumKeys = []struct {
+	pattern string
+	key     string
+}{
+	{"osquery-%s.pkg", "darwin"},
+	{"osquery-%s_1.linux_x86_64.tar.gz", "linux_amd64"},
+	{"osquery-%s_1.linux_aarch64.tar.gz", "linux_arm64"},
+	{"osquery-%s.windows_arm64.zip", "windows_arm64"},
+	{"osquery-%s.windows_x86_64.zip", "windows_amd64"},
 }
 
 func main() {
 	version := flag.String("version", "latest", "Osquery release version, or latest")
-	distroFile := flag.String("distro-file", "internal/distro/distro.go", "Path to distro.go")
+	distroFile := flag.String("distro-file", "internal/distro/distro.json", "Path to distro.json")
 	changelogDir := flag.String("changelog-dir", "../../changelog/fragments", "Path to changelog fragments")
 	flag.Parse()
 
@@ -109,14 +113,14 @@ func releaseHashes(client *http.Client, rel release, version string) (map[string
 	for _, asset := range rel.Assets {
 		assets[asset.Name] = asset
 	}
-	hashes := make(map[string]string, len(artifactConstants))
-	for pattern, constantName := range artifactConstants {
-		name := fmt.Sprintf(pattern, version)
+	hashes := make(map[string]string, len(artifactChecksumKeys))
+	for _, artifact := range artifactChecksumKeys {
+		name := fmt.Sprintf(artifact.pattern, version)
 		asset, ok := assets[name]
 		if !ok {
 			return nil, fmt.Errorf("release %s does not contain %s", version, name)
 		}
-		digest := strings.TrimPrefix(strings.TrimSpace(asset.Digest), "sha256:")
+		digest := strings.ToLower(strings.TrimPrefix(strings.TrimSpace(asset.Digest), "sha256:"))
 		if decoded, err := hex.DecodeString(digest); err != nil || len(decoded) != sha256.Size {
 			if sidecar, ok := assets[name+".sha256"]; ok {
 				var err error
@@ -132,7 +136,7 @@ func releaseHashes(client *http.Client, rel release, version string) (map[string
 				}
 			}
 		}
-		hashes[constantName] = digest
+		hashes[artifact.key] = strings.ToLower(digest)
 	}
 	return hashes, nil
 }
@@ -186,27 +190,19 @@ func downloadSHA256(client *http.Client, url string) (string, error) {
 }
 
 func updateDistroFile(path, version string, hashes map[string]string) (bool, error) {
-	b, err := os.ReadFile(path)
+	meta, err := distro.ReadMetadataFile(path)
 	if err != nil {
 		return false, err
 	}
-	updated := string(b)
-	values := make(map[string]string, len(hashes)+1)
-	values["osqueryVersion"] = version
-	for name, hash := range hashes {
-		values[name] = hash
+	meta.Version = version
+	meta.Checksums = distro.Checksums{
+		Darwin:       hashes["darwin"],
+		LinuxAMD64:   hashes["linux_amd64"],
+		LinuxARM64:   hashes["linux_arm64"],
+		WindowsARM64: hashes["windows_arm64"],
+		WindowsAMD64: hashes["windows_amd64"],
 	}
-	for name, value := range values {
-		re := regexp.MustCompile(`(?m)^(\s*` + regexp.QuoteMeta(name) + `\s*=\s*)"[^"]+"`)
-		if !re.MatchString(updated) {
-			return false, fmt.Errorf("constant %s not found in %s", name, path)
-		}
-		updated = re.ReplaceAllString(updated, `${1}"`+value+`"`)
-	}
-	if updated == string(b) {
-		return false, nil
-	}
-	return true, os.WriteFile(path, []byte(updated), 0o644)
+	return distro.WriteMetadataFile(path, meta)
 }
 
 func ensureChangelogFragment(dir, version string, now time.Time) error {

--- a/x-pack/osquerybeat/scripts/update_osquery/main_test.go
+++ b/x-pack/osquerybeat/scripts/update_osquery/main_test.go
@@ -1,0 +1,95 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestFetchSidecarHash(t *testing.T) {
+	const validHash = "9f40cea0358759ab2ee871c577055657e3cc2c7cbe5c1247f764245941178aa6"
+	cases := []struct {
+		name    string
+		body    string
+		wantErr bool
+	}{
+		{"bare hash", validHash, false},
+		{"shasum format", validHash + "  osquery-5.23.1.pkg", false},
+		{"empty", "", true},
+		{"invalid hash", "notahash", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Write([]byte(tc.body))
+			}))
+			defer srv.Close()
+			got, err := fetchSidecarHash(http.DefaultClient, srv.URL)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != validHash {
+				t.Fatalf("got %q, want %q", got, validHash)
+			}
+		})
+	}
+}
+
+func TestUpdateDistroFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "distro.go")
+	input := `const (
+	osqueryVersion = "1.0.0"
+	osqueryDistroDarwinSHA256 = "old"
+)
+`
+	if err := os.WriteFile(path, []byte(input), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	changed, err := updateDistroFile(path, "1.0.1", map[string]string{"osqueryDistroDarwinSHA256": "new"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed {
+		t.Fatal("expected file to change")
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(b), `osqueryVersion = "1.0.1"`) || !strings.Contains(string(b), `osqueryDistroDarwinSHA256 = "new"`) {
+		t.Fatalf("unexpected output:\n%s", b)
+	}
+}
+
+func TestEnsureChangelogFragmentIsIdempotent(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Unix(123, 0)
+	if err := ensureChangelogFragment(dir, "1.0.1", now); err != nil {
+		t.Fatal(err)
+	}
+	if err := ensureChangelogFragment(dir, "1.0.1", now.Add(time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected one fragment, got %d", len(entries))
+	}
+}

--- a/x-pack/osquerybeat/scripts/update_osquery/main_test.go
+++ b/x-pack/osquerybeat/scripts/update_osquery/main_test.go
@@ -12,6 +12,11 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/beats/v7/x-pack/osquerybeat/internal/distro"
 )
 
 func TestFetchSidecarHash(t *testing.T) {
@@ -34,62 +39,62 @@ func TestFetchSidecarHash(t *testing.T) {
 			defer srv.Close()
 			got, err := fetchSidecarHash(http.DefaultClient, srv.URL)
 			if tc.wantErr {
-				if err == nil {
-					t.Fatalf("expected error, got %q", got)
-				}
+				assert.Error(t, err, "expected error, got %q", got)
 				return
 			}
-			if err != nil {
-				t.Fatal(err)
-			}
-			if got != validHash {
-				t.Fatalf("got %q, want %q", got, validHash)
-			}
+			require.NoError(t, err, "fetchSidecarHash should succeed")
+			assert.Equal(t, validHash, got, "unexpected sidecar hash")
 		})
 	}
 }
 
 func TestUpdateDistroFile(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "distro.go")
-	input := `const (
-	osqueryVersion = "1.0.0"
-	osqueryDistroDarwinSHA256 = "old"
-)
-`
-	if err := os.WriteFile(path, []byte(input), 0o644); err != nil {
-		t.Fatal(err)
+	path := filepath.Join(t.TempDir(), "distro.json")
+	oldHash := strings.Repeat("a", 64)
+	newHash := strings.Repeat("b", 64)
+	_, err := distro.WriteMetadataFile(path, distro.Metadata{
+		Version: "1.0.0",
+		Checksums: distro.Checksums{
+			Darwin:       oldHash,
+			LinuxAMD64:   oldHash,
+			LinuxARM64:   oldHash,
+			WindowsARM64: oldHash,
+			WindowsAMD64: oldHash,
+		},
+	})
+	require.NoError(t, err, "setup distro.json")
+
+	hashes := map[string]string{
+		"darwin":        newHash,
+		"linux_amd64":   newHash,
+		"linux_arm64":   newHash,
+		"windows_arm64": newHash,
+		"windows_amd64": newHash,
 	}
-	changed, err := updateDistroFile(path, "1.0.1", map[string]string{"osqueryDistroDarwinSHA256": "new"})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !changed {
-		t.Fatal("expected file to change")
-	}
-	b, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !strings.Contains(string(b), `osqueryVersion = "1.0.1"`) || !strings.Contains(string(b), `osqueryDistroDarwinSHA256 = "new"`) {
-		t.Fatalf("unexpected output:\n%s", b)
-	}
+	changed, err := updateDistroFile(path, "1.0.1", hashes)
+	require.NoError(t, err, "updateDistroFile should succeed")
+	assert.True(t, changed, "expected distro.json to change")
+
+	got, err := distro.ReadMetadataFile(path)
+	require.NoError(t, err, "updated distro.json should parse")
+	assert.Equal(t, "1.0.1", got.Version, "version should be updated")
+	assert.Equal(t, newHash, got.Checksums.Darwin, "darwin checksum should be updated")
+	assert.Equal(t, newHash, got.Checksums.LinuxAMD64, "linux_amd64 checksum should be updated")
+	assert.Equal(t, newHash, got.Checksums.LinuxARM64, "linux_arm64 checksum should be updated")
+	assert.Equal(t, newHash, got.Checksums.WindowsARM64, "windows_arm64 checksum should be updated")
+	assert.Equal(t, newHash, got.Checksums.WindowsAMD64, "windows_amd64 checksum should be updated")
+
+	changed, err = updateDistroFile(path, "1.0.1", hashes)
+	require.NoError(t, err, "second updateDistroFile should succeed")
+	assert.False(t, changed, "expected no change when metadata is already current")
 }
 
 func TestEnsureChangelogFragmentIsIdempotent(t *testing.T) {
 	dir := t.TempDir()
 	now := time.Unix(123, 0)
-	if err := ensureChangelogFragment(dir, "1.0.1", now); err != nil {
-		t.Fatal(err)
-	}
-	if err := ensureChangelogFragment(dir, "1.0.1", now.Add(time.Second)); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, ensureChangelogFragment(dir, "1.0.1", now), "first changelog write should succeed")
+	require.NoError(t, ensureChangelogFragment(dir, "1.0.1", now.Add(time.Second)), "second changelog write should succeed")
 	entries, err := os.ReadDir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(entries) != 1 {
-		t.Fatalf("expected one fragment, got %d", len(entries))
-	}
+	require.NoError(t, err, "read changelog dir")
+	assert.Len(t, entries, 1, "expected one fragment")
 }


### PR DESCRIPTION
## Proposed commit message

Upgrade the bundled Osquery runtime to 5.23.1. Add a Mage target that resolves releases, updates artifact checksums, and creates the changelog fragment.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] ~~I have made corresponding change to the default configuration files.~~ Not applicable.
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

None.

## How to test this PR locally

```bash
cd x-pack/osquerybeat
go test ./internal/distro ./scripts/mage ./scripts/update_osquery
mage fetchOsquerydForTesting
```

## Related issues

- None.

## Use cases

Keep the bundled Osquery runtime and its checksums current.

## Screenshots

Not applicable.

## Logs

Not applicable.
