### PR TITLE
Allow sharing schedulers between heartbeat receivers

### DIFF
--- a/changelog/fragments/1787591085-heartbeat-receiver-scheduler-group.yaml
+++ b/changelog/fragments/1787591085-heartbeat-receiver-scheduler-group.yaml
@@ -1,0 +1,38 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: enhancement
+
+# Change summary; a 80ish characters long description of the change.
+summary: Let heartbeat receivers share a scheduler via the `scheduler_group` setting
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+description: |
+  A Heartbeat process has exactly one scheduler, so `heartbeat.scheduler.limit`,
+  `heartbeat.jobs.<type>.limit` and the `SYNTHETICS_LIMIT_<TYPE>` environment
+  variables bound the concurrency of every monitor it runs. A collector, on the
+  other hand, hosts one Heartbeat instance per heartbeat receiver, and each of
+  them builds its own scheduler, so those settings only bound a single receiver.
+
+  Heartbeat receivers now accept a `scheduler_group` setting. Receivers
+  configured with the same group share one scheduler, and therefore one set of
+  concurrency limits, which lets a set of receivers reproduce the limits of the
+  single Heartbeat process they were split out of. The setting defaults to the
+  receiver's own id, so behavior is unchanged unless a group is configured.
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: heartbeat
+
+# PR URL: A link the PR that added the changeset.
+# pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+issue: https://github.com/elastic/elastic-agent/issues/16283

--- a/heartbeat/beater/heartbeat.go
+++ b/heartbeat/beater/heartbeat.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/elastic/beats/v7/heartbeat/config"
 	"github.com/elastic/beats/v7/heartbeat/hbregistry"
+	"github.com/elastic/beats/v7/heartbeat/hbscheduler"
 	"github.com/elastic/beats/v7/heartbeat/monitors"
 	"github.com/elastic/beats/v7/heartbeat/monitors/plugin"
 	"github.com/elastic/beats/v7/heartbeat/monitors/wrappers/monitorstate"
