### PR TITLE
[9.4] libbeat/otel/otelmap: backport FromMapstr from main

### DIFF
--- a/changelog/fragments/1787700000-backport-otelmap-from-mapstr-9.4.yaml
+++ b/changelog/fragments/1787700000-backport-otelmap-from-mapstr-9.4.yaml
@@ -1,3 +1,0 @@
-kind: enhancement
-summary: Add FromMapstr to libbeat/otel/otelmap to allow encoding mapstr.M directly into pcommon.Map
-component: libbeat

--- a/changelog/fragments/1787700000-backport-otelmap-from-mapstr-9.4.yaml
+++ b/changelog/fragments/1787700000-backport-otelmap-from-mapstr-9.4.yaml
@@ -1,0 +1,3 @@
+kind: enhancement
+summary: Add FromMapstr to libbeat/otel/otelmap to allow encoding mapstr.M directly into pcommon.Map
+component: libbeat

--- a/libbeat/otel/otelmap/otelmap.go
+++ b/libbeat/otel/otelmap/otelmap.go
@@ -44,8 +44,7 @@ func ToMapstr(m pcommon.Map) mapstr.M {
 }
 
 // FromMapstr encodes src directly into dst as the inverse of [ToMapstr].
-// Unlike [ConvertNonPrimitive], this function writes directly into dst and
-// does not mutate src.
+// Note: nested map values in src may be mutated in place by [ConvertNonPrimitive].
 func FromMapstr[T mapstrOrMap](dst pcommon.Map, src T) error {
 	clone := make(map[string]any, len(src))
 	maps.Copy(clone, src)

--- a/libbeat/otel/otelmap/otelmap.go
+++ b/libbeat/otel/otelmap/otelmap.go
@@ -22,6 +22,7 @@ import (
 	"encoding"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"math"
 	"reflect"
 	"time"
@@ -47,9 +48,7 @@ func ToMapstr(m pcommon.Map) mapstr.M {
 // does not mutate src.
 func FromMapstr[T mapstrOrMap](dst pcommon.Map, src T) error {
 	clone := make(map[string]any, len(src))
-	for k, v := range src {
-		clone[k] = v
-	}
+	maps.Copy(clone, src)
 	ConvertNonPrimitive(clone)
 	return dst.FromRaw(clone)
 }

--- a/libbeat/otel/otelmap/otelmap.go
+++ b/libbeat/otel/otelmap/otelmap.go
@@ -42,6 +42,18 @@ func ToMapstr(m pcommon.Map) mapstr.M {
 	return m.AsRaw()
 }
 
+// FromMapstr encodes src directly into dst as the inverse of [ToMapstr].
+// Unlike [ConvertNonPrimitive], this function writes directly into dst and
+// does not mutate src.
+func FromMapstr[T mapstrOrMap](dst pcommon.Map, src T) error {
+	clone := make(map[string]any, len(src))
+	for k, v := range src {
+		clone[k] = v
+	}
+	ConvertNonPrimitive(clone)
+	return dst.FromRaw(clone)
+}
+
 // ConvertNonPrimitive handles the conversion of non-primitive data types to pcommon-primitive types.
 // The conversion is performed in place.
 // Notes:

--- a/libbeat/otel/otelmap/otelmap_test.go
+++ b/libbeat/otel/otelmap/otelmap_test.go
@@ -462,6 +462,23 @@ func TestUnknownType(t *testing.T) {
 	assert.Equal(t, expected, inputMap)
 }
 
+func TestFromMapstr(t *testing.T) {
+	input := mapstr.M{
+		"str":    "hello",
+		"num":    int64(42),
+		"nested": mapstr.M{"key": "value"},
+	}
+	dst := pcommon.NewMap()
+	err := FromMapstr(dst, input)
+	assert.NoError(t, err)
+	assert.Equal(t, "hello", dst.AsRaw()["str"])
+	assert.Equal(t, int64(42), dst.AsRaw()["num"])
+	assert.Equal(t, map[string]any{"key": "value"}, dst.AsRaw()["nested"])
+
+	// Verify src is not mutated
+	assert.Equal(t, mapstr.M{"key": "value"}, input["nested"])
+}
+
 func TestIsFloatWholeNumber(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
## What does this PR do?

Backports `otelmap.FromMapstr` from main/9.5 (#50303) to the 9.4 branch.

`otelmap.FromMapstr[T mapstrOrMap](dst pcommon.Map, src T) error` encodes a `mapstr.M` (or `map[string]any`) directly into a `pcommon.Map`. It was added to main in [perf(otelconsumer): encode log bodies directly (#50303)](https://github.com/elastic/beats/pull/50303) but was never backported to 9.4.

elastic-agent 9.4 references this function in its `elasticmonitoring` receiver, causing CI build failures when the beats submodule is updated to a 9.4 commit that predates this function.

The 9.4 implementation uses the existing `ConvertNonPrimitive` + `pcommon.Map.FromRaw` path (rather than the optimised `putIntoMap`-based approach from 9.5) to minimise diff size and avoid pulling in the full 9.5 rewrite. `ConvertNonPrimitive` is preserved as it is still used by `otelconsumer.go`.

## Why is it important?

Unblocks the automated beats-update PR in elastic-agent: https://github.com/elastic/elastic-agent/pull/16348

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `changelog/fragments` (only required for user-facing changes)