### PR TITLE
[dependabot] Run weekly; increase PR limit to 10

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,12 +4,14 @@ updates:
   - package-ecosystem: gomod
     directory: /
     schedule:
-      interval: daily
+      interval: "weekly"
+      day: "monday"
+      time: "08:00"
     labels:
       - automation
       - dependabot
       - skip-changelog
-      - Team:Core
+      - Team:Elastic-Agent-Data-Plane
       - backport-active-all
     allow:
       # Team:Elastic-Agent-Data-Plane
@@ -62,7 +64,7 @@ updates:
     ignore:
       # Skip github.com/elastic/mito because it requires documentation updates.
       - dependency-name: github.com/elastic/mito
-    open-pull-requests-limit: 2
+    open-pull-requests-limit: 10
 
   - package-ecosystem: gomod
     directory: /


### PR DESCRIPTION
Adjustments to the Beats dependabot config:

* Run weekly at 08:00 on Mondays instead of daily
* Allow up to 10 PR requests simultaneously instead of two.
* Update Team label