### PR TITLE
winlogbeat: prefer publisher metadata message templates over event-handle ones

### DIFF
--- a/changelog/fragments/1787128310-fix-winlogbeat-message-template-zero-values.yaml
+++ b/changelog/fragments/1787128310-fix-winlogbeat-message-template-zero-values.yaml
@@ -1,0 +1,45 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: Fix rendering of event messages with zero values (e.g. "PID: 0") in place of non-string parameters when the event data does not match the publisher metadata
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# description:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: winlogbeat
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+# issue: https://github.com/owner/repo/1234

--- a/changelog/fragments/1787128310-fix-winlogbeat-message-template-zero-values.yaml
+++ b/changelog/fragments/1787128310-fix-winlogbeat-message-template-zero-values.yaml
@@ -13,7 +13,7 @@ kind: bug-fix
 
 # REQUIRED for all kinds
 # Change summary; a 80ish characters long description of the change.
-summary: Fix rendering of event messages with zero values (e.g. "PID: 0") in place of non-string parameters when the event data does not match the publisher metadata
+summary: 'Fix event messages rendering zero values (e.g. "PID: 0") in place of non-string parameters'
 
 # REQUIRED for breaking-change, deprecation, known-issue
 # Long description; in case the summary is not enough to describe the change

--- a/winlogbeat/sys/wineventlog/metadata_store.go
+++ b/winlogbeat/sys/wineventlog/metadata_store.go
@@ -278,9 +278,15 @@ func (s *PublisherMetadataStore) getEventMetadata(eventID uint16, version uint8,
 		return defaultEM
 	}
 
-	// If we couldn't get a message from the event handle use the one
-	// from the installed provider metadata.
-	if defaultEM != nil && em.MsgStatic == "" && em.MsgTemplate == nil {
+	// Prefer the message from the installed provider metadata over the one
+	// obtained from the event handle. The message from the event handle is
+	// built with EvtFormatMessageEvent, which only substitutes the insert
+	// placeholders that correspond to string parameters. Placeholders for
+	// non-string parameters (e.g. win:UInt32) are replaced by a zero value,
+	// permanently baking values like "(PID: 0)" into the cached message
+	// template. The provider metadata message is built with
+	// EvtFormatMessageId, which substitutes all placeholders verbatim.
+	if defaultEM != nil && (defaultEM.MsgStatic != "" || defaultEM.MsgTemplate != nil) {
 		em.MsgStatic = defaultEM.MsgStatic
 		em.MsgTemplate = defaultEM.MsgTemplate
 	}

--- a/winlogbeat/sys/wineventlog/metadata_store.go
+++ b/winlogbeat/sys/wineventlog/metadata_store.go
@@ -286,9 +286,12 @@ func (s *PublisherMetadataStore) getEventMetadata(eventID uint16, version uint8,
 	// permanently baking values like "(PID: 0)" into the cached message
 	// template. The provider metadata message is built with
 	// EvtFormatMessageId, which substitutes all placeholders verbatim.
+	//
+	// Assign both fields together: MsgStatic and MsgTemplate are mutually
+	// exclusive representations, and formatMessage prefers MsgStatic. Copying
+	// only one field would leave a stale event-handle message in place.
 	if defaultEM != nil && (defaultEM.MsgStatic != "" || defaultEM.MsgTemplate != nil) {
-		em.MsgStatic = defaultEM.MsgStatic
-		em.MsgTemplate = defaultEM.MsgTemplate
+		em.MsgStatic, em.MsgTemplate = defaultEM.MsgStatic, defaultEM.MsgTemplate
 	}
 
 	s.log.Debugw("Obtained unique event metadata from event handle. "+

--- a/winlogbeat/sys/wineventlog/metadata_store_test.go
+++ b/winlogbeat/sys/wineventlog/metadata_store_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/elastic-agent-libs/logp"
 )
@@ -61,5 +62,37 @@ func TestPublisherMetadataStore(t *testing.T) {
 		assert.Empty(t, em.MsgStatic)
 		assert.NotNil(t, em.MsgTemplate)
 		assert.NotEmpty(t, em.EventData)
+	})
+
+	t.Run("publisher_message_is_preferred_on_event_data_mismatch", func(t *testing.T) {
+		log := openLog(t, security4752File)
+		defer log.Close()
+
+		h := mustNextHandle(t, log)
+		defer h.Close()
+
+		defaultEM := s.EventsNewest[4752]
+		require.NotNil(t, defaultEM, "expected event 4752 in the publisher metadata")
+		require.NotNil(t, defaultEM.MsgTemplate, "expected a message template for event 4752")
+
+		// Simulate an event whose data does not match the parameters declared
+		// in the publisher metadata (e.g. Schannel events whose XML
+		// representation does not include the __binLength/binaryData template
+		// parameters) by adding an extra parameter to the metadata.
+		originalParams := defaultEM.EventData.Params
+		defaultEM.EventData.Params = append(originalParams[:len(originalParams):len(originalParams)], EventData{Name: "__binLength"})
+		t.Cleanup(func() { defaultEM.EventData.Params = originalParams })
+
+		em := s.getEventMetadata(4752, 0, 12345, h)
+		require.NotNil(t, em, "expected event metadata for the mismatched event")
+		require.NotSame(t, defaultEM, em, "expected unique event metadata built from the event handle")
+
+		// The message template must come from the publisher metadata, not
+		// from formatting the event handle with the template inserts. The
+		// latter (EvtFormatMessageEvent) only substitutes the inserts for
+		// string parameters and bakes zero values for all other types into
+		// the cached template (e.g. "(PID: 0)").
+		assert.Same(t, defaultEM.MsgTemplate, em.MsgTemplate, "expected the message template from the publisher metadata to be used")
+		assert.Equal(t, defaultEM.MsgStatic, em.MsgStatic, "expected the static message from the publisher metadata to be used")
 	})
 }

