### PR TITLE
Docs: Fix applicable Beats versions in known issue

### DIFF
--- a/docs/release-notes/known-issues.md
+++ b/docs/release-notes/known-issues.md
@@ -22,7 +22,7 @@ Known issues are significant defects or limitations that may impact your impleme
 % :::
 
 :::{dropdown} Disk queue filled metrics can underflow after blocked publishes
-**Applies to**: Beats version v8.15.0+.
+**Applies to**: Beats versions 8.15.0+, 8.16.0+, 8.17.0+, 8.18.0+, 8.19.0-8.19.20, 9.0.0+, 9.1.0+, 9.2.0+, 9.3.0+, 9.4.0-9.4.5, 9.5.0-9.5.2
 
 **Details**
 When a disk queue reaches its configured capacity, inputs can block until
@@ -32,7 +32,7 @@ updating its metrics. When the event is later removed, the
 metrics might report incorrect values. Event delivery is unaffected.
 
 **Resolved**
-To apply the fix, upgrade to version v8.19.21, v9.5.3, v9.4.6, or any later release.
+To apply the fix, upgrade to version 8.19.21, 9.4.6, 9.5.3, or any later release.
 :::
 
 :::{dropdown} OTel runtime silently converts `map[string]string` values to `"unknown type: map[string]string"`


### PR DESCRIPTION
Docs

## Proposed commit message

This updates the list of Beats versions to which a known issue (added in https://github.com/elastic/beats/pull/52666) applies to make it clear this issue does not only apply to 8.15.x versions.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).
