### PR TITLE
packetbeat/protos/{cassandra/internal/gocql,tls}: fix bounds panics in parsers

### DIFF
--- a/changelog/fragments/1787808118-fix-packetbeat-tls-cassandra-parser-panics.yaml
+++ b/changelog/fragments/1787808118-fix-packetbeat-tls-cassandra-parser-panics.yaml
@@ -1,0 +1,3 @@
+kind: bug-fix
+summary: Fix bounds-check panics in Packetbeat TLS and Cassandra protocol parsers.
+component: packetbeat

--- a/packetbeat/protos/cassandra/internal/gocql/array_decoder.go
+++ b/packetbeat/protos/cassandra/internal/gocql/array_decoder.go
@@ -168,7 +168,7 @@ func (f ByteArrayDecoder) ReadInet() (net.IP, int) {
 	}
 
 	data = *f.Data
-	if len(data) < 1 {
+	if len(data) < int(size) {
 		panic(fmt.Errorf("not enough bytes in buffer to Read inet require %d got: %d", size, len(data)))
 	}
 

--- a/packetbeat/protos/cassandra/internal/gocql/array_decoder_test.go
+++ b/packetbeat/protos/cassandra/internal/gocql/array_decoder_test.go
@@ -1,0 +1,60 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package cassandra
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestReadInetTruncatedPayload(t *testing.T) {
+	tests := []struct {
+		name string
+		data []byte
+	}{
+		{name: "IPv4 truncated", data: []byte{4, 0x7f}},        // size=4, only 1 byte follows
+		{name: "IPv6 truncated", data: []byte{16, 0x20, 0x01}}, // size=16, only 2 bytes follow
+		{name: "IPv4 empty", data: []byte{4}},                  // size=4, zero bytes follow
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			data := make([]byte, len(tc.data))
+			copy(data, tc.data)
+			decoder := ByteArrayDecoder{Data: &data}
+
+			var panicVal any
+			func() {
+				defer func() { panicVal = recover() }()
+				_, _ = decoder.ReadInet()
+			}()
+
+			if panicVal == nil {
+				t.Fatal("expected panic on truncated inet payload, got none")
+			}
+			// The panic should be our controlled error message, not a runtime
+			// index-out-of-bounds panic.
+			err, ok := panicVal.(error)
+			if !ok {
+				t.Fatalf("panic value should be an error, got %T: %v", panicVal, panicVal)
+			}
+			if !strings.Contains(err.Error(), "not enough bytes") {
+				t.Errorf("unexpected panic message: %v", err)
+			}
+		})
+	}
+}

--- a/packetbeat/protos/tls/tls.go
+++ b/packetbeat/protos/tls/tls.go
@@ -406,8 +406,7 @@ func (plugin *tlsPlugin) createEvent(conn *tlsConnectionData) beat.Event {
 		if raw, ok = serverHello.extensions.Raw[supportedVersionsExt]; ok && len(raw) >= 2 {
 			version.major = raw[0]
 			version.minor = raw[1]
-		}
-		if !ok {
+		} else {
 			version = serverHello.version
 		}
 	} else if !clientHello.version.IsZero() {

--- a/packetbeat/protos/tls/tls.go
+++ b/packetbeat/protos/tls/tls.go
@@ -403,7 +403,7 @@ func (plugin *tlsPlugin) createEvent(conn *tlsConnectionData) beat.Event {
 		var ok bool
 		var raw []byte
 		const supportedVersionsExt = 43
-		if raw, ok = serverHello.extensions.Raw[supportedVersionsExt]; ok {
+		if raw, ok = serverHello.extensions.Raw[supportedVersionsExt]; ok && len(raw) >= 2 {
 			version.major = raw[0]
 			version.minor = raw[1]
 		}

--- a/packetbeat/protos/tls/tls_test.go
+++ b/packetbeat/protos/tls/tls_test.go
@@ -666,6 +666,15 @@ func TestSupportedVersionsEmptyExtension(t *testing.T) {
 		private = p.Parse(&protos.Packet{Payload: reqData}, tcpTuple, 0, private)
 	})
 	assert.NotEmpty(t, results.events)
+	for key, expected := range map[string]string{
+		"tls.version":          "1.2",
+		"tls.version_protocol": "tls",
+		"tls.detailed.version": "TLS 1.2",
+	} {
+		version, err := results.events[0].Fields.GetValue(key)
+		assert.NoError(t, err)
+		assert.Equal(t, expected, version)
+	}
 }
 
 func TestLegacyVersionNegotiation(t *testing.T) {

--- a/packetbeat/protos/tls/tls_test.go
+++ b/packetbeat/protos/tls/tls_test.go
@@ -636,6 +636,38 @@ func TestTLS13VersionNegotiation(t *testing.T) {
 	}
 }
 
+func TestSupportedVersionsEmptyExtension(t *testing.T) {
+	results, p := testInit()
+	tcpTuple := testTCPTuple()
+	var private protos.ProtocolData
+
+	// Client Hello.
+	reqData, err := hex.DecodeString(rawClientHello)
+	require.NoError(t, err)
+	private = p.Parse(&protos.Packet{Payload: reqData}, tcpTuple, 0, private)
+
+	// ServerHello with supported_versions extension (0x002b) set to length 0,
+	// followed by a server-side ChangeCipherSpec.
+	reqData, err = hex.DecodeString("" +
+		"1603030078020000740303225084578024a693566bc71ba223826eeffc875b20" +
+		"27eec7337bf5fdf0eb1de720944f9b7806d887e27500dc6a05cfed8becf3d65a" +
+		"9a75ab618828f1b9e418d168130100002c00330024001d002070b27700b360aa" +
+		"3941a22da86901c00e174dc3d83e13cf4159b34b3de6809372" +
+		"002b0000" +
+		"140303000101",
+	)
+	require.NoError(t, err)
+	private = p.Parse(&protos.Packet{Payload: reqData}, tcpTuple, 1, private)
+
+	// Client ChangeCipherSpec triggers event construction — previously panicked.
+	reqData, err = hex.DecodeString(rawChangeCipherSpec)
+	require.NoError(t, err)
+	require.NotPanics(t, func() {
+		private = p.Parse(&protos.Packet{Payload: reqData}, tcpTuple, 0, private)
+	})
+	assert.NotEmpty(t, results.events)
+}
+
 func TestLegacyVersionNegotiation(t *testing.T) {
 	results, tls := testInit()
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message
```
packetbeat/protos/{cassandra/internal/gocql,tls}: fix bounds panics in parsers

TLS: a ServerHello with a zero-length supported_versions extension
(type 43) caused an index out of bounds panic at tls.go:407 because
raw[0] and raw[1] were accessed without checking len(raw) >= 2 first.
Add the length guard so a malformed extension is silently ignored.

Cassandra: ReadInet in array_decoder.go checked len(data) < 1 after
reading the size byte, but used size (4 or 16) as the slice bound,
so a truncated payload panicked with a runtime error instead of our
controlled message. Change the guard to len(data) < int(size).
```
<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Fixes #52649

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
