### PR TITLE
[docs] Warn not to use Cloud ID over AWS PrivateLink

### DIFF
--- a/docs/reference/_snippets/aws-privatelink-cloud-id.md
+++ b/docs/reference/_snippets/aws-privatelink-cloud-id.md
@@ -1,0 +1,9 @@
+:::{warning}
+If you connect over AWS PrivateLink, don't set `cloud.id`. The Cloud ID encodes the public {{es}} endpoint, which doesn't match the PrivateLink TLS certificate. Copy the {{es}} endpoint from the deployment overview page, then connect using the {{es}} endpoint URL and an API key:
+
+```yaml
+output.elasticsearch:
+  hosts: ["ELASTICSEARCH_ENDPOINT_URL"]
+  api_key: "YOUR_API_KEY"
+```
+:::

--- a/docs/reference/_snippets/aws-privatelink-cloud-id.md
+++ b/docs/reference/_snippets/aws-privatelink-cloud-id.md
@@ -1,5 +1,5 @@
 :::{warning}
-If an {{ech}} deployment is protected by an AWS PrivateLink VPC filter, you can't use `cloud.id` or `cloud.auth`. The Cloud ID encodes the public {{es}} endpoint, which is not available after the filter is associated. Copy the private {{es}} endpoint from the deployment overview page, then connect using the {{es}} endpoint URL and an API key:
+If an {{ech}} deployment is protected by an AWS PrivateLink VPC filter, you can't use `cloud.id`. The Cloud ID encodes the public {{es}} endpoint, which is not available after the filter is associated. Copy the private {{es}} endpoint from the deployment overview page, then connect using the {{es}} endpoint URL and an API key:
 
 ```yaml
 output.elasticsearch:

--- a/docs/reference/_snippets/aws-privatelink-cloud-id.md
+++ b/docs/reference/_snippets/aws-privatelink-cloud-id.md
@@ -1,5 +1,5 @@
 :::{warning}
-If you connect over AWS PrivateLink, you can't use `cloud.id` or `cloud.auth`. The Cloud ID encodes the public {{es}} endpoint, which doesn't match the PrivateLink TLS certificate. Copy the private {{es}} endpoint from the deployment overview page, then connect using the {{es}} endpoint URL and an API key:
+If an {{ech}} deployment is protected by an AWS PrivateLink VPC filter, you can't use `cloud.id` or `cloud.auth`. The Cloud ID encodes the public {{es}} endpoint, which is not available after the filter is associated. Copy the private {{es}} endpoint from the deployment overview page, then connect using the {{es}} endpoint URL and an API key:
 
 ```yaml
 output.elasticsearch:

--- a/docs/reference/_snippets/aws-privatelink-cloud-id.md
+++ b/docs/reference/_snippets/aws-privatelink-cloud-id.md
@@ -1,5 +1,5 @@
 :::{warning}
-If you connect over AWS PrivateLink, don't set `cloud.id`. The Cloud ID encodes the public {{es}} endpoint, which doesn't match the PrivateLink TLS certificate. Copy the {{es}} endpoint from the deployment overview page, then connect using the {{es}} endpoint URL and an API key:
+If you connect over AWS PrivateLink, you can't use `cloud.id`. The Cloud ID encodes the public {{es}} endpoint, which doesn't match the PrivateLink TLS certificate. Copy the private {{es}} endpoint from the deployment overview page, then connect using the {{es}} endpoint URL and an API key:
 
 ```yaml
 output.elasticsearch:

--- a/docs/reference/_snippets/aws-privatelink-cloud-id.md
+++ b/docs/reference/_snippets/aws-privatelink-cloud-id.md
@@ -1,5 +1,5 @@
 :::{warning}
-If an {{ech}} deployment is protected by an AWS PrivateLink VPC filter, you can't use `cloud.id`. The Cloud ID encodes the public {{es}} endpoint, which is not available after the filter is associated. Copy the private {{es}} endpoint from the deployment overview page, then connect using the {{es}} endpoint URL and an API key:
+If an {{ech}} deployment is protected by an AWS PrivateLink VPC filter, you can't use `cloud.id`. The Cloud ID encodes the public {{es}} endpoint, which is not available after the filter is associated. [Find the private {{es}} URL](docs-content://deploy-manage/security/private-connectivity-aws.md#ec-access-the-deployment-over-private-link), then connect using that URL and an API key:
 
 ```yaml
 output.elasticsearch:

--- a/docs/reference/_snippets/aws-privatelink-cloud-id.md
+++ b/docs/reference/_snippets/aws-privatelink-cloud-id.md
@@ -1,5 +1,5 @@
 :::{warning}
-If you connect over AWS PrivateLink, you can't use `cloud.id`. The Cloud ID encodes the public {{es}} endpoint, which doesn't match the PrivateLink TLS certificate. Copy the private {{es}} endpoint from the deployment overview page, then connect using the {{es}} endpoint URL and an API key:
+If you connect over AWS PrivateLink, you can't use `cloud.id` or `cloud.auth`. The Cloud ID encodes the public {{es}} endpoint, which doesn't match the PrivateLink TLS certificate. Copy the private {{es}} endpoint from the deployment overview page, then connect using the {{es}} endpoint URL and an API key:
 
 ```yaml
 output.elasticsearch:

--- a/docs/reference/auditbeat/auditbeat-installation-configuration.md
+++ b/docs/reference/auditbeat/auditbeat-installation-configuration.md
@@ -148,6 +148,9 @@ cloud.auth: "auditbeat_setup:YOUR_PASSWORD" <1>
 ```
 
 1. This examples shows a hard-coded password, but you should store sensitive values in the [secrets keystore](/reference/auditbeat/keystore.md).
