### PR TITLE
Rename log key component to log.logger to prevent mapping conflict on Elasticsearch

### DIFF
--- a/changelog/fragments/1787946152-osquerybeat-rename-log-key-component-to-log.logger.yaml
+++ b/changelog/fragments/1787946152-osquerybeat-rename-log-key-component-to-log.logger.yaml
@@ -1,0 +1,4 @@
+kind: bug-fix
+summary: Rename log key `component` to `log.logger` to prevent mapping conflict on Elasticsearch
+component: osquerybeat
+issue: https://github.com/elastic/beats/issues/52888

--- a/x-pack/osquerybeat/beater/recurrence_query_handler.go
+++ b/x-pack/osquerybeat/beater/recurrence_query_handler.go
@@ -60,7 +60,7 @@ type recurrenceQueryHandler struct {
 // (same backing store as live queries), and policy-driven publish still follows LookupQueryProfile.
 func newRecurrenceQueryHandler(log *logp.Logger, cli *osqdcli.Client, configPlugin *ConfigPlugin, pub scheduledQueryPublisher, profiles liveProfileRecorder, osqueryVersion string) *recurrenceQueryHandler {
 	h := &recurrenceQueryHandler{
-		log:             log.With("component", "rrule-query-handler"),
+		log:             log.With("log.logger", "rrule-query-handler"),
 		cli:             cli,
 		configPlugin:    configPlugin,
 		publisher:       pub,

--- a/x-pack/osquerybeat/internal/scheduler/scheduler.go
+++ b/x-pack/osquerybeat/internal/scheduler/scheduler.go
@@ -85,7 +85,7 @@ type scheduledJob struct {
 // New creates a new recurrence scheduler
 func New(log *logp.Logger, queryFunc QueryFunc) *Scheduler {
 	return &Scheduler{
-		log:       log.With("component", "recurrence-scheduler"),
+		log:       log.With("log.logger", "recurrence-scheduler"),
 		queries:   make(map[string]*scheduledJob),
 		queryFunc: queryFunc,
 	}


### PR DESCRIPTION
## Proposed commit message

```
The log key component clashes with the Elastic Agent mapping of
component: Osquerybeat uses it as string and Elastic Agent uses it as
an object.
```


## Checklist

- [x] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] I~~ have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.~~
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

~~## Disruptive User Impact~~


## How to test this PR locally
Run Osquerybeat, look for a log entry with the message `Recurrence scheduler started`, this entry must contain the field `log.logger: recurrence-scheduler` instead of `component: recurrence-scheduler`

## Related issues

- Closes https://github.com/elastic/beats/issues/52888


~~## Use cases~~
~~# Screenshots~~
~~## Logs~~