### PR TITLE
x-pack/filebeat/input/httpjson: call SetID before cursor migration store read

### DIFF
--- a/changelog/fragments/1787267404-fix-httpjson-cel-cursor-migration-set-id.yaml
+++ b/changelog/fragments/1787267404-fix-httpjson-cel-cursor-migration-set-id.yaml
@@ -1,0 +1,10 @@
+kind: bug-fix
+summary: Fix httpjson cursor migration losing position when redirecting to CEL with a named input in Agentless deployments.
+description: |
+  When an httpjson input with an id field uses run_as_cel: true to redirect to
+  the CEL input, the cursor migration path was not calling SetID on the state
+  store before reading the stored cursor. In Agentless deployments backed by the
+  Elasticsearch state store, SetID selects the per-input index, so omitting the
+  call caused the migration to read from the wrong index and silently fall back
+  to the default cursor state.
+component: filebeat

--- a/x-pack/filebeat/input/httpjson/redirect.go
+++ b/x-pack/filebeat/input/httpjson/redirect.go
@@ -63,6 +63,7 @@ func (m InputManager) migrateCursor(src, dst *conf.C) {
 		return
 	}
 	defer store.Close()
+	store.SetID(id)
 
 	key := cursorKey("httpjson", id, u.String())
 	var entry map[string]any

--- a/x-pack/filebeat/input/httpjson/redirect_test.go
+++ b/x-pack/filebeat/input/httpjson/redirect_test.go
@@ -5,7 +5,9 @@
 package httpjson
 
 import (
+	"encoding/json"
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -14,6 +16,7 @@ import (
 	v2 "github.com/elastic/beats/v7/filebeat/input/v2"
 	"github.com/elastic/beats/v7/libbeat/feature"
 	"github.com/elastic/beats/v7/libbeat/statestore"
+	"github.com/elastic/beats/v7/libbeat/statestore/backend"
 	"github.com/elastic/beats/v7/libbeat/statestore/storetest"
 	"github.com/elastic/beats/v7/x-pack/filebeat/input/cel"
 	conf "github.com/elastic/elastic-agent-libs/config"
@@ -718,6 +721,39 @@ func TestMigrateCursor(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, v1, v2)
 	})