--- a/winlogbeat/sys/wineventlog/metadata_store_test.go
+++ b/winlogbeat/sys/wineventlog/metadata_store_test.go
@@ -91,8 +91,11 @@ func TestPublisherMetadataStore(t *testing.T) {
 		// from formatting the event handle with the template inserts. The
 		// latter (EvtFormatMessageEvent) only substitutes the inserts for
 		// string parameters and bakes zero values for all other types into
-		// the cached template (e.g. "(PID: 0)").
+		// the cached template (e.g. "(PID: 0)"). Both representations must
+		// be replaced together so a stale event-handle MsgStatic cannot win
+		// over the publisher MsgTemplate in formatMessage.
 		assert.Same(t, defaultEM.MsgTemplate, em.MsgTemplate, "expected the message template from the publisher metadata to be used")
 		assert.Equal(t, defaultEM.MsgStatic, em.MsgStatic, "expected the static message from the publisher metadata to be used")
+		assert.Empty(t, em.MsgStatic, "publisher MsgTemplate must clear any event-handle MsgStatic")
 	})
 }


### PR DESCRIPTION
## Proposed commit message

When an event's data doesn't match the parameters declared in the publisher metadata (e.g. Schannel events whose rendered XML omits the `__binLength`/`binaryData` template parameters), the message template was built from the event handle with `EvtFormatMessageEvent`. That API only substitutes the insert placeholders of string-typed parameters and silently bakes zero values into all other slots, permanently caching messages like `(PID: 0)` for every subsequent event.

Prefer the message from the installed publisher metadata whenever one exists, since it is built with `EvtFormatMessageId` which substitutes all insert placeholders verbatim regardless of type. The event-handle message remains as a last resort when the publisher metadata carries no message at all (e.g. provider not installed locally).

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

None. Messages that previously rendered baked zero values now render the actual event data values, matching Event Viewer.

## How to test this PR locally

On Windows:

```
cd winlogbeat
go test -v -run TestPublisherMetadataStore ./sys/wineventlog/...
```

To reproduce end to end, enable Schannel event logging (`HKLM\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\EventLogging = 7`), run winlogbeat on the `System` channel without `include_xml`, and verify Schannel events (e.g. 36867/36871/36880) report the actual PID in `message` instead of `(PID: 0)`.

## Related issues

- Closes https://github.com/elastic/beats/issues/52775