@@ -51,8 +52,18 @@ type Heartbeat struct {
 	done     chan struct{}
 	stopOnce sync.Once
 	// config is used for iterating over elements of the config.
-	config             *config.Config
-	scheduler          *scheduler.Scheduler
+	config *config.Config
+	// scheduler is shared with the other Heartbeat instances in this process
+	// that use the same scheduler group, see hbscheduler.Acquire. It is released
+	// by whichever of Run and Stop is responsible for it, see schedMu.
+	scheduler        *scheduler.Scheduler
+	releaseScheduler hbscheduler.ReleaseFunc
+	// schedMu guards the handover of the scheduler between Run and Stop. Run
+	// releases the scheduler when it returns, but a Heartbeat may be stopped
+	// without ever being run, in which case Stop has to release it.
+	schedMu            sync.Mutex
+	runStarted         bool
+	stopped            bool
 	monitorReloader    *cfgfile.Reloader
 	monitorFactory     cfgfile.RunnerFactory
 	autodiscover       *autodiscover.Autodiscover
@@ -63,8 +74,24 @@ type Heartbeat struct {
 	logger                   *logp.Logger
 }
 
-// New creates a new heartbeat.
+// New creates a new heartbeat with its own scheduler, which is what a Heartbeat
+// process wants: it is the only Heartbeat instance in the process.
 func New(b *beat.Beat, rawConfig *conf.C) (beat.Beater, error) {
+	return newHeartbeat(b, rawConfig, "")
+}
+
+// NewWithSchedulerGroup creates Heartbeats that share one scheduler, and
+// therefore one set of concurrency limits, with every other Heartbeat in this
+// process created for the same schedulerGroup. It exists for hosts that run
+// several Heartbeat instances in a single process, such as the Heartbeat OTel
+// receiver. An empty schedulerGroup behaves like New.
+func NewWithSchedulerGroup(schedulerGroup string) beat.Creator {
+	return func(b *beat.Beat, rawConfig *conf.C) (beat.Beater, error) {
+		return newHeartbeat(b, rawConfig, schedulerGroup)
+	}
+}
+
+func newHeartbeat(b *beat.Beat, rawConfig *conf.C, schedulerGroup string) (beat.Beater, error) {
 	logger := b.Info.Logger
 
 	parsedConfig := config.DefaultConfig(logger)
@@ -119,7 +146,20 @@ func New(b *beat.Beat, rawConfig *conf.C) (beat.Beater, error) {
 	}
 	jobConfig := parsedConfig.Jobs
 
-	sched := scheduler.Create(limit, hbregistry.SchedulerRegistry, location, jobConfig, parsedConfig.RunOnce, logger)
+	// The scheduler, and so its limits, may be shared with the other Heartbeat
+	// instances in this process that belong to the same scheduler group. It is
+	// released by Run, or by Stop if this Heartbeat never runs.
+	sched, releaseSched, err := hbscheduler.Acquire(logger, schedulerGroup, hbscheduler.Params{
+		Limit:          limit,
+		Registry:       hbregistry.SchedulerRegistry,
+		Location:       location,
+		JobLimitByType: jobConfig,
+		RunOnce:        parsedConfig.RunOnce,
+	})
+	if err != nil {
+		trace.Abort()
+		return nil, err
+	}
 
 	pipelineClientFactory := func(p beat.Pipeline) (beat.Client, error) {
 		return p.Connect()
@@ -129,6 +169,7 @@ func New(b *beat.Beat, rawConfig *conf.C) (beat.Beater, error) {
 		done:               make(chan struct{}),
 		config:             parsedConfig,
 		scheduler:          sched,
+		releaseScheduler:   releaseSched,
 		replaceStateLoader: replaceStateLoader,
 		// monitorFactory is the factory used for creating all monitor instances,
 		// wiring them up to everything needed to actually execute.
@@ -153,6 +194,23 @@ func New(b *beat.Beat, rawConfig *conf.C) (beat.Beater, error) {
 
 // Run executes the beat.
 func (bt *Heartbeat) Run(b *beat.Beat) error {
+	// Take responsibility for releasing the scheduler, unless Stop got here first
+	// and already released it. There is nothing left to run in that case.
+	bt.schedMu.Lock()
+	if bt.stopped {
+		bt.schedMu.Unlock()
+		bt.logger.Debug("not running heartbeat, it was stopped before it started")
+		// This run never happens, so the trace is aborted instead of being
+		// started and closed, matching how New gives up on a trace.
+		bt.trace.Abort()
+		return nil
+	}
+	bt.runStarted = true
+	bt.schedMu.Unlock()
+	// Release here so that an early return below does not leave a permanent reference.
+	// The sync.Once inside releaseScheduler makes any later call from Stop a no-op.
+	defer bt.releaseScheduler()
+
 	bt.trace.Start()
 	defer bt.trace.Close()
 
@@ -217,8 +275,6 @@ func (bt *Heartbeat) Run(b *beat.Beat) error {
 		bt.autodiscover.Start()
 		defer bt.autodiscover.Stop()
 	}
-
-	defer bt.scheduler.Stop()
 
 	// Wait until run_once ends or bt is being shut down
 	waitMonitors.AddChan(bt.done)
@@ -322,7 +378,23 @@ func (bt *Heartbeat) makeAutodiscover(b *beat.Beat) (*autodiscover.Autodiscover,
 
 // Stop stops the beat.
 func (bt *Heartbeat) Stop() {
-	bt.stopOnce.Do(func() { close(bt.done) })
+	bt.stopOnce.Do(func() {
+		close(bt.done)
+
+		// Run releases the scheduler when it returns, so it only has to be
+		// released here if Run never started. Otherwise a Heartbeat that is
+		// created and stopped without ever running, which is what a collector
+		// does to a receiver it gives up on, would hold on to its group's
+		// scheduler until the process exits.
+		bt.schedMu.Lock()
+		bt.stopped = true
+		runStarted := bt.runStarted
+		bt.schedMu.Unlock()
+
+		if !runStarted {
+			bt.releaseScheduler()
+		}
+	})
 }
 
 func (bt *Heartbeat) WithOtelFactoryWrapper(wrapper cfgfile.FactoryWrapper) {

--- a/heartbeat/beater/heartbeat_test.go
+++ b/heartbeat/beater/heartbeat_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/elastic/beats/v7/heartbeat/tracer"
 	"github.com/elastic/beats/v7/libbeat/beat"
 
 	conf "github.com/elastic/elastic-agent-libs/config"
@@ -49,4 +50,42 @@ func TestMakeESClient(t *testing.T) {
 		require.NoError(t, err)
 		assert.EqualValues(t, origTimeout, timeout)
 	})
+}
+
+func TestStopBeforeRunReleasesScheduler(t *testing.T) {
+	released := 0
+	bt := &Heartbeat{
+		done:             make(chan struct{}),
+		releaseScheduler: func() { released++ },
+		trace:            tracer.NewNoopTracer(),
+		logger:           logptest.NewTestingLogger(t, ""),
+	}
+
+	// A collector may create a receiver and give up on it without ever starting
+	// it. The scheduler it acquired has to be released anyway, otherwise it is
+	// pinned for the lifetime of the process.
+	bt.Stop()
+	assert.Equal(t, 1, released, "Stop must release the scheduler when Run never started")
+
+	// Run has nothing left to do, and must not release a second time.
+	require.NoError(t, bt.Run(nil))
+	assert.Equal(t, 1, released)
+}
+
+func TestStopAfterRunLeavesReleaseToRun(t *testing.T) {
+	released := 0
+	bt := &Heartbeat{
+		done:             make(chan struct{}),
+		releaseScheduler: func() { released++ },
+		logger:           logptest.NewTestingLogger(t, ""),
+	}
+
+	// Stand in for a Run that is under way: it releases the scheduler when it
+	// returns, after its monitors have wound down, so Stop must not do it early.
+	bt.schedMu.Lock()
+	bt.runStarted = true
+	bt.schedMu.Unlock()
+
+	bt.Stop()
+	assert.Zero(t, released, "Run is responsible for releasing the scheduler once it started")
 }

--- a/heartbeat/hbscheduler/hbscheduler.go
+++ b/heartbeat/hbscheduler/hbscheduler.go
@@ -1,0 +1,234 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Package hbscheduler shares Heartbeat schedulers between the Heartbeat
+// instances running in a process.
+//
+// A Heartbeat process has exactly one Heartbeat instance, and therefore one
+// scheduler, so `heartbeat.scheduler.limit` and the per job type
+// `heartbeat.jobs.<type>.limit` settings bound the concurrency of every monitor
+// it runs. That is no longer true when Heartbeat runs as an OTel receiver,
+// because a process then hosts one Heartbeat instance per receiver and each of
+// them would otherwise build its own scheduler, turning those settings from
+// process-wide bounds into per receiver bounds.
+//
+// Acquire hands out reference counted schedulers grouped by an opaque key, so
+// that instances which should share concurrency bounds also share a scheduler.
+// Callers that want the standalone Heartbeat behavior pass an empty group.
+package hbscheduler
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/elastic/beats/v7/heartbeat/config"
+	"github.com/elastic/beats/v7/heartbeat/scheduler"
+	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/monitoring"
+)
+
+// Params describes the scheduler a consumer asks for. Only the consumer that
+// creates a group's scheduler gets to configure it; see Acquire.
+type Params struct {
+	// Limit is the maximum number of concurrently running tasks. Values below
+	// one mean unlimited.
+	Limit int64
+	// Registry is where the scheduler publishes its metrics.
+	Registry *monitoring.Registry
+	// Location is the time zone schedules are evaluated in.
+	Location *time.Location
+	// JobLimitByType bounds concurrency per monitor type, e.g. `browser`.
+	JobLimitByType map[string]*config.JobLimit
+	// RunOnce puts the scheduler in run_once mode.
+	RunOnce bool
+}
+
+// ReleaseFunc gives up a scheduler acquired with Acquire. It is safe to call
+// more than once, and from multiple goroutines. A group's scheduler is stopped
+// once every acquisition of it has been released.
+type ReleaseFunc func()
+
+type sharedScheduler struct {
+	group  string
+	sched  *scheduler.Scheduler
+	params Params
+	users  int
+}
+
+var (
+	mtx sync.Mutex
+	// schedulers holds the scheduler handed out for each group. Entries are
+	// removed when their last consumer releases them.
+	schedulers = map[string]*sharedScheduler{}
+)
+
+// Acquire returns the scheduler shared by the given group, creating it from
+// params if the group does not have one yet. Later callers for the same group
+// reuse its running scheduler; their params are only used to warn about
+// settings that cannot be honored, with one exception: a run_once mismatch
+// returns an error because mixing run_once and non-run_once consumers in a
+// group causes WaitForRunOnce to behave incorrectly for both sides.
+//
+// The group is an opaque key. An empty group is the default group, which is
+// what a standalone Heartbeat process uses.
+//
+// The caller must invoke the returned ReleaseFunc once it is done with the
+// scheduler. A group's scheduler is stopped when its last consumer releases it.
+func Acquire(logger *logp.Logger, group string, params Params) (*scheduler.Scheduler, ReleaseFunc, error) {
+	logger = logger.Named("hbscheduler").With("scheduler_group", group)
+
+	mtx.Lock()
+	defer mtx.Unlock()
+
+	// A stopped scheduler cannot be restarted, so it must not be handed out
+	// again. This is defensive: a caller that invokes s.Stop() directly rather
+	// than going through Release would leave a stopped scheduler in the map.
+	if shared, ok := schedulers[group]; ok && shared.sched.Stopped() {
+		logger.Debug("discarding stopped shared scheduler")
+		delete(schedulers, group)
+	}
+
+	shared, ok := schedulers[group]
+	if !ok {
+		shared = &sharedScheduler{
+			group: group,
+			sched: scheduler.Create(
+				params.Limit,
+				params.Registry,
+				params.Location,
+				params.JobLimitByType,
+				params.RunOnce,
+				logger,
+			),
+			params: params,
+		}
+		schedulers[group] = shared
+	} else {
+		if shared.params.RunOnce != params.RunOnce {
+			return nil, nil, fmt.Errorf(
+				"scheduler group %q already has run_once=%t; "+
+					"a consumer with run_once=%t cannot join it — "+
+					"assign receivers with different run_once settings to separate scheduler groups",
+				group, shared.params.RunOnce, params.RunOnce,
+			)
+		}
+		if diffs := paramsDiff(shared.params, params); len(diffs) > 0 {
+			logger.Warnf(
+				"reusing the scheduler already running for this group, "+
+					"ignoring conflicting scheduler settings: %s",
+				strings.Join(diffs, ", "),
+			)
+		}
+	}
+
+	shared.users++
+	logger.Debugf("acquired shared scheduler, consumers: %d", shared.users)
+
+	var once sync.Once
+	return shared.sched, func() {
+		once.Do(func() { release(logger, shared) })
+	}, nil
+}
+
+func release(logger *logp.Logger, shared *sharedScheduler) {
+	mtx.Lock()
+	defer mtx.Unlock()
+
+	shared.users--
+	if shared.users > 0 {
+		logger.Debugf("released shared scheduler, consumers: %d", shared.users)
+		return
+	}
+
+	// The scheduler this consumer held may already have been replaced, in which
+	// case the group's new one must be left alone.
+	if schedulers[shared.group] == shared {
+		delete(schedulers, shared.group)
+	}
+	logger.Debug("released shared scheduler, stopping it as it has no consumers left")
+	shared.sched.Stop()
+}
+
+// paramsDiff describes the settings in requested that the already running
+// scheduler, configured with active, does not honor.
+func paramsDiff(active, requested Params) []string {
+	var diffs []string
+
+	if limitName(active.Limit) != limitName(requested.Limit) {
+		diffs = append(diffs, fmt.Sprintf("scheduler.limit: running with %s, requested %s", limitName(active.Limit), limitName(requested.Limit)))
+	}
+	if locationName(active.Location) != locationName(requested.Location) {
+		diffs = append(diffs, fmt.Sprintf("scheduler.location: running with %s, requested %s", locationName(active.Location), locationName(requested.Location)))
+	}
+	for _, jobType := range jobTypes(active.JobLimitByType, requested.JobLimitByType) {
+		activeLimit, requestedLimit := jobLimit(active.JobLimitByType, jobType), jobLimit(requested.JobLimitByType, jobType)
+		if limitName(activeLimit) != limitName(requestedLimit) {
+			diffs = append(diffs, fmt.Sprintf("jobs.%s.limit: running with %s, requested %s", jobType, limitName(activeLimit), limitName(requestedLimit)))
+		}
+	}
+
+	return diffs
+}
+
+// limitName renders a concurrency limit, where anything below one is unlimited.
+// Normalizing keeps equivalent limits, e.g. an unset and an explicit zero, from
+// being reported as a conflict.
+func limitName(limit int64) string {
+	if limit < 1 {
+		return "unlimited"
+	}
+	return strconv.FormatInt(limit, 10)
+}
+
+func locationName(location *time.Location) string {
+	if location == nil {
+		return "Local"
+	}
+	return location.String()
+}
+
+// jobLimit returns the limit configured for jobType, zero (unlimited) if there
+// is none.
+func jobLimit(jobLimitByType map[string]*config.JobLimit, jobType string) int64 {
+	limit := jobLimitByType[jobType]
+	if limit == nil {
+		return 0
+	}
+	return limit.Limit
+}
+
+// jobTypes returns the sorted union of the job types in the given maps, so that
+// diffs are reported in a stable order.
+func jobTypes(maps ...map[string]*config.JobLimit) []string {
+	seen := map[string]struct{}{}
+	for _, m := range maps {
+		for jobType := range m {
+			seen[jobType] = struct{}{}
+		}
+	}
+
+	types := make([]string, 0, len(seen))
+	for jobType := range seen {
+		types = append(types, jobType)
+	}
+	sort.Strings(types)
+	return types
+}

--- a/heartbeat/hbscheduler/hbscheduler_test.go
+++ b/heartbeat/hbscheduler/hbscheduler_test.go
@@ -1,0 +1,349 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package hbscheduler
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/beats/v7/heartbeat/config"
+	"github.com/elastic/beats/v7/heartbeat/scheduler"
+	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
+	"github.com/elastic/elastic-agent-libs/monitoring"
+)
+
+// resetShared drops every shared scheduler so each test starts from a clean
+// state, and again once the test is done so it doesn't leak into the next one.
+func resetShared(t *testing.T) {
+	t.Helper()
+
+	drop := func() {
+		mtx.Lock()
+		defer mtx.Unlock()
+
+		for group, shared := range schedulers {
+			shared.sched.Stop()
+			delete(schedulers, group)
+		}
+	}
+
+	drop()
+	t.Cleanup(drop)
+}
+
+func testParams() Params {
+	return Params{
+		Limit:          10,
+		Registry:       monitoring.NewRegistry(),
+		Location:       time.UTC,
+		JobLimitByType: map[string]*config.JobLimit{"browser": {Limit: 2}},
+	}
+}
+
+// runOnceSchedule runs a job immediately and then effectively never again, so
+// that tests observe exactly one run per job.
+type runOnceSchedule struct{}
+
+func (runOnceSchedule) RunOnInit() bool              { return true }
+func (runOnceSchedule) Next(now time.Time) time.Time { return now.Add(time.Hour) }
+
+// blockingJob adds a job that reports the id it ran with and then blocks until
+// unblock is closed, so that tests can observe which jobs hold a slot.
+func blockingJob(t *testing.T, sched *scheduler.Scheduler, id string, started chan<- string, unblock <-chan struct{}) {
+	t.Helper()
+
+	_, err := sched.Add(runOnceSchedule{}, nil, id, func(_ context.Context) []scheduler.TaskFunc {
+		started <- id
+		<-unblock
+		return nil
+	}, "browser")
+	require.NoError(t, err)
+}
+
+func mustAcquire(t *testing.T, logger *logp.Logger, group string, params Params) (*scheduler.Scheduler, ReleaseFunc) {
+	t.Helper()
+	sched, release, err := Acquire(logger, group, params)
+	require.NoError(t, err)
+	return sched, release
+}
+
+func TestAcquireSharesOneSchedulerPerGroup(t *testing.T) {
+	resetShared(t)
+	logger := logptest.NewTestingLogger(t, "")
+
+	first, releaseFirst := mustAcquire(t, logger, "group", testParams())
+	second, releaseSecond := mustAcquire(t, logger, "group", testParams())
+
+	assert.Same(t, first, second, "consumers of a group must get the same scheduler")
+	assert.False(t, first.Stopped())
+
+	releaseFirst()
+	assert.False(t, first.Stopped(), "the scheduler must keep running while its group has consumers")
+
+	releaseSecond()
+	assert.True(t, first.Stopped(), "the scheduler must stop once its last consumer released it")
+}
+
+func TestGroupsAreIsolated(t *testing.T) {
+	resetShared(t)
+	logger := logptest.NewTestingLogger(t, "")
+
+	// The empty group is the default one, used by a standalone Heartbeat.
+	defaultSched, releaseDefault := mustAcquire(t, logger, "", testParams())
+	first, releaseFirst := mustAcquire(t, logger, "first", testParams())
+	second, releaseSecond := mustAcquire(t, logger, "second", testParams())
+	defer releaseSecond()
+
+	assert.NotSame(t, defaultSched, first)
+	assert.NotSame(t, defaultSched, second)
+	assert.NotSame(t, first, second)
+
+	releaseDefault()
+	releaseFirst()
+	assert.True(t, defaultSched.Stopped())
+	assert.True(t, first.Stopped())
+	assert.False(t, second.Stopped(), "releasing one group must not stop another group's scheduler")
+}
+
+func TestReleaseIsIdempotent(t *testing.T) {
+	resetShared(t)
+	logger := logptest.NewTestingLogger(t, "")
+
+	sched, releaseFirst := mustAcquire(t, logger, "group", testParams())
+	_, releaseSecond := mustAcquire(t, logger, "group", testParams())
+
+	releaseFirst()
+	releaseFirst()
+	releaseFirst()
+	assert.False(t, sched.Stopped(), "repeated releases must not drop another consumer's reference")
+
+	releaseSecond()
+	assert.True(t, sched.Stopped())
+}
+
+func TestAcquireAfterLastReleaseCreatesNewScheduler(t *testing.T) {
+	resetShared(t)
+	logger := logptest.NewTestingLogger(t, "")
+
+	first, releaseFirst := mustAcquire(t, logger, "group", testParams())
+	releaseFirst()
+	require.True(t, first.Stopped())
+
+	second, releaseSecond := mustAcquire(t, logger, "group", testParams())
+	defer releaseSecond()
+
+	assert.NotSame(t, first, second, "a stopped scheduler cannot be restarted, so a new one is needed")
+	assert.False(t, second.Stopped())
+}
+
+// A stopped scheduler must not be handed out to new consumers. This is
+// defensive against callers that invoke Stop directly rather than via Release.
+func TestAcquireReplacesExternallyStoppedScheduler(t *testing.T) {
+	resetShared(t)
+	logger := logptest.NewTestingLogger(t, "")
+
+	first, releaseFirst := mustAcquire(t, logger, "group", testParams())
+	first.Stop()
+
+	second, releaseSecond := mustAcquire(t, logger, "group", testParams())
+	defer releaseSecond()
+	require.NotSame(t, first, second)
+
+	// Releasing the stopped scheduler must leave its replacement alone.
+	releaseFirst()
+	assert.False(t, second.Stopped())
+}
+
+func TestAcquireWarnsAboutConflictingParams(t *testing.T) {
+	resetShared(t)
+	logger, observed := logptest.NewTestingLoggerWithObserver(t, "")
+
+	_, release := mustAcquire(t, logger, "group", testParams())
+	defer release()
+
+	conflicting := testParams()
+	conflicting.Limit = 20
+	conflicting.Location = time.FixedZone("Fake", 3600)
+	conflicting.JobLimitByType = map[string]*config.JobLimit{"http": {Limit: 4}}
+
+	_, releaseConflicting := mustAcquire(t, logger, "group", conflicting)
+	defer releaseConflicting()
+
+	warnings := observed.FilterLevelExact(logp.WarnLevel.ZapLevel()).All()
+	require.Len(t, warnings, 1)
+	msg := warnings[0].Message
+	assert.Contains(t, msg, "scheduler.limit: running with 10, requested 20")
+	assert.Contains(t, msg, "scheduler.location: running with UTC, requested Fake")
+	assert.Contains(t, msg, "jobs.browser.limit: running with 2, requested unlimited")
+	assert.Contains(t, msg, "jobs.http.limit: running with unlimited, requested 4")
+}
+
+func TestAcquireErrorsOnRunOnceConflict(t *testing.T) {
+	resetShared(t)
+	logger := logptest.NewTestingLogger(t, "")
+
+	_, release := mustAcquire(t, logger, "group", testParams()) // run_once=false
+	defer release()
+
+	runOnce := testParams()
+	runOnce.RunOnce = true
+	_, _, err := Acquire(logger, "group", runOnce)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "run_once")
+}
+
+func TestAcquireDoesNotWarnAboutMatchingParams(t *testing.T) {
+	resetShared(t)
+	logger, observed := logptest.NewTestingLoggerWithObserver(t, "")
+
+	_, releaseFirst := mustAcquire(t, logger, "group", testParams())
+	defer releaseFirst()
+	// The registry is only used by the consumer that creates the scheduler, so
+	// a different one must not count as a conflict.
+	_, releaseSecond := mustAcquire(t, logger, "group", testParams())
+	defer releaseSecond()
+
+	// Params of a different group are unrelated and must not be compared.
+	otherGroup := testParams()
+	otherGroup.Limit = 20
+	_, releaseOther := mustAcquire(t, logger, "other", otherGroup)
+	defer releaseOther()
+
+	assert.Empty(t, observed.FilterLevelExact(logp.WarnLevel.ZapLevel()).All())
+}
+
+func TestAcquireIsConcurrencySafe(t *testing.T) {
+	resetShared(t)
+	logger := logptest.NewTestingLogger(t, "")
+
+	const consumers = 32
+	var (
+		wg       sync.WaitGroup
+		mu       sync.Mutex
+		acquired []*scheduler.Scheduler
+		releases []ReleaseFunc
+	)
+
+	wg.Add(consumers)
+	for range consumers {
+		go func() {
+			defer wg.Done()
+			sched, release := mustAcquire(t, logger, "group", testParams())
+
+			mu.Lock()
+			defer mu.Unlock()
+			acquired = append(acquired, sched)
+			releases = append(releases, release)
+		}()
+	}
+	wg.Wait()
+
+	require.Len(t, acquired, consumers)
+	for _, sched := range acquired {
+		assert.Same(t, acquired[0], sched)
+	}
+
+	wg.Add(consumers)
+	for _, release := range releases {
+		go func(release ReleaseFunc) {
+			defer wg.Done()
+			release()
+		}(release)
+	}
+	wg.Wait()
+
+	assert.True(t, acquired[0].Stopped(), "the scheduler must stop once all consumers released it")
+}
+
+// TestJobLimitsAreSharedWithinGroup covers the point of this package, and so of
+// https://github.com/elastic/elastic-agent/issues/16283: a per job type limit of
+// one must let only a single job of a group run at a time, no matter how many
+// consumers added jobs.
+func TestJobLimitsAreSharedWithinGroup(t *testing.T) {
+	resetShared(t)
+	logger := logptest.NewTestingLogger(t, "")
+
+	params := testParams()
+	params.JobLimitByType = map[string]*config.JobLimit{"browser": {Limit: 1}}
+
+	first, releaseFirst := mustAcquire(t, logger, "group", params)
+	defer releaseFirst()
+	second, releaseSecond := mustAcquire(t, logger, "group", params)
+	defer releaseSecond()
+
+	started := make(chan string)
+	unblock := make(chan struct{})
+	defer close(unblock)
+
+	blockingJob(t, first, "first", started, unblock)
+	blockingJob(t, second, "second", started, unblock)
+
+	var firstToRun string
+	select {
+	case firstToRun = <-started:
+	case <-time.After(30 * time.Second):
+		require.Fail(t, "no job started")
+	}
+
+	// While the first job holds the only browser slot the other one must wait,
+	// even though it was added through a different consumer.
+	select {
+	case id := <-started:
+		require.Failf(t, "browser limit was not shared", "job %q ran while %q held the only slot", id, firstToRun)
+	case <-time.After(500 * time.Millisecond):
+	}
+}
+
+// Different groups are independent, which is what keeps a standalone Heartbeat
+// process, and a receiver that opted out of grouping, unaffected.
+func TestJobLimitsAreNotSharedAcrossGroups(t *testing.T) {
+	resetShared(t)
+	logger := logptest.NewTestingLogger(t, "")
+
+	params := testParams()
+	params.JobLimitByType = map[string]*config.JobLimit{"browser": {Limit: 1}}
+
+	first, releaseFirst := mustAcquire(t, logger, "first", params)
+	defer releaseFirst()
+	second, releaseSecond := mustAcquire(t, logger, "second", params)
+	defer releaseSecond()
+
+	started := make(chan string)
+	unblock := make(chan struct{})
+	defer close(unblock)
+
+	blockingJob(t, first, "first", started, unblock)
+	blockingJob(t, second, "second", started, unblock)
+
+	ran := map[string]bool{}
+	for range 2 {
+		select {
+		case id := <-started:
+			ran[id] = true
+		case <-time.After(30 * time.Second):
+			require.Failf(t, "a job of another group was blocked", "only %v ran", ran)
+		}
+	}
+	assert.Equal(t, map[string]bool{"first": true, "second": true}, ran)
+}

--- a/heartbeat/scheduler/scheduler.go
+++ b/heartbeat/scheduler/scheduler.go
@@ -159,12 +159,17 @@ func (s *Scheduler) Stop() {
 	s.cancelCtx()
 }
 
+// Stopped returns true once Stop has been invoked. A stopped scheduler cannot be
+// restarted and rejects new jobs.
+func (s *Scheduler) Stopped() bool {
+	return s.ctx.Err() != nil
+}
+
 // Wait until all tasks are done if run in runOnce mode. Will block forever
 // if this scheduler does not have the runOnce option set.
 // Adding new tasks after this method is invoked is not supported.
 func (s *Scheduler) WaitForRunOnce() {
 	s.runOnceWg.Wait()
-	s.Stop()
 }
 
 // ErrAlreadyStopped is returned when an Add operation is attempted after the scheduler

--- a/x-pack/heartbeat/hbreceiver/config.go
+++ b/x-pack/heartbeat/hbreceiver/config.go
@@ -13,8 +13,20 @@ import (
 )
 
 // Config is config settings for heartbeat receiver.  The structure of
-// which is the same as the heartbeat.yml configuration file.
+// which is the same as the heartbeat.yml configuration file, except for the
+// receiver specific settings declared as fields below.
 type Config struct {
+	// SchedulerGroup makes this receiver share its scheduler, and therefore its
+	// `heartbeat.scheduler.limit` and `heartbeat.jobs.<type>.limit` concurrency
+	// bounds, with every other heartbeat receiver in this collector configured
+	// with the same group. A Heartbeat process only ever has one scheduler, so
+	// grouping the receivers that were split out of one Heartbeat process keeps
+	// those limits meaningful.
+	//
+	// Defaults to the receiver's own id, giving each receiver a scheduler of its
+	// own.
+	SchedulerGroup string `mapstructure:"scheduler_group"`
+
 	Beatconfig map[string]any `mapstructure:",remain"`
 }
 

--- a/x-pack/heartbeat/hbreceiver/config_test.go
+++ b/x-pack/heartbeat/hbreceiver/config_test.go
@@ -37,6 +37,32 @@ func TestUnmarshal(t *testing.T) {
 		assert.Contains(t, cfg.Beatconfig, "heartbeat")
 	})
 
+	t.Run("scheduler_group is a receiver setting, not beat config", func(t *testing.T) {
+		cfg := &Config{}
+
+		userConf := confmap.NewFromStringMap(map[string]any{
+			"scheduler_group": "synthetics/synthetics-browser-default",
+			"heartbeat":       map[string]any{"monitors": []any{}},
+		})
+
+		require.NoError(t, cfg.Unmarshal(userConf))
+
+		assert.Equal(t, "synthetics/synthetics-browser-default", cfg.SchedulerGroup)
+		assert.NotContains(t, cfg.Beatconfig, "scheduler_group",
+			"scheduler_group must not be passed down to heartbeat as beat config")
+	})
+
+	t.Run("scheduler_group defaults to empty", func(t *testing.T) {
+		cfg := &Config{}
+
+		userConf := confmap.NewFromStringMap(map[string]any{
+			"heartbeat": map[string]any{"monitors": []any{}},
+		})
+
+		require.NoError(t, cfg.Unmarshal(userConf))
+		assert.Empty(t, cfg.SchedulerGroup)
+	})
+
 	t.Run("no defaults does not error", func(t *testing.T) {
 		cfg := &Config{}
 

--- a/x-pack/heartbeat/hbreceiver/factory.go
+++ b/x-pack/heartbeat/hbreceiver/factory.go
@@ -48,7 +48,15 @@ func createReceiver(ctx context.Context, set receiver.Settings, baseCfg componen
 		return nil, fmt.Errorf("error creating %s: %w", Name, err)
 	}
 
-	beatCreator := beater.New
+	// Receivers sharing a scheduler group share their scheduler, and so their
+	// concurrency limits. Without an explicit group each receiver gets its own,
+	// keyed by its unique id.
+	schedulerGroup := cfg.SchedulerGroup
+	if schedulerGroup == "" {
+		schedulerGroup = set.ID.String()
+	}
+
+	beatCreator := beater.NewWithSchedulerGroup(schedulerGroup)
 	br, err := xpInstance.NewBeatReceiver(ctx, b, beatCreator, set)
 	if err != nil {
 		return nil, fmt.Errorf("error creating %s: %w", Name, err)

--- a/x-pack/heartbeat/hbreceiver/scheduler_group_test.go
+++ b/x-pack/heartbeat/hbreceiver/scheduler_group_test.go
@@ -1,0 +1,99 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package hbreceiver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/receiver"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+
+	"github.com/elastic/beats/v7/x-pack/otel/oteltest"
+)
+
+// TestSchedulerGroup checks the scheduler group each receiver hands to Heartbeat.
+// Whether Heartbeats of a group then actually share concurrency limits is
+// covered by the heartbeat/hbscheduler tests.
+func TestSchedulerGroup(t *testing.T) {
+	// A receiver that is shut down without ever being started must still give up
+	// the scheduler it acquired.
+	defer oteltest.VerifyNoLeaks(t)
+
+	newReceiver := func(t *testing.T, name, schedulerGroup string) *observer.ObservedLogs {
+		t.Helper()
+
+		observed, logs := observer.New(zapcore.DebugLevel)
+		factory := NewFactoryWithSettings(Settings{Home: t.TempDir()})
+
+		set := receiver.Settings{}
+		set.ID = component.NewIDWithName(factory.Type(), name)
+		set.Logger = zap.New(observed)
+
+		cfg := &Config{
+			SchedulerGroup: schedulerGroup,
+			Beatconfig: map[string]any{
+				"heartbeat": map[string]any{
+					"monitors": []map[string]any{
+						{
+							"type":     "tcp",
+							"id":       "test-tcp-" + name,
+							"schedule": "@every 60s",
+							"hosts":    []string{"localhost:0"},
+							"enabled":  true,
+						},
+					},
+				},
+				"logging": map[string]any{
+					"level":     "debug",
+					"selectors": []string{"*"},
+				},
+				"path.home": t.TempDir(),
+			},
+		}
+
+		r, err := factory.CreateLogs(t.Context(), set, cfg, consumertest.NewNop())
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, r.Shutdown(t.Context())) })
+
+		return logs
+	}
+
+	// groupsOf returns the scheduler groups the receiver acquired a scheduler for.
+	groupsOf := func(t *testing.T, logs *observer.ObservedLogs) []string {
+		t.Helper()
+
+		var groups []string
+		for _, entry := range logs.All() {
+			if group, ok := entry.ContextMap()["scheduler_group"]; ok {
+				groups = append(groups, group.(string))
+			}
+		}
+		require.NotEmpty(t, groups, "receiver logged no scheduler group")
+		return groups
+	}
+
+	t.Run("defaults to the receiver id", func(t *testing.T) {
+		logs := newReceiver(t, "no-group", "")
+
+		for _, group := range groupsOf(t, logs) {
+			assert.Equal(t, "heartbeatreceiver/no-group", group)
+		}
+	})
+
+	t.Run("uses the configured group", func(t *testing.T) {
+		const group = "synthetics/synthetics-browser-default"
+		logs := newReceiver(t, "with-group", group)
+
+		for _, got := range groupsOf(t, logs) {
+			assert.Equal(t, group, got)
+		}
+	})
+}

--- a/x-pack/heartbeat/hbreceiver/scheduler_group_test.go
+++ b/x-pack/heartbeat/hbreceiver/scheduler_group_test.go
@@ -73,7 +73,9 @@ func TestSchedulerGroup(t *testing.T) {
 		var groups []string
 		for _, entry := range logs.All() {
 			if group, ok := entry.ContextMap()["scheduler_group"]; ok {
-				groups = append(groups, group.(string))
+				if s, ok := group.(string); ok {
+					groups = append(groups, s)
+				}
 			}
 		}
 		require.NotEmpty(t, groups, "receiver logged no scheduler group")


### PR DESCRIPTION
## Proposed commit message

When Heartbeat runs as an OTel receiver in a collector, the collector runs one Heartbeat instance per receiver. Each instance creates its own scheduler, so settings like `heartbeat.scheduler.limit` and `heartbeat.jobs.<type>.limit` only bound a single receiver instead of the whole process. This breaks the concurrency guarantees users expect when splitting a single Heartbeat process into multiple receivers.

Add a `scheduler_group` setting to the heartbeat receiver. Receivers configured with the same group share one scheduler (and therefore one set of concurrency limits) via a new ref-counted `hbscheduler` package. Receivers without an explicit group default to using their own ID as the group, preserving existing per-receiver isolation. A standalone Heartbeat process is unaffected.

The `hbscheduler.Acquire` function hands out reference-counted schedulers keyed by group. The scheduler is stopped when its last consumer releases it. A `sync.Once`-guarded handover between `Run` and `Stop` ensures the scheduler is always released exactly once, even when a receiver is shut down before it ever starts.
## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## How to test this PR locally

Run the new unit tests:
```
go test ./heartbeat/hbscheduler/...
go test ./heartbeat/beater/...
go test ./x-pack/heartbeat/hbreceiver/...
```

To verify shared concurrency limits, configure two heartbeat receivers in a collector with the same `scheduler_group` and a `heartbeat.jobs.browser.limit` of 1; only one browser monitor should run at a time across both receivers.

## Related issues

- Relates https://github.com/elastic/elastic-agent/issues/16283

## Use cases

- A collector running multiple Synthetics receivers that were split out of a single Heartbeat process can set the same `scheduler_group` on all of them to restore process-wide concurrency bounds.
- Receivers without a `scheduler_group` continue to have independent schedulers (default behavior unchanged).

