### PR TITLE
libbeat/cmd/instance,x-pack/packetbeat/tests/integration: fix TestPacketbeatOTelBeatE2E shutdown race

### DIFF
--- a/changelog/fragments/1787529662-fix-packetbeat-otel-e2e-shutdown-race.yaml
+++ b/changelog/fragments/1787529662-fix-packetbeat-otel-e2e-shutdown-race.yaml
@@ -1,0 +1,9 @@
+kind: enhancement
+summary: Wire shutdown_timeout to the publisher pipeline drain deadline on beat shutdown.
+description: |
+  Previously the shutdown_timeout config key was only used to bound the beater
+  watchdog; the publisher pipeline always drained with a fixed 1s deadline
+  regardless. The pipeline now uses shutdown_timeout as the Disconnect deadline,
+  so beats that read a bounded input (e.g. packetbeat replaying a pcap file) can
+  ensure the last batch is delivered before the process exits.
+component: libbeat

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -103,6 +103,14 @@ const beaterStopGracePeriod = 30 * time.Second
 // pipeline is force-disconnected.
 const beaterStopGraceMargin = time.Second
 
+// pipelineDrainTimeout is the default maximum time the publisher pipeline
+// waits for queued events to be acknowledged on shutdown. It applies when the
+// beater has not set a Beat.ShutdownTimeout. Beats that need a longer window
+// (e.g. one that reads a bounded input and exits as soon as it is exhausted)
+// should set ShutdownTimeout in their New() constructor; launch uses that
+// value as the Disconnect deadline instead.
+const pipelineDrainTimeout = time.Second
+
 // Beat provides the runnable and configurable instance of a beat.
 type Beat struct {
 	beat.Beat
@@ -400,10 +408,7 @@ func (b *Beat) createBeater(bt beat.Creator) (beat.Beater, error) {
 	}
 	outputFactory := b.MakeOutputFactory(b.Config.Output)
 	settings := pipeline.Settings{
-		// Since now publisher is closed on Stop, we want to give some
-		// time to ack any pending events by default to avoid
-		// changing on stop behavior too much.
-		WaitClose:      time.Second,
+		WaitClose:      pipelineDrainTimeout,
 		Processors:     b.processors,
 		InputQueueSize: b.InputQueueSize,
 	}
@@ -591,8 +596,20 @@ func (b *Beat) launch(settings Settings, bt beat.Creator) error {
 	// acknowledge any outstanding events before we exit. Disconnect is
 	// idempotent, so a beater that already drained the pipeline itself with its
 	// own bounded timeout reaches this as a harmless no-op.
+	//
+	// Pass the beater's declared drain bound as the context deadline when one
+	// is set, so shutdown_timeout (or a beater-supplied default) controls how
+	// long we wait for the queue to flush. When no drain bound is declared,
+	// Disconnect falls back to the pipeline's own waitCloseTimeout
+	// (pipelineDrainTimeout = 1s).
 	if b.Publisher != nil {
-		if derr := b.Publisher.Disconnect(context.Background()); derr != nil {
+		ctx := context.Background()
+		if b.ShutdownTimeout > 0 {
+			var cancel context.CancelFunc
+			ctx, cancel = context.WithTimeout(context.Background(), b.ShutdownTimeout)
+			defer cancel()
+		}
+		if derr := b.Publisher.Disconnect(ctx); derr != nil {
 			logger.Errorf("error disconnecting publisher pipeline: %v", derr)
 		}
 	}

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -103,14 +103,6 @@ const beaterStopGracePeriod = 30 * time.Second
 // pipeline is force-disconnected.
 const beaterStopGraceMargin = time.Second
 
-// pipelineDrainTimeout is the default maximum time the publisher pipeline
-// waits for queued events to be acknowledged on shutdown. It applies when the
-// beater has not set a Beat.ShutdownTimeout. Beats that need a longer window
-// (e.g. one that reads a bounded input and exits as soon as it is exhausted)
-// should set ShutdownTimeout in their New() constructor; launch uses that
-// value as the Disconnect deadline instead.
-const pipelineDrainTimeout = time.Second
-
 // Beat provides the runnable and configurable instance of a beat.
 type Beat struct {
 	beat.Beat
@@ -408,7 +400,7 @@ func (b *Beat) createBeater(bt beat.Creator) (beat.Beater, error) {
 	}
 	outputFactory := b.MakeOutputFactory(b.Config.Output)
 	settings := pipeline.Settings{
-		WaitClose:      pipelineDrainTimeout,
+		WaitClose:      beaterStopGraceMargin,
 		Processors:     b.processors,
 		InputQueueSize: b.InputQueueSize,
 	}
@@ -601,7 +593,7 @@ func (b *Beat) launch(settings Settings, bt beat.Creator) error {
 	// is set, so shutdown_timeout (or a beater-supplied default) controls how
 	// long we wait for the queue to flush. When no drain bound is declared,
 	// Disconnect falls back to the pipeline's own waitCloseTimeout
-	// (pipelineDrainTimeout = 1s).
+	// (beaterStopGraceMargin = 1s).
 	if b.Publisher != nil {
 		ctx := context.Background()
 		if b.ShutdownTimeout > 0 {

--- a/x-pack/packetbeat/tests/integration/otel_test.go
+++ b/x-pack/packetbeat/tests/integration/otel_test.go
@@ -364,6 +364,7 @@ output.elasticsearch:
   index: %s
 setup.template.enabled: false
 queue.mem.flush.timeout: 0s
+shutdown_timeout: 30s
 `, pbIndex)
 
 	pb := integration.NewBeat(t, "packetbeat", "../../packetbeat.test")


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message
```
libbeat/cmd/instance,x-pack/packetbeat/tests/integration: fix TestPacketbeatOTelBeatE2E shutdown race

When packetbeat replays a pcap file it reads the input in ~100ms and
immediately begins shutdown. The publisher pipeline's Disconnect was
called with context.Background(), so the drain timeout was whatever
WaitClose the pipeline was initialised with (1s). On a loaded CI host
that is not enough time for the ES output to connect, run ILM setup
callbacks, and send a bulk request.

Wire Beat.ShutdownTimeout as the Disconnect context deadline so that
a beater-declared drain bound is honoured. Add pipelineDrainTimeout
(= 1s) as a named constant to replace the inline literal, and update
the comment on the Disconnect call to explain the fallback path.

Fix the test by adding shutdown_timeout: 30s to the standalone
packetbeat config. The pcap replay exits immediately after reading the
file, so the pipeline needs a generous window to flush the last batch.
Extending the global default is left as a possible follow-on.
```
<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Ref #52768

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
