### PR TITLE
AGENTS.md: fix and shorten the changelog instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,18 +136,7 @@ When referencing code, always use exact locations and names:
 
 ## Changelog
 
-PRs require a changelog fragment in `changelog/fragments/` (CI enforced unless `skip-changelog` label is applied). Create using `elastic-agent-changelog-tool`:
-
-```bash
-go run github.com/elastic/elastic-agent-changelog-tool@latest new --component <beat> --kind <kind>
-```
-
-Fragment format (`changelog/fragments/<timestamp>-<slug>.yaml`):
-```yaml
-kind: bug-fix          # bug-fix, enhancement, breaking-change, deprecation, known-issue
-summary: Short description of the change
-component: filebeat    # the affected beat/component
-```
+If the change is user-visible (not tests, CI, refactoring, or docs), add a changelog fragment: run `go run github.com/elastic/elastic-agent-changelog-tool@latest new` and edit the emitted fragment following the instructions in its comments. Otherwise, add the `skip-changelog` label to the PR.
 
 ## Commits and PRs
 


### PR DESCRIPTION
## Proposed commit message

```
AGENTS.md: fix and shorten the changelog instructions

The documented `--component` and `--kind` flags do not exist on the
changelog tool's `new` subcommand.

The inline fragment template was incomplete, better read it directly
from the tool. The emitted fragment already documents every field in its
comments, which keeps this file from drifting out of sync.

Name the cases that do not need a fragment, since agents routinely add
them for test and CI changes.
```

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.~~
- [ ] ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).~~ Not user-visible, `skip-changelog` applied.

## Disruptive User Impact

None.

## How to test this PR locally

Run the command the file now points at from the repository root, on a branch:

```bash
go run github.com/elastic/elastic-agent-changelog-tool@latest new
```

It creates `changelog/fragments/<timestamp>-<branch>.yaml`, titled from the branch name, with comments documenting every field: the full list of `kind` values, `component`, and when `description`, `impact` and `action` are required.

For contrast, the command this PR removes fails outright:

```console
$ go run github.com/elastic/elastic-agent-changelog-tool@latest new --component filebeat --kind bug-fix
Error: unknown flag: --component
```

`new` accepts only `--title`:

```console
$ go run github.com/elastic/elastic-agent-changelog-tool@latest new --help
Create a new changelog fragment

Usage:
  elastic-agent-changelog-tool new title [flags]

Flags:
  -h, --help           help for new
      --title string   The title for the changelog
```
