### PR TITLE
[ci] Revert non-IronBank container images to using UBI9

### DIFF
--- a/changelog/fragments/1787598969-revert-non-ironbank-container-images-to-ubi9.yaml
+++ b/changelog/fragments/1787598969-revert-non-ironbank-container-images-to-ubi9.yaml
@@ -36,7 +36,7 @@ component: all
 # If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
 # NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
 # Please provide it if you are adding a fragment for a different PR.
-pr: https://github.com/elastic/beats/pull/abcd
+pr: https://github.com/elastic/beats/pull/52823
 
 # AUTOMATED
 # OPTIONAL to manually add other issue URLs

--- a/changelog/fragments/1787598969-revert-non-ironbank-container-images-to-ubi9.yaml
+++ b/changelog/fragments/1787598969-revert-non-ironbank-container-images-to-ubi9.yaml
@@ -1,0 +1,45 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: "Revert non-Ironbank container images to UBI9."
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# description:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: all
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+pr: https://github.com/elastic/beats/pull/abcd
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+# issue: https://github.com/owner/repo/1234

--- a/dev-tools/packaging/packages.yml
+++ b/dev-tools/packaging/packages.yml
@@ -170,7 +170,7 @@ shared:
   - &docker_spec
     <<: *binary_spec
     extra_vars:
-      from: '--platform=linux/amd64 redhat/ubi10-minimal'
+      from: '--platform=linux/amd64 redhat/ubi9-minimal'
       buildFrom: '--platform=linux/amd64 cgr.dev/chainguard/wolfi-base'
       user: '{{ .BeatName }}'
       linux_capabilities: ''
@@ -183,18 +183,18 @@ shared:
   - &docker_arm_spec
     <<: *docker_spec
     extra_vars:
-      from: '--platform=linux/arm64 redhat/ubi10-minimal'
+      from: '--platform=linux/arm64 redhat/ubi9-minimal'
       buildFrom: '--platform=linux/arm64 cgr.dev/chainguard/wolfi-base'
 
   - &docker_ubi_spec
     extra_vars:
       image_name: '{{.BeatName}}-ubi'
-      from: '--platform=linux/amd64 redhat/ubi10-minimal'
+      from: '--platform=linux/amd64 redhat/ubi9-minimal'
 
   - &docker_arm_ubi_spec
     extra_vars:
       image_name: '{{.BeatName}}-ubi'
-      from: '--platform=linux/arm64 redhat/ubi10-minimal'
+      from: '--platform=linux/arm64 redhat/ubi9-minimal'
 
   - &docker_wolfi_spec
     extra_vars:

--- a/dev-tools/packaging/templates/docker/Dockerfile.tmpl
+++ b/dev-tools/packaging/templates/docker/Dockerfile.tmpl
@@ -163,7 +163,7 @@ RUN HOME={{ $beatHome }} node "$(npm root -g)/@elastic/synthetics/node_modules/p
     test -d {{ $beatHome }}/.cache/ms-playwright
 {{- end }}
 
-{{- if (and (eq .BeatName "heartbeat") (contains .from "ubi10-minimal")) }}
+{{- if (and (eq .BeatName "heartbeat") (contains .from "ubi") (contains .from "minimal")) }}
 USER root
 
 # Install the deps as needed by the exact version of playwright elastic synthetics uses


### PR DESCRIPTION
### Summary

UBI 10 dropped support for x86_64-v2 which impact systems with certain Intel/AMD processors.

This change reverts the Elastic hosted container images to UBI while leaving IronBank on UBI10.

There is also a Heartbeat synthetics condition block in `Dockerfile.tmpl` which needed updated to avoid skipping the entire NodeJS/synthetics setup.

### Related

Addresses https://github.com/elastic/beats/issues/51824