+
+::::{include} /reference/_snippets/aws-privatelink-cloud-id.md
+::::
 ::::::
 
 ::::::{applies-item} self: ga

--- a/docs/reference/auditbeat/auditbeat-installation-configuration.md
+++ b/docs/reference/auditbeat/auditbeat-installation-configuration.md
@@ -147,7 +147,7 @@ cloud.id: "staging:dXMtZWFzdC0xLmF3cy5mb3VuZC5pbyRjZWM2ZjI2MWE3NGJmMjRjZTMzYmI4O
 cloud.auth: "auditbeat_setup:YOUR_PASSWORD" <1>
 ```
 
-1. This examples shows a hard-coded password, but you should store sensitive values in the [secrets keystore](/reference/auditbeat/keystore.md).
+1. This example shows a hard-coded password, but you should store sensitive values in the [secrets keystore](/reference/auditbeat/keystore.md).
 
 ::::{include} /reference/_snippets/aws-privatelink-cloud-id.md
 ::::

--- a/docs/reference/auditbeat/configure-cloud-id.md
+++ b/docs/reference/auditbeat/configure-cloud-id.md
@@ -29,20 +29,8 @@ auditbeat -e -E cloud.id="<cloud-id>" -E cloud.auth="<cloud.auth>"
 
 The Cloud ID, which can be found in the [{{ecloud}} console](https://cloud.elastic.co/?page=docs&placement=docs-body), is used by Auditbeat to resolve the {{es}} and {{kib}} URLs. This setting overwrites the `output.elasticsearch.hosts` and `setup.kibana.host` settings. For more on locating and configuring the Cloud ID, see [Find your Cloud ID](docs-content://deploy-manage/deploy/elastic-cloud/find-cloud-id.md).
 
-:::{warning}
-If you connect over AWS PrivateLink, don't set `cloud.id`. The Cloud ID uses the public endpoint, which doesn't match the PrivateLink TLS certificate. Use the {{es}} endpoint URL instead.
-:::
-
-Set `output.elasticsearch.hosts` to the private URL for your deployment. Don't also set `cloud.id`. That setting overwrites `output.elasticsearch.hosts`.
-
-```yaml
-output.elasticsearch:
-  hosts: ["https://my-deployment-d53192.es.vpce.us-east-1.aws.elastic-cloud.com:443"]
-  username: "elastic"
-  password: "YOUR_PASSWORD"
-```
-
-For the private URL, refer to [Access the resource over a PrivateLink](docs-content://deploy-manage/security/private-connectivity-aws.md#ec-access-the-deployment-over-private-link).
+::::{include} /reference/_snippets/aws-privatelink-cloud-id.md
+::::
 
 ## `cloud.auth` [_cloud_auth]
 

--- a/docs/reference/auditbeat/configure-cloud-id.md
+++ b/docs/reference/auditbeat/configure-cloud-id.md
@@ -29,6 +29,20 @@ auditbeat -e -E cloud.id="<cloud-id>" -E cloud.auth="<cloud.auth>"
 
 The Cloud ID, which can be found in the [{{ecloud}} console](https://cloud.elastic.co/?page=docs&placement=docs-body), is used by Auditbeat to resolve the {{es}} and {{kib}} URLs. This setting overwrites the `output.elasticsearch.hosts` and `setup.kibana.host` settings. For more on locating and configuring the Cloud ID, see [Find your Cloud ID](docs-content://deploy-manage/deploy/elastic-cloud/find-cloud-id.md).
 
+:::{warning}
+If you connect over AWS PrivateLink, don't set `cloud.id`. The Cloud ID uses the public endpoint, which doesn't match the PrivateLink TLS certificate. Use the {{es}} endpoint URL instead.
+:::
+
+Set `output.elasticsearch.hosts` to the private URL for your deployment. Don't also set `cloud.id`. That setting overwrites `output.elasticsearch.hosts`.
+
+```yaml
+output.elasticsearch:
+  hosts: ["https://my-deployment-d53192.es.vpce.us-east-1.aws.elastic-cloud.com:443"]
+  username: "elastic"
+  password: "YOUR_PASSWORD"
+```
+
+For the private URL, refer to [Access the resource over a PrivateLink](docs-content://deploy-manage/security/private-connectivity-aws.md#ec-access-the-deployment-over-private-link).
 
 ## `cloud.auth` [_cloud_auth]
 

--- a/docs/reference/auditbeat/configure-cloud-id.md
+++ b/docs/reference/auditbeat/configure-cloud-id.md
@@ -25,12 +25,12 @@ These settings can be also specified at the command line, like this:
 auditbeat -e -E cloud.id="<cloud-id>" -E cloud.auth="<cloud.auth>"
 ```
 
