### PR TITLE
filestream: stop allocating per file to fingerprint it

### DIFF
--- a/changelog/fragments/1787035300-filestream-scanner-fingerprint-allocations.yaml
+++ b/changelog/fragments/1787035300-filestream-scanner-fingerprint-allocations.yaml
@@ -1,0 +1,5 @@
+kind: enhancement
+
+summary: Reduce the allocations Filebeat makes per file when scanning with fingerprint file identity.
+
+component: filebeat

--- a/filebeat/input/filestream/fscanner.go
+++ b/filebeat/input/filestream/fscanner.go
@@ -123,8 +123,6 @@ type fileScanner struct {
 	paths            []string
 	cfg              fileScannerConfig
 	log              *logp.Logger
-	hasher           hash.Hash
-	readBuffer       []byte
 	compression      string
 	// completedFingerprints holds paths already complete on the previous watch scan
 	// (growing mode), so attachBridgingRaw can skip re-encoding their bridging header.
@@ -144,6 +142,12 @@ type fileScanner struct {
 	pathIndex       map[string]int
 	pathsCanOverlap bool
 
+	// Everything below exists only to avoid per-file allocations
+
+	hasher       hash.Hash
+	readBuffer   []byte
+	sumBuffer    [sha256.Size]byte
+	rawHexBuffer []byte
 	// lastCount is the number of unique files the previous scan produced.
 	lastCount int
 }
@@ -170,6 +174,9 @@ func newFileScanner(logger *logp.Logger, paths []string, config fileScannerConfi
 		s.log.Debugf("fingerprint mode enabled: offset %d, length %d, growing %t",
 			s.cfg.Fingerprint.Offset, s.cfg.Fingerprint.Length, s.cfg.Fingerprint.Growing)
 		s.readBuffer = make([]byte, s.cfg.Fingerprint.Length)
+		if s.cfg.Fingerprint.Growing {
+			s.rawHexBuffer = make([]byte, hex.EncodedLen(int(s.cfg.Fingerprint.Length)))
+		}
 	}
 
 	err := s.resolveRecursiveGlobs(config)
@@ -866,86 +873,23 @@ func (s *fileScanner) toFileDescriptor(it *ingestTarget) (fd loginp.FileDescript
 	length := s.cfg.Fingerprint.Length
 	threshold := offset + length
 
-	// opener is used to open the file only once
-	opener := struct {
-		Open func() (*os.File, error)
-		f    *os.File
-	}{}
-	opener.Open = func() (*os.File, error) {
-		if opener.f != nil {
-			return opener.f, nil
-		}
-
-		opener.f, err = os.Open(it.originalFilename)
-		if err != nil {
-			return nil, fmt.Errorf("fileScanner: failed to open %q to create FileDescriptor: %w", it.originalFilename, err)
-		}
-		return opener.f, err
+	var osFile *os.File
+	osFile, fd.GZIP, err = s.openFingerprintSource(it)
+	if osFile != nil {
+		defer osFile.Close()
+	}
+	if err != nil {
+		return fd, err
 	}
 
-	defer func() {
-		if opener.f != nil {
-			opener.f.Close()
-		}
-	}()
-
-	switch s.compression {
-	case CompressionNone:
-		// fd.GZIP stays false
-	case CompressionGZIP:
-		fd.GZIP = true
-	case CompressionAuto:
-		osFile, err := opener.Open()
-		if err != nil {
-			return fd, fmt.Errorf("fileScanner: failed to open %q to create FileDescriptor: %w", it.originalFilename, err)
-		}
-
-		fd.GZIP, err = IsGZIP(osFile)
-		if err != nil {
-			return fd, fmt.Errorf("failed to check if %q is gzip: %w",
-				it.originalFilename, err)
-		}
-	}
-
-	// Fast path for non-GZIP files we know the size from lstat and can
-	// reject too-small files in static mode without opening the file. This
-	// preserves the no-open guarantee for static fingerprint on
-	// unreadable/permission-denied small files.
-	if !fd.GZIP {
-		// size <= offset we cannot read anything from the offset, regardless of mode.
-		if it.info.Size() <= offset {
-			return fd, fmt.Errorf(
-				"filesize of %q is %d bytes, less than fingerprint offset %d: %w",
-				fd.Filename, it.info.Size(), offset, errFileTooSmall)
-		}
-		if !s.cfg.Fingerprint.Growing && it.info.Size() < threshold {
-			return fd, fmt.Errorf(
-				"filesize of %q is %d bytes, expected at least %d bytes for fingerprinting: %w",
-				fd.Filename, it.info.Size(), threshold, errFileTooSmall)
-		}
-	}
-
-	// Wrap the open file (plain or GZIP) so subsequent reads/seeks operate
-	// on the decompressed stream when applicable.
-	var file File
+	var file io.ReadSeeker = osFile
 	if fd.GZIP {
-		osFile, err := opener.Open()
-		if err != nil {
-			return fd, fmt.Errorf("fileScanner: failed to open %q to create FileDescriptor: %w", it.originalFilename, err)
-		}
-
-		// Check if there is enough *decompressed* data for fingerprint
-		file, err = newGzipSeekerReader(osFile, int(threshold))
+		gzFile, err := newGzipSeekerReader(osFile, int(threshold))
 		if err != nil {
 			return fd, fmt.Errorf("failed to create gzip seeker: %w", err)
 		}
-		defer file.Close()
-	} else {
-		osFile, err := opener.Open()
-		if err != nil {
-			return fd, fmt.Errorf("fileScanner: failed to open %q to create FileDescriptor: %w", it.originalFilename, err)
-		}
-		file = newPlainFile(osFile)
+		defer gzFile.Close()
+		file = gzFile
 	}
 
 	// Seek to offset (for both growing and static paths).
@@ -984,7 +928,7 @@ func (s *fileScanner) toFileDescriptor(it *ingestTarget) (fd loginp.FileDescript
 		}
 
 		// Growing mode small file: hex of bytes[offset:offset+n].
-		fd.Fingerprint = loginp.FingerprintID{Raw: hex.EncodeToString(s.readBuffer[:n])}
+		fd.Fingerprint = loginp.FingerprintID{Raw: s.rawHex(s.readBuffer[:n])}
 
 		return fd, nil
 	}
@@ -992,11 +936,80 @@ func (s *fileScanner) toFileDescriptor(it *ingestTarget) (fd loginp.FileDescript
 	// File at or above threshold: compute SHA-256 of bytes[offset:offset+length].
 	s.hasher.Reset()
 	s.hasher.Write(s.readBuffer[:length])
-	fd.Fingerprint = loginp.FingerprintID{
-		Sum: hex.EncodeToString(s.hasher.Sum(nil)),
-	}
+	// hexBuffer is allocated on the stack. sumBuffer can't because Sum() is an
+	// interface call
+	var hexBuffer [2 * sha256.Size]byte
+	hex.Encode(hexBuffer[:], s.hasher.Sum(s.sumBuffer[:0]))
+	fd.Fingerprint = loginp.FingerprintID{Sum: string(hexBuffer[:])}
 
 	return fd, nil
+}
+
+// rawHex returns hex(b) with the reusable buffer
+func (s *fileScanner) rawHex(b []byte) string {
+	n := hex.Encode(s.rawHexBuffer, b)
+	return string(s.rawHexBuffer[:n])
+}
+
+// openFingerprintSource opens the file the fingerprint is read from and reports
+// whether that file is GZIP. Callers must close a non-nil *os.File.
+func (s *fileScanner) openFingerprintSource(it *ingestTarget) (osFile *os.File, isGZIP bool, err error) {
+	switch s.compression {
+	case CompressionNone:
+		if err = s.checkFingerprintSize(it); err != nil {
+			return nil, false, err
+		}
+
+	case CompressionGZIP:
+		isGZIP = true
+
+	case CompressionAuto:
+		// Open the file to check its magic bytes
+		osFile, err = openIngestTarget(it)
+		if err != nil {
+			return osFile, false, err
+		}
+		isGZIP, err = IsGZIP(osFile)
+		if err != nil {
+			return osFile, false, fmt.Errorf("failed to check if %q is gzip: %w",
+				it.originalFilename, err)
+		}
+		if !isGZIP {
+			err = s.checkFingerprintSize(it)
+		}
+		return osFile, isGZIP, err
+	}
+
+	osFile, err = openIngestTarget(it)
+	return osFile, isGZIP, err
+}
+
+func openIngestTarget(it *ingestTarget) (*os.File, error) {
+	osFile, err := os.Open(it.originalFilename)
+	if err != nil {
+		return nil, fmt.Errorf("fileScanner: failed to open %q to create FileDescriptor: %w", it.originalFilename, err)
+	}
+	return osFile, nil
+}
+
+// checkFingerprintSize reports errFileTooSmall when the stat size cannot yield
+// a fingerprint. Not applicable to GZIP files.
+func (s *fileScanner) checkFingerprintSize(it *ingestTarget) error {
+	offset := s.cfg.Fingerprint.Offset
+	threshold := offset + s.cfg.Fingerprint.Length
+
+	// At or below the offset nothing is readable from it, regardless of mode.
+	if it.info.Size() <= offset {
+		return fmt.Errorf(
+			"filesize of %q is %d bytes, less than fingerprint offset %d: %w",
+			it.filename, it.info.Size(), offset, errFileTooSmall)
+	}
+	if !s.cfg.Fingerprint.Growing && it.info.Size() < threshold {
+		return fmt.Errorf(
+			"filesize of %q is %d bytes, expected at least %d bytes for fingerprinting: %w",
+			it.filename, it.info.Size(), threshold, errFileTooSmall)
+	}
+	return nil
 }
 
 // attachBridgingRaw sets a complete descriptor's raw header.
@@ -1007,7 +1020,7 @@ func (s *fileScanner) attachBridgingRaw(fd *loginp.FileDescriptor) {
 	if _, done := s.completedFingerprints[fd.Filename]; done {
 		return
 	}
-	fd.Fingerprint.Raw = hex.EncodeToString(s.readBuffer[:s.cfg.Fingerprint.Length])
+	fd.Fingerprint.Raw = s.rawHex(s.readBuffer[:s.cfg.Fingerprint.Length])
 }
 
 func (s *fileScanner) isFileExcluded(file string) bool {

--- a/filebeat/input/filestream/fswatch_test.go
+++ b/filebeat/input/filestream/fswatch_test.go
@@ -3264,8 +3264,7 @@ func TestGetFiles_DuplicateFingerprint(t *testing.T) {
 	}
 }
 
-// TestGetFiles_DuplicateFingerprintAllocBudget asserts only dedup winners encode the bridging raw
-// header; a stray encode is invisible to a behavior test, so bound the growing-vs-static delta.
+// TestGetFiles_DuplicateFingerprintAllocBudget bounds the extra allocations.
 func TestGetFiles_DuplicateFingerprintAllocBudget(t *testing.T) {
 	dir := t.TempDir()
 	glob := writeBenchmarkDuplicateFiles(t, dir, benchmarkFileCount)
@@ -3290,12 +3289,12 @@ func TestGetFiles_DuplicateFingerprintAllocBudget(t *testing.T) {
 	staticAllocs := measure(false)
 	delta := growingAllocs - staticAllocs
 
-	// Budget one alloc per file: far below the ~2*benchmarkFileCount per-duplicate cost, above noise.
-	const budget = float64(benchmarkFileCount)
-	assert.Less(t, delta, budget,
-		"growing mode must not re-encode the bridging raw header per dropped "+
-			"duplicate: growing=%.0f static=%.0f delta=%.0f allocs exceeds "+
-			"budget=%.0f", growingAllocs, staticAllocs, delta, budget)
+	// One dedup winner encodes one header, so the delta is one allocation.
+	// The slack absorbs the noise of process-wide malloc counting.
+	const allocBudget = 10
+	assert.LessOrEqualf(t, delta, float64(allocBudget),
+		"growing mode must encode the bridging header once per scan, not once per duplicate: growing=%.1f static=%.1f allocs/scan over %d files",
+		growingAllocs, staticAllocs, benchmarkFileCount)
 }
 
 func BenchmarkToFileDescriptor(b *testing.B) {

--- a/libbeat/reader/readfile/metafields.go
+++ b/libbeat/reader/readfile/metafields.go
@@ -97,8 +97,7 @@ func (r *FileMetaReader) Next() (reader.Message, error) {
 	}
 
 	// Copy cached fields into a fresh map for this event.
-	fileMap := make(mapstr.M, len(r.cachedMeta))
-	maps.Copy(fileMap, r.cachedMeta)
+	fileMap := maps.Clone(r.cachedMeta)
 	// Direct assignment replaces any existing "log" key rather than merging.
 	// This is intentional and safe: FileMetaReader is always the first component
 	// in the pipeline to write log.* fields. Downstream readers (parsers,


### PR DESCRIPTION
## Proposed commit message

```
filestream: stop allocating per file to fingerprint it

A scan no longer makes these heap allocations for each file:

- a lazy-open helper struct, the closure over it, and the named error
  result moved to the heap
- a plainFile wrapper for an interface that only the GZIP path needs
- the buffer that hasher.Sum(nil) returns
- the slice that hex.EncodeToString fills
- in growing mode, the same scratch slice for the raw header

The lazy opener is factored out in cleaner method. A file is still
opened one time for each descriptor and too-small files are not opened.

Growing mode re-uses a read buffer with the configured length.

Benchstat:

goos: linux
goarch: amd64
pkg: github.com/elastic/beats/v7/filebeat/input/filestream
cpu: Intel(R) Core(TM) Ultra 7 265U
                                            │    before    │               after                │
                                            │    sec/op    │   sec/op     vs base               │
GetFilesWithFingerprintGrowing/static-8        7.669m ± 1%   7.354m ± 1%   -4.10% (p=0.002 n=8)
GetFilesWithFingerprintGrowing/growing-8      10.245m ± 2%   9.190m ± 1%  -10.30% (p=0.000 n=8)
GetFilesWithFingerprintGrowing/duplicates-8    7.920m ± 1%   7.666m ± 1%   -3.21% (p=0.005 n=8)
ToFileDescriptor-8                             5.596µ ± 0%   5.442µ ± 0%   -2.75% (p=0.000 n=8)
geomean                                        1.366m        1.296m        -5.14%

                                            │    before     │                after                 │
                                            │     B/op      │     B/op       vs base               │
GetFilesWithFingerprintGrowing/static-8        1.251Mi ± 0%    1.029Mi ± 0%  -17.78% (p=0.000 n=8)
GetFilesWithFingerprintGrowing/growing-8       5.164Mi ± 0%    2.986Mi ± 0%  -42.18% (p=0.000 n=8)
GetFilesWithFingerprintGrowing/duplicates-8   1240.3Ki ± 1%   1019.7Ki ± 4%  -17.79% (p=0.000 n=8)
ToFileDescriptor-8                               416.0 ± 0%      248.0 ± 0%  -40.38% (p=0.000 n=8)
geomean                                        241.7Ki         167.9Ki       -30.52%

                                            │    before    │               after                │
                                            │  allocs/op   │  allocs/op   vs base               │
GetFilesWithFingerprintGrowing/static-8       16.038k ± 0%   9.038k ± 0%  -43.65% (p=0.000 n=8)
GetFilesWithFingerprintGrowing/growing-8       18.04k ± 0%   10.04k ± 0%  -44.35% (p=0.000 n=8)
GetFilesWithFingerprintGrowing/duplicates-8    20.04k ± 0%   13.04k ± 0%  -34.93% (p=0.000 n=8)
ToFileDescriptor-8                             11.000 ± 0%    5.000 ± 0%  -54.55% (p=0.000 n=8)
geomean                                        2.826k        1.560k       -44.81%

and BenchmarkFilestream:

                                     │   before    │               after               │
                                     │   sec/op    │   sec/op     vs base              │
Filestream/1_file/inode-8              13.34m ± 1%   12.75m ± 1%  -4.39% (p=0.005 n=8)
Filestream/1000_files/fingerprint-8    37.79m ± 2%   36.91m ± 4%  -2.33% (p=0.010 n=8)
Filestream/10000_files/fingerprint-8   499.1m ± 6%   502.1m ± 7%       ~ (p=0.878 n=8)
Filestream/1000_files/growing-8        38.42m ± 9%   38.51m ± 3%       ~ (p=0.798 n=8)
Filestream/10000_files/growing-8       444.3m ± 2%   443.6m ± 3%       ~ (p=0.328 n=8)
Filestream/line_filter/drop_all-8      9.414m ± 1%   8.599m ± 1%  -8.66% (p=0.000 n=8)
geomean                                58.58m        57.12m       -2.50%

                                     │    before    │               after                │
                                     │     B/op     │     B/op      vs base              │
Filestream/1_file/inode-8              14.37Mi ± 0%   14.37Mi ± 0%       ~ (p=0.721 n=8)
Filestream/1000_files/fingerprint-8    43.17Mi ± 0%   40.97Mi ± 0%  -5.08% (p=0.000 n=8)
Filestream/10000_files/fingerprint-8   431.3Mi ± 0%   409.5Mi ± 0%  -5.06% (p=0.000 n=8)
Filestream/1000_files/growing-8        22.72Mi ± 0%   21.50Mi ± 0%  -5.40% (p=0.000 n=8)
Filestream/10000_files/growing-8       226.3Mi ± 0%   213.3Mi ± 0%  -5.73% (p=0.000 n=8)
Filestream/line_filter/drop_all-8      11.91Mi ± 0%   11.91Mi ± 0%       ~ (p=0.328 n=8)
geomean                                50.40Mi        48.60Mi       -3.58%

                                     │   before    │               after               │
                                     │  allocs/op  │  allocs/op   vs base              │
Filestream/1_file/inode-8              130.5k ± 0%   130.5k ± 0%  -0.00% (p=0.002 n=8)
Filestream/1000_files/fingerprint-8    388.4k ± 0%   380.3k ± 0%  -2.10% (p=0.000 n=8)
Filestream/10000_files/fingerprint-8   3.890M ± 0%   3.810M ± 0%  -2.05% (p=0.000 n=8)
Filestream/1000_files/growing-8        197.8k ± 0%   191.8k ± 0%  -3.05% (p=0.000 n=8)
Filestream/10000_files/growing-8       1.986M ± 0%   1.920M ± 0%  -3.35% (p=0.000 n=8)
Filestream/line_filter/drop_all-8      80.41k ± 0%   80.41k ± 0%       ~ (p=0.262 n=8)
geomean                                428.9k        421.4k       -1.77%

The wall clock comes from the readfile change in this commit, not from the scanner.
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~ (no user-facing behavior changes)
- [ ] ~~I have made corresponding change to the default configuration files~~ (no configuration changes)
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

None.

## How to test this PR locally

Run the unit tests for both packages with the race detector:

```bash
cd filebeat && go test -race -count=1 ./input/filestream/...
cd .. && go test -race -count=1 ./libbeat/reader/readfile/...
```

Then compare the benchmarks against `upstream/main`:

```bash
cd filebeat
go test -run '^$' -bench 'BenchmarkGetFilesWithFingerprintGrowing|BenchmarkToFileDescriptor' -benchmem ./input/filestream/
```

## Related issues

- Relates #51694