+
+	t.Run("set_id_scoped_store", func(t *testing.T) {
+		// Simulate an Elasticsearch-backed store where SetID routes to a different
+		// index. The cursor was previously written under the "my-input" namespace;
+		// migrateCursor must call SetID so it reads from the right partition.
+		b := newNamespacedMemBackend()
+		b.partitions["my-input"] = map[string]any{
+			"httpjson::my-input::https://api.example.com/events": map[string]any{
+				"ttl":     0,
+				"updated": time.Now(),
+				"cursor":  map[string]any{"timestamp": "2025-06-15T10:30:00Z"},
+			},
+		}
+
+		store := newNamespacedTestStore(b)
+		mgr := NewInputManager(logp.NewNopLogger(), store)
+		cfg := conf.MustNewConfigFrom(map[string]any{
+			"type":        "httpjson",
+			"id":          "my-input",
+			"interval":    "60s",
+			"run_as_cel":  true,
+			"request.url": "https://api.example.com/events",
+			"cel.program": `true`,
+			"cel.state":   map[string]any{"cursor": map[string]any{"timestamp": "default_timestamp_should_not_be_in_redirected_cursor"}},
+		})
+
+		_, newCfg, err := mgr.Redirect(cfg)
+		require.NoError(t, err)
+
+		v, err := newCfg.String("state.cursor.timestamp", -1)
+		require.NoError(t, err)
+		require.Equal(t, "2025-06-15T10:30:00Z", v)
+	})
 }
 
 func TestCursorKey(t *testing.T) {
@@ -742,3 +778,145 @@ func (s *testStore) Close()                                     { s.registry.Clo
 func (s *testStore) StoreFor(string) (*statestore.Store, error) { return s.registry.Get("filebeat") }
 func (s *testStore) StoreKey() string                           { return fmt.Sprintf("test:%p", s.registry) }
 func (s *testStore) CleanupInterval() time.Duration             { return 0 }
+
+// namespacedMemBackend is a backend.Registry whose stores partition keys by
+// namespace, simulating the Elasticsearch state store where SetID routes
+// operations to a different index.
+type namespacedMemBackend struct {
+	mu         sync.Mutex
+	partitions map[string]map[string]any
+}
+
+// newNamespacedMemBackend returns an empty namespacedMemBackend.
+func newNamespacedMemBackend() *namespacedMemBackend {
+	return &namespacedMemBackend{partitions: make(map[string]map[string]any)}
+}
+
+// Access returns a new namespacedMemStore sharing the back end's partition map.
+// The store family name is ignored; it selects which backing store to open,
+// but we are a singleton in this setting.
+func (b *namespacedMemBackend) Access(string) (backend.Store, error) {
+	return &namespacedMemStore{b: b}, nil
+}
+
+// Close is a no-op.
+func (b *namespacedMemBackend) Close() error { return nil }
+
+// namespacedMemStore is a backend.Store that routes all key operations to the
+// partition currently selected by SetID. The default namespace (before any
+// SetID call) is the empty string. ns is protected by b.mu.
+type namespacedMemStore struct {
+	b  *namespacedMemBackend
+	ns string
+}
+
+// SetID sets the active namespace; all subsequent key operations target that
+// partition, mirroring how the Elasticsearch back end switches index on SetID.
+func (s *namespacedMemStore) SetID(id string) {
+	s.b.mu.Lock()
+	s.ns = id
+	s.b.mu.Unlock()
+}
+
+// Has reports whether key exists in the current namespace's partition.
+func (s *namespacedMemStore) Has(key string) (bool, error) {
+	s.b.mu.Lock()
+	_, ok := s.b.partitions[s.ns][key]
+	s.b.mu.Unlock()
+	return ok, nil
+}
+
+// Get decodes the value stored under key in the current namespace into value
+// via a JSON round-trip.
+func (s *namespacedMemStore) Get(key string, val any) error {
+	s.b.mu.Lock()
+	v, ok := s.b.partitions[s.ns][key]
+	s.b.mu.Unlock()
+	if !ok {
+		return fmt.Errorf("key not found: %s", key)
+	}
+	buf, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(buf, val)
+}
+
+// Set stores value under key in the current namespace's partition, creating
+// the partition if it does not yet exist.
+func (s *namespacedMemStore) Set(key string, val any) error {
+	s.b.mu.Lock()
+	if s.b.partitions[s.ns] == nil {
+		s.b.partitions[s.ns] = make(map[string]any)
+	}
+	s.b.partitions[s.ns][key] = val
+	s.b.mu.Unlock()
+	return nil
+}
+
+// Remove deletes key from the current namespace's partition.
+func (s *namespacedMemStore) Remove(key string) error {
+	s.b.mu.Lock()
+	delete(s.b.partitions[s.ns], key)
+	s.b.mu.Unlock()
+	return nil
+}
+
+// Each snapshots the current namespace's partition under the lock, then
+// iterates over the snapshot without holding the lock, calling fn for each
+// key-value pair. Iteration stops when fn returns false or a non-nil error.
+func (s *namespacedMemStore) Each(fn func(string, backend.ValueDecoder) (bool, error)) error {
+	s.b.mu.Lock()
+	p := s.b.partitions[s.ns]
+	keys := make([]string, 0, len(p))
+	vals := make([]any, 0, len(p))
+	for k, v := range p {
+		keys = append(keys, k)
+		vals = append(vals, v)
+	}
+	s.b.mu.Unlock()
+	for i, k := range keys {
+		cont, err := fn(k, jsonValueDecoder{vals[i]})
+		if err != nil || !cont {
+			return err
+		}
+	}
+	return nil
+}
+
+// Close is a no-op; the store holds no resources beyond the shared backend.
+func (s *namespacedMemStore) Close() error { return nil }
+
+// jsonValueDecoder implements backend.ValueDecoder via a JSON round-trip,
+// allowing arbitrary in-memory values to be decoded into typed targets.
+type jsonValueDecoder struct{ v any }
+
+// Decode marshals the held value to JSON and unmarshals it into to.
+func (d jsonValueDecoder) Decode(dst any) error {
+	buf, err := json.Marshal(d.v)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(buf, dst)
+}
+
+var _ statestore.States = (*namespacedTestStore)(nil)
+
+// namespacedTestStore implements statestore.States backed by a
+// namespacedMemBackend, for use in tests that require SetID-aware storage.
+type namespacedTestStore struct {
+	registry *statestore.Registry
+}
+
+// newNamespacedTestStore returns a namespacedTestStore backed by b.
+func newNamespacedTestStore(b *namespacedMemBackend) *namespacedTestStore {
+	return &namespacedTestStore{registry: statestore.NewRegistry(b)}
+}
+
+// StoreFor returns the shared "filebeat" store from the underlying registry.
+func (s *namespacedTestStore) StoreFor(_ string) (*statestore.Store, error) {
+	return s.registry.Get("filebeat")
+}
+
+func (s *namespacedTestStore) StoreKey() string               { return fmt.Sprintf("namespaced:%p", s.registry) }
+func (s *namespacedTestStore) CleanupInterval() time.Duration { return 0 }

--- a/x-pack/filebeat/input/httpjson/transform_delete.go
+++ b/x-pack/filebeat/input/httpjson/transform_delete.go
@@ -19,13 +19,13 @@ type deleteConfig struct {
 	Target string `config:"target"`
 }
 
-type delete struct {
+type deleteTransform struct {
 	targetInfo targetInfo
 
 	runFunc func(ctx *transformContext, transformable transformable, key string) error
 }
 
-func (delete) transformName() string { return deleteName }
+func (deleteTransform) transformName() string { return deleteName }
 
 func newDeleteRequest(cfg *conf.C, _ status.StatusReporter, _ *logp.Logger) (transform, error) {
 	delete, err := newDelete(cfg)
@@ -83,23 +83,23 @@ func newDeletePagination(cfg *conf.C, _ status.StatusReporter, _ *logp.Logger) (
 	return &delete, nil
 }
 
-func newDelete(cfg *conf.C) (delete, error) {
+func newDelete(cfg *conf.C) (deleteTransform, error) {
 	c := &deleteConfig{}
 	if err := cfg.Unpack(c); err != nil {
-		return delete{}, fmt.Errorf("fail to unpack the delete configuration: %w", err)
+		return deleteTransform{}, fmt.Errorf("fail to unpack the delete configuration: %w", err)
 	}
 
 	ti, err := getTargetInfo(c.Target)
 	if err != nil {
-		return delete{}, err
+		return deleteTransform{}, err
 	}
 
-	return delete{
+	return deleteTransform{
 		targetInfo: ti,
 	}, nil
 }
 
-func (delete *delete) run(ctx *transformContext, tr transformable) (transformable, error) {
+func (delete *deleteTransform) run(ctx *transformContext, tr transformable) (transformable, error) {
 	if err := delete.runFunc(ctx, tr, delete.targetInfo.Name); err != nil {
 		return transformable{}, err
 	}

--- a/x-pack/filebeat/input/httpjson/transform_delete_test.go
+++ b/x-pack/filebeat/input/httpjson/transform_delete_test.go
@@ -118,7 +118,7 @@ func TestNewDelete(t *testing.T) {
 			gotDelete, gotErr := tc.constructor(cfg, noopReporter{}, nil)
 			if tc.expectedErr == "" {
 				assert.NoError(t, gotErr)
-				assert.Equal(t, tc.expectedTarget, (gotDelete.(*delete)).targetInfo)
+				assert.Equal(t, tc.expectedTarget, (gotDelete.(*deleteTransform)).targetInfo)
 			} else {
 				assert.EqualError(t, gotErr, tc.expectedErr)
 			}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message
```
x-pack/filebeat/input/httpjson: call SetID before cursor migration store read

migrateCursor was opening the persistent store without calling SetID,
so on Elasticsearch-backed stores (used in Agentless deployments) it
read from the wrong per-input index and silently fell back to the
default cursor state.

Rename the httpjson-internal type delete to deleteTransform to avoid
shadowing the built-in delete function, which broke the new test helper.
```
<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Fixes #49915

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