+::::{include} /reference/_snippets/aws-privatelink-cloud-id.md
+::::
+
 ## `cloud.id` [_cloud_id]
 
 The Cloud ID, which can be found in the [{{ecloud}} console](https://cloud.elastic.co/?page=docs&placement=docs-body), is used by Auditbeat to resolve the {{es}} and {{kib}} URLs. This setting overwrites the `output.elasticsearch.hosts` and `setup.kibana.host` settings. For more on locating and configuring the Cloud ID, see [Find your Cloud ID](docs-content://deploy-manage/deploy/elastic-cloud/find-cloud-id.md).
-
-::::{include} /reference/_snippets/aws-privatelink-cloud-id.md
-::::
 
 ## `cloud.auth` [_cloud_auth]
 

--- a/docs/reference/filebeat/configure-cloud-id.md
+++ b/docs/reference/filebeat/configure-cloud-id.md
@@ -25,12 +25,12 @@ These settings can be also specified at the command line, like this:
 filebeat -e -E cloud.id="<cloud-id>" -E cloud.auth="<cloud.auth>"
 ```
 
+::::{include} /reference/_snippets/aws-privatelink-cloud-id.md
+::::
+
 ## `cloud.id` [_cloud_id]
 
 The Cloud ID, which can be found in the [{{ecloud}} console](https://cloud.elastic.co/?page=docs&placement=docs-body), is used by Filebeat to resolve the {{es}} and {{kib}} URLs. This setting overwrites the `output.elasticsearch.hosts` and `setup.kibana.host` settings. For more on locating and configuring the Cloud ID, see [Find your Cloud ID](docs-content://deploy-manage/deploy/elastic-cloud/find-cloud-id.md).
-
-::::{include} /reference/_snippets/aws-privatelink-cloud-id.md
-::::
 
 ## `cloud.auth` [_cloud_auth]
 

--- a/docs/reference/filebeat/configure-cloud-id.md
+++ b/docs/reference/filebeat/configure-cloud-id.md
@@ -29,6 +29,20 @@ filebeat -e -E cloud.id="<cloud-id>" -E cloud.auth="<cloud.auth>"
 
 The Cloud ID, which can be found in the [{{ecloud}} console](https://cloud.elastic.co/?page=docs&placement=docs-body), is used by Filebeat to resolve the {{es}} and {{kib}} URLs. This setting overwrites the `output.elasticsearch.hosts` and `setup.kibana.host` settings. For more on locating and configuring the Cloud ID, see [Find your Cloud ID](docs-content://deploy-manage/deploy/elastic-cloud/find-cloud-id.md).
 
+:::{warning}
+If you connect over AWS PrivateLink, don't set `cloud.id`. The Cloud ID uses the public endpoint, which doesn't match the PrivateLink TLS certificate. Use the {{es}} endpoint URL instead.
+:::
+
+Set `output.elasticsearch.hosts` to the private URL for your deployment. Don't also set `cloud.id`. That setting overwrites `output.elasticsearch.hosts`.
+
+```yaml
+output.elasticsearch:
+  hosts: ["https://my-deployment-d53192.es.vpce.us-east-1.aws.elastic-cloud.com:443"]
+  username: "elastic"
+  password: "YOUR_PASSWORD"
+```
+
+For the private URL, refer to [Access the resource over a PrivateLink](docs-content://deploy-manage/security/private-connectivity-aws.md#ec-access-the-deployment-over-private-link).
 
 ## `cloud.auth` [_cloud_auth]
 

--- a/docs/reference/filebeat/configure-cloud-id.md
+++ b/docs/reference/filebeat/configure-cloud-id.md
@@ -29,20 +29,8 @@ filebeat -e -E cloud.id="<cloud-id>" -E cloud.auth="<cloud.auth>"
 
 The Cloud ID, which can be found in the [{{ecloud}} console](https://cloud.elastic.co/?page=docs&placement=docs-body), is used by Filebeat to resolve the {{es}} and {{kib}} URLs. This setting overwrites the `output.elasticsearch.hosts` and `setup.kibana.host` settings. For more on locating and configuring the Cloud ID, see [Find your Cloud ID](docs-content://deploy-manage/deploy/elastic-cloud/find-cloud-id.md).
 
-:::{warning}
-If you connect over AWS PrivateLink, don't set `cloud.id`. The Cloud ID uses the public endpoint, which doesn't match the PrivateLink TLS certificate. Use the {{es}} endpoint URL instead.
-:::
-
-Set `output.elasticsearch.hosts` to the private URL for your deployment. Don't also set `cloud.id`. That setting overwrites `output.elasticsearch.hosts`.
-
-```yaml
-output.elasticsearch:
-  hosts: ["https://my-deployment-d53192.es.vpce.us-east-1.aws.elastic-cloud.com:443"]
-  username: "elastic"
-  password: "YOUR_PASSWORD"
-```
-
-For the private URL, refer to [Access the resource over a PrivateLink](docs-content://deploy-manage/security/private-connectivity-aws.md#ec-access-the-deployment-over-private-link).
+::::{include} /reference/_snippets/aws-privatelink-cloud-id.md
+::::
 
 ## `cloud.auth` [_cloud_auth]
 

--- a/docs/reference/filebeat/filebeat-installation-configuration.md
+++ b/docs/reference/filebeat/filebeat-installation-configuration.md
@@ -152,7 +152,7 @@ cloud.id: "staging:dXMtZWFzdC0xLmF3cy5mb3VuZC5pbyRjZWM2ZjI2MWE3NGJmMjRjZTMzYmI4O
 cloud.auth: "filebeat_setup:YOUR_PASSWORD" <1>
 ```
 
-1. This examples shows a hard-coded password, but you should store sensitive values in the [secrets keystore](/reference/filebeat/keystore.md).
+1. This example shows a hard-coded password, but you should store sensitive values in the [secrets keystore](/reference/filebeat/keystore.md).
 
 ::::{include} /reference/_snippets/aws-privatelink-cloud-id.md
 ::::

--- a/docs/reference/filebeat/filebeat-installation-configuration.md
+++ b/docs/reference/filebeat/filebeat-installation-configuration.md
@@ -153,6 +153,9 @@ cloud.auth: "filebeat_setup:YOUR_PASSWORD" <1>
 ```
 
 1. This examples shows a hard-coded password, but you should store sensitive values in the [secrets keystore](/reference/filebeat/keystore.md).
+
+::::{include} /reference/_snippets/aws-privatelink-cloud-id.md
+::::
 ::::::
 
 ::::::{applies-item} self: ga

--- a/docs/reference/heartbeat/configure-cloud-id.md
+++ b/docs/reference/heartbeat/configure-cloud-id.md
@@ -29,20 +29,8 @@ heartbeat -e -E cloud.id="<cloud-id>" -E cloud.auth="<cloud.auth>"
 
 The Cloud ID, which can be found in the [{{ecloud}} console](https://cloud.elastic.co/?page=docs&placement=docs-body), is used by Heartbeat to resolve the {{es}} and {{kib}} URLs. This setting overwrites the `output.elasticsearch.hosts` and `setup.kibana.host` settings. For more on locating and configuring the Cloud ID, see [Find your Cloud ID](docs-content://deploy-manage/deploy/elastic-cloud/find-cloud-id.md).
 
-:::{warning}
-If you connect over AWS PrivateLink, don't set `cloud.id`. The Cloud ID uses the public endpoint, which doesn't match the PrivateLink TLS certificate. Use the {{es}} endpoint URL instead.
-:::
-
-Set `output.elasticsearch.hosts` to the private URL for your deployment. Don't also set `cloud.id`. That setting overwrites `output.elasticsearch.hosts`.
-
-```yaml
-output.elasticsearch:
-  hosts: ["https://my-deployment-d53192.es.vpce.us-east-1.aws.elastic-cloud.com:443"]
-  username: "elastic"
-  password: "YOUR_PASSWORD"
-```
-
-For the private URL, refer to [Access the resource over a PrivateLink](docs-content://deploy-manage/security/private-connectivity-aws.md#ec-access-the-deployment-over-private-link).
+::::{include} /reference/_snippets/aws-privatelink-cloud-id.md
+::::
 
 ## `cloud.auth` [_cloud_auth]
 

--- a/docs/reference/heartbeat/configure-cloud-id.md
+++ b/docs/reference/heartbeat/configure-cloud-id.md
@@ -25,12 +25,12 @@ These settings can be also specified at the command line, like this:
 heartbeat -e -E cloud.id="<cloud-id>" -E cloud.auth="<cloud.auth>"
 ```
 
+::::{include} /reference/_snippets/aws-privatelink-cloud-id.md
+::::
+
 ## `cloud.id` [_cloud_id]
 
 The Cloud ID, which can be found in the [{{ecloud}} console](https://cloud.elastic.co/?page=docs&placement=docs-body), is used by Heartbeat to resolve the {{es}} and {{kib}} URLs. This setting overwrites the `output.elasticsearch.hosts` and `setup.kibana.host` settings. For more on locating and configuring the Cloud ID, see [Find your Cloud ID](docs-content://deploy-manage/deploy/elastic-cloud/find-cloud-id.md).
-
-::::{include} /reference/_snippets/aws-privatelink-cloud-id.md
-::::
 
 ## `cloud.auth` [_cloud_auth]
 

--- a/docs/reference/heartbeat/configure-cloud-id.md
+++ b/docs/reference/heartbeat/configure-cloud-id.md
@@ -29,6 +29,20 @@ heartbeat -e -E cloud.id="<cloud-id>" -E cloud.auth="<cloud.auth>"
 
 The Cloud ID, which can be found in the [{{ecloud}} console](https://cloud.elastic.co/?page=docs&placement=docs-body), is used by Heartbeat to resolve the {{es}} and {{kib}} URLs. This setting overwrites the `output.elasticsearch.hosts` and `setup.kibana.host` settings. For more on locating and configuring the Cloud ID, see [Find your Cloud ID](docs-content://deploy-manage/deploy/elastic-cloud/find-cloud-id.md).
 
+:::{warning}
+If you connect over AWS PrivateLink, don't set `cloud.id`. The Cloud ID uses the public endpoint, which doesn't match the PrivateLink TLS certificate. Use the {{es}} endpoint URL instead.
+:::
+
+Set `output.elasticsearch.hosts` to the private URL for your deployment. Don't also set `cloud.id`. That setting overwrites `output.elasticsearch.hosts`.
+
+```yaml
+output.elasticsearch:
+  hosts: ["https://my-deployment-d53192.es.vpce.us-east-1.aws.elastic-cloud.com:443"]
+  username: "elastic"
+  password: "YOUR_PASSWORD"
+```
+
+For the private URL, refer to [Access the resource over a PrivateLink](docs-content://deploy-manage/security/private-connectivity-aws.md#ec-access-the-deployment-over-private-link).
 
 ## `cloud.auth` [_cloud_auth]
 

--- a/docs/reference/heartbeat/heartbeat-installation-configuration.md
+++ b/docs/reference/heartbeat/heartbeat-installation-configuration.md
@@ -153,6 +153,9 @@ cloud.auth: "heartbeat_setup:YOUR_PASSWORD" <1>
 ```
 
 1. This examples shows a hard-coded password, but you should store sensitive values in the [secrets keystore](/reference/heartbeat/keystore.md).
+
+::::{include} /reference/_snippets/aws-privatelink-cloud-id.md
+::::
 ::::::
 
 ::::::{applies-item} self: ga

--- a/docs/reference/heartbeat/heartbeat-installation-configuration.md
+++ b/docs/reference/heartbeat/heartbeat-installation-configuration.md
@@ -152,7 +152,7 @@ cloud.id: "staging:dXMtZWFzdC0xLmF3cy5mb3VuZC5pbyRjZWM2ZjI2MWE3NGJmMjRjZTMzYmI4O
 cloud.auth: "heartbeat_setup:YOUR_PASSWORD" <1>
 ```
 
-1. This examples shows a hard-coded password, but you should store sensitive values in the [secrets keystore](/reference/heartbeat/keystore.md).
+1. This example shows a hard-coded password, but you should store sensitive values in the [secrets keystore](/reference/heartbeat/keystore.md).
 
 ::::{include} /reference/_snippets/aws-privatelink-cloud-id.md
 ::::

--- a/docs/reference/metricbeat/configure-cloud-id.md
+++ b/docs/reference/metricbeat/configure-cloud-id.md
@@ -29,6 +29,20 @@ metricbeat -e -E cloud.id="<cloud-id>" -E cloud.auth="<cloud.auth>"
 
 The Cloud ID, which can be found in the [{{ecloud}} console](https://cloud.elastic.co/?page=docs&placement=docs-body), is used by Metricbeat to resolve the {{es}} and {{kib}} URLs. This setting overwrites the `output.elasticsearch.hosts` and `setup.kibana.host` settings. For more on locating and configuring the Cloud ID, see [Find your Cloud ID](docs-content://deploy-manage/deploy/elastic-cloud/find-cloud-id.md).
 
+:::{warning}
+If you connect over AWS PrivateLink, don't set `cloud.id`. The Cloud ID uses the public endpoint, which doesn't match the PrivateLink TLS certificate. Use the {{es}} endpoint URL instead.
+:::
+
+Set `output.elasticsearch.hosts` to the private URL for your deployment. Don't also set `cloud.id`. That setting overwrites `output.elasticsearch.hosts`.
+
+```yaml
+output.elasticsearch:
+  hosts: ["https://my-deployment-d53192.es.vpce.us-east-1.aws.elastic-cloud.com:443"]
+  username: "elastic"
+  password: "YOUR_PASSWORD"
+```
+
+For the private URL, refer to [Access the resource over a PrivateLink](docs-content://deploy-manage/security/private-connectivity-aws.md#ec-access-the-deployment-over-private-link).
 
 ## `cloud.auth` [_cloud_auth]
 

--- a/docs/reference/metricbeat/configure-cloud-id.md
+++ b/docs/reference/metricbeat/configure-cloud-id.md
@@ -25,12 +25,12 @@ These settings can be also specified at the command line, like this:
 metricbeat -e -E cloud.id="<cloud-id>" -E cloud.auth="<cloud.auth>"
 ```
 
+::::{include} /reference/_snippets/aws-privatelink-cloud-id.md
+::::
+
 ## `cloud.id` [_cloud_id]
 
 The Cloud ID, which can be found in the [{{ecloud}} console](https://cloud.elastic.co/?page=docs&placement=docs-body), is used by Metricbeat to resolve the {{es}} and {{kib}} URLs. This setting overwrites the `output.elasticsearch.hosts` and `setup.kibana.host` settings. For more on locating and configuring the Cloud ID, see [Find your Cloud ID](docs-content://deploy-manage/deploy/elastic-cloud/find-cloud-id.md).
-
-::::{include} /reference/_snippets/aws-privatelink-cloud-id.md
-::::
 
 ## `cloud.auth` [_cloud_auth]
 

--- a/docs/reference/metricbeat/configure-cloud-id.md
+++ b/docs/reference/metricbeat/configure-cloud-id.md
@@ -29,20 +29,8 @@ metricbeat -e -E cloud.id="<cloud-id>" -E cloud.auth="<cloud.auth>"
 
 The Cloud ID, which can be found in the [{{ecloud}} console](https://cloud.elastic.co/?page=docs&placement=docs-body), is used by Metricbeat to resolve the {{es}} and {{kib}} URLs. This setting overwrites the `output.elasticsearch.hosts` and `setup.kibana.host` settings. For more on locating and configuring the Cloud ID, see [Find your Cloud ID](docs-content://deploy-manage/deploy/elastic-cloud/find-cloud-id.md).
 
-:::{warning}
-If you connect over AWS PrivateLink, don't set `cloud.id`. The Cloud ID uses the public endpoint, which doesn't match the PrivateLink TLS certificate. Use the {{es}} endpoint URL instead.
-:::
-
-Set `output.elasticsearch.hosts` to the private URL for your deployment. Don't also set `cloud.id`. That setting overwrites `output.elasticsearch.hosts`.
-
-```yaml
-output.elasticsearch:
-  hosts: ["https://my-deployment-d53192.es.vpce.us-east-1.aws.elastic-cloud.com:443"]
-  username: "elastic"
-  password: "YOUR_PASSWORD"
-```
-
-For the private URL, refer to [Access the resource over a PrivateLink](docs-content://deploy-manage/security/private-connectivity-aws.md#ec-access-the-deployment-over-private-link).
+::::{include} /reference/_snippets/aws-privatelink-cloud-id.md
+::::
 
 ## `cloud.auth` [_cloud_auth]
 

--- a/docs/reference/metricbeat/metricbeat-installation-configuration.md
+++ b/docs/reference/metricbeat/metricbeat-installation-configuration.md
@@ -157,6 +157,9 @@ cloud.auth: "metricbeat_setup:YOUR_PASSWORD" <1>
 ```
 
 1. This examples shows a hard-coded password, but you should store sensitive values in the [secrets keystore](/reference/metricbeat/keystore.md).
+
+::::{include} /reference/_snippets/aws-privatelink-cloud-id.md
+::::
 ::::::
 
 ::::::{applies-item} self: ga

--- a/docs/reference/metricbeat/metricbeat-installation-configuration.md
+++ b/docs/reference/metricbeat/metricbeat-installation-configuration.md
@@ -156,7 +156,7 @@ cloud.id: "staging:dXMtZWFzdC0xLmF3cy5mb3VuZC5pbyRjZWM2ZjI2MWE3NGJmMjRjZTMzYmI4O
 cloud.auth: "metricbeat_setup:YOUR_PASSWORD" <1>
 ```
 
-1. This examples shows a hard-coded password, but you should store sensitive values in the [secrets keystore](/reference/metricbeat/keystore.md).
+1. This example shows a hard-coded password, but you should store sensitive values in the [secrets keystore](/reference/metricbeat/keystore.md).
 
 ::::{include} /reference/_snippets/aws-privatelink-cloud-id.md
 ::::

--- a/docs/reference/packetbeat/configure-cloud-id.md
+++ b/docs/reference/packetbeat/configure-cloud-id.md
@@ -25,12 +25,12 @@ These settings can be also specified at the command line, like this:
 packetbeat -e -E cloud.id="<cloud-id>" -E cloud.auth="<cloud.auth>"
 ```
 
+::::{include} /reference/_snippets/aws-privatelink-cloud-id.md
+::::
+
 ## `cloud.id` [_cloud_id]
 
 The Cloud ID, which can be found in the [{{ecloud}} console](https://cloud.elastic.co/?page=docs&placement=docs-body), is used by Packetbeat to resolve the {{es}} and {{kib}} URLs. This setting overwrites the `output.elasticsearch.hosts` and `setup.kibana.host` settings. For more on locating and configuring the Cloud ID, see [Find your Cloud ID](docs-content://deploy-manage/deploy/elastic-cloud/find-cloud-id.md).
-
-::::{include} /reference/_snippets/aws-privatelink-cloud-id.md
-::::
 
 ## `cloud.auth` [_cloud_auth]
 

--- a/docs/reference/packetbeat/configure-cloud-id.md
+++ b/docs/reference/packetbeat/configure-cloud-id.md
@@ -29,20 +29,8 @@ packetbeat -e -E cloud.id="<cloud-id>" -E cloud.auth="<cloud.auth>"
 
 The Cloud ID, which can be found in the [{{ecloud}} console](https://cloud.elastic.co/?page=docs&placement=docs-body), is used by Packetbeat to resolve the {{es}} and {{kib}} URLs. This setting overwrites the `output.elasticsearch.hosts` and `setup.kibana.host` settings. For more on locating and configuring the Cloud ID, see [Find your Cloud ID](docs-content://deploy-manage/deploy/elastic-cloud/find-cloud-id.md).
 
-:::{warning}
-If you connect over AWS PrivateLink, don't set `cloud.id`. The Cloud ID uses the public endpoint, which doesn't match the PrivateLink TLS certificate. Use the {{es}} endpoint URL instead.
-:::
-
-Set `output.elasticsearch.hosts` to the private URL for your deployment. Don't also set `cloud.id`. That setting overwrites `output.elasticsearch.hosts`.
-
-```yaml
-output.elasticsearch:
-  hosts: ["https://my-deployment-d53192.es.vpce.us-east-1.aws.elastic-cloud.com:443"]
-  username: "elastic"
-  password: "YOUR_PASSWORD"
-```
-
-For the private URL, refer to [Access the resource over a PrivateLink](docs-content://deploy-manage/security/private-connectivity-aws.md#ec-access-the-deployment-over-private-link).
+::::{include} /reference/_snippets/aws-privatelink-cloud-id.md
+::::
 
 ## `cloud.auth` [_cloud_auth]
 

--- a/docs/reference/packetbeat/configure-cloud-id.md
+++ b/docs/reference/packetbeat/configure-cloud-id.md
@@ -29,6 +29,20 @@ packetbeat -e -E cloud.id="<cloud-id>" -E cloud.auth="<cloud.auth>"
 
 The Cloud ID, which can be found in the [{{ecloud}} console](https://cloud.elastic.co/?page=docs&placement=docs-body), is used by Packetbeat to resolve the {{es}} and {{kib}} URLs. This setting overwrites the `output.elasticsearch.hosts` and `setup.kibana.host` settings. For more on locating and configuring the Cloud ID, see [Find your Cloud ID](docs-content://deploy-manage/deploy/elastic-cloud/find-cloud-id.md).
 
+:::{warning}
+If you connect over AWS PrivateLink, don't set `cloud.id`. The Cloud ID uses the public endpoint, which doesn't match the PrivateLink TLS certificate. Use the {{es}} endpoint URL instead.
+:::
+
+Set `output.elasticsearch.hosts` to the private URL for your deployment. Don't also set `cloud.id`. That setting overwrites `output.elasticsearch.hosts`.
+
+```yaml
+output.elasticsearch:
+  hosts: ["https://my-deployment-d53192.es.vpce.us-east-1.aws.elastic-cloud.com:443"]
+  username: "elastic"
+  password: "YOUR_PASSWORD"
+```
+
+For the private URL, refer to [Access the resource over a PrivateLink](docs-content://deploy-manage/security/private-connectivity-aws.md#ec-access-the-deployment-over-private-link).
 
 ## `cloud.auth` [_cloud_auth]
 

--- a/docs/reference/packetbeat/packetbeat-installation-configuration.md
+++ b/docs/reference/packetbeat/packetbeat-installation-configuration.md
@@ -192,6 +192,9 @@ cloud.auth: "packetbeat_setup:YOUR_PASSWORD" <1>
 ```
 
 1. This examples shows a hard-coded password, but you should store sensitive values in the [secrets keystore](/reference/packetbeat/keystore.md).
+
+::::{include} /reference/_snippets/aws-privatelink-cloud-id.md
+::::
 ::::::
 
 ::::::{applies-item} self: ga

--- a/docs/reference/packetbeat/packetbeat-installation-configuration.md
+++ b/docs/reference/packetbeat/packetbeat-installation-configuration.md
@@ -191,7 +191,7 @@ cloud.id: "staging:dXMtZWFzdC0xLmF3cy5mb3VuZC5pbyRjZWM2ZjI2MWE3NGJmMjRjZTMzYmI4O
 cloud.auth: "packetbeat_setup:YOUR_PASSWORD" <1>
 ```
 
-1. This examples shows a hard-coded password, but you should store sensitive values in the [secrets keystore](/reference/packetbeat/keystore.md).
+1. This example shows a hard-coded password, but you should store sensitive values in the [secrets keystore](/reference/packetbeat/keystore.md).
 
 ::::{include} /reference/_snippets/aws-privatelink-cloud-id.md
 ::::

--- a/docs/reference/winlogbeat/configure-cloud-id.md
+++ b/docs/reference/winlogbeat/configure-cloud-id.md
@@ -29,20 +29,8 @@ winlogbeat -e -E cloud.id="<cloud-id>" -E cloud.auth="<cloud.auth>"
 
 The Cloud ID, which can be found in the [{{ecloud}} console](https://cloud.elastic.co/?page=docs&placement=docs-body), is used by Winlogbeat to resolve the {{es}} and {{kib}} URLs. This setting overwrites the `output.elasticsearch.hosts` and `setup.kibana.host` settings. For more on locating and configuring the Cloud ID, see [Find your Cloud ID](docs-content://deploy-manage/deploy/elastic-cloud/find-cloud-id.md).
 
-:::{warning}
-If you connect over AWS PrivateLink, don't set `cloud.id`. The Cloud ID uses the public endpoint, which doesn't match the PrivateLink TLS certificate. Use the {{es}} endpoint URL instead.
-:::
-
-Set `output.elasticsearch.hosts` to the private URL for your deployment. Don't also set `cloud.id`. That setting overwrites `output.elasticsearch.hosts`.
-
-```yaml
-output.elasticsearch:
-  hosts: ["https://my-deployment-d53192.es.vpce.us-east-1.aws.elastic-cloud.com:443"]
-  username: "elastic"
-  password: "YOUR_PASSWORD"
-```
-
-For the private URL, refer to [Access the resource over a PrivateLink](docs-content://deploy-manage/security/private-connectivity-aws.md#ec-access-the-deployment-over-private-link).
+::::{include} /reference/_snippets/aws-privatelink-cloud-id.md
+::::
 
 ## `cloud.auth` [_cloud_auth]
 

--- a/docs/reference/winlogbeat/configure-cloud-id.md
+++ b/docs/reference/winlogbeat/configure-cloud-id.md
@@ -29,6 +29,20 @@ winlogbeat -e -E cloud.id="<cloud-id>" -E cloud.auth="<cloud.auth>"
 
 The Cloud ID, which can be found in the [{{ecloud}} console](https://cloud.elastic.co/?page=docs&placement=docs-body), is used by Winlogbeat to resolve the {{es}} and {{kib}} URLs. This setting overwrites the `output.elasticsearch.hosts` and `setup.kibana.host` settings. For more on locating and configuring the Cloud ID, see [Find your Cloud ID](docs-content://deploy-manage/deploy/elastic-cloud/find-cloud-id.md).
 
+:::{warning}
+If you connect over AWS PrivateLink, don't set `cloud.id`. The Cloud ID uses the public endpoint, which doesn't match the PrivateLink TLS certificate. Use the {{es}} endpoint URL instead.
+:::
+
+Set `output.elasticsearch.hosts` to the private URL for your deployment. Don't also set `cloud.id`. That setting overwrites `output.elasticsearch.hosts`.
+
+```yaml
+output.elasticsearch:
+  hosts: ["https://my-deployment-d53192.es.vpce.us-east-1.aws.elastic-cloud.com:443"]
+  username: "elastic"
+  password: "YOUR_PASSWORD"
+```
+
+For the private URL, refer to [Access the resource over a PrivateLink](docs-content://deploy-manage/security/private-connectivity-aws.md#ec-access-the-deployment-over-private-link).
 
 ## `cloud.auth` [_cloud_auth]
 

--- a/docs/reference/winlogbeat/configure-cloud-id.md
+++ b/docs/reference/winlogbeat/configure-cloud-id.md
@@ -25,12 +25,12 @@ These settings can be also specified at the command line, like this:
 winlogbeat -e -E cloud.id="<cloud-id>" -E cloud.auth="<cloud.auth>"
 ```
 
+::::{include} /reference/_snippets/aws-privatelink-cloud-id.md
+::::
+
 ## `cloud.id` [_cloud_id]
 
 The Cloud ID, which can be found in the [{{ecloud}} console](https://cloud.elastic.co/?page=docs&placement=docs-body), is used by Winlogbeat to resolve the {{es}} and {{kib}} URLs. This setting overwrites the `output.elasticsearch.hosts` and `setup.kibana.host` settings. For more on locating and configuring the Cloud ID, see [Find your Cloud ID](docs-content://deploy-manage/deploy/elastic-cloud/find-cloud-id.md).
-
-::::{include} /reference/_snippets/aws-privatelink-cloud-id.md
-::::
 
 ## `cloud.auth` [_cloud_auth]
 

--- a/docs/reference/winlogbeat/winlogbeat-installation-configuration.md
+++ b/docs/reference/winlogbeat/winlogbeat-installation-configuration.md
@@ -112,6 +112,9 @@ cloud.auth: "winlogbeat_setup:YOUR_PASSWORD" <1>
 ```
 
 1. This examples shows a hard-coded password, but you should store sensitive values in the [secrets keystore](/reference/winlogbeat/keystore.md).
+
+::::{include} /reference/_snippets/aws-privatelink-cloud-id.md
+::::
 ::::::
 
 ::::::{applies-item} self: ga

--- a/docs/reference/winlogbeat/winlogbeat-installation-configuration.md
+++ b/docs/reference/winlogbeat/winlogbeat-installation-configuration.md
@@ -111,7 +111,7 @@ cloud.id: "staging:dXMtZWFzdC0xLmF3cy5mb3VuZC5pbyRjZWM2ZjI2MWE3NGJmMjRjZTMzYmI4O
 cloud.auth: "winlogbeat_setup:YOUR_PASSWORD" <1>
 ```
 
-1. This examples shows a hard-coded password, but you should store sensitive values in the [secrets keystore](/reference/winlogbeat/keystore.md).
+1. This example shows a hard-coded password, but you should store sensitive values in the [secrets keystore](/reference/winlogbeat/keystore.md).
 
 ::::{include} /reference/_snippets/aws-privatelink-cloud-id.md
 ::::


### PR DESCRIPTION
## Summary

Cloud ID encodes the public Elasticsearch endpoint. Over AWS PrivateLink, that hostname does not match the PrivateLink TLS certificate, so `cloud.id` fails.

This adds a warning on the Hosted connection tab and on each Beat's Cloud ID page. The workaround is in the warning: copy the Elasticsearch endpoint from the deployment overview, then connect with the same `hosts` plus API key pattern used for serverless.

Existing Cloud ID instructions are unchanged. This is AWS PrivateLink only.

## Context

- [Private connectivity with AWS PrivateLink](https://www.elastic.co/docs/deploy-manage/security/private-connectivity-aws)
- [KB: avoid Cloud ID for PrivateLink deployments](https://ela.st/avoid-using-cloudid-for-privatelink-deployment)
- Companion Logstash PR: https://github.com/elastic/logstash/pull/19462
- Related hosted-docs PR: https://github.com/elastic/docs-content/pull/8034