### PR TITLE
x-pack/osquerybeat: stamp space_id on live query result and profile documents

### DIFF
--- a/changelog/fragments/1788155659-osquerybeat-live-query-space-id.yaml
+++ b/changelog/fragments/1788155659-osquerybeat-live-query-space-id.yaml
@@ -1,0 +1,3 @@
+kind: bug-fix
+summary: Stamp space_id on Osquerybeat live query result and profile documents so results are visible in non-default Kibana spaces.
+component: osquerybeat

--- a/x-pack/osquerybeat/beater/action_handler.go
+++ b/x-pack/osquerybeat/beater/action_handler.go
@@ -34,7 +34,7 @@ type scheduledResponsePublisher interface {
 }
 
 type queryProfilePublisher interface {
-	PublishQueryProfile(index, queryName, actionID, responseID string, profile map[string]any, reqData any)
+	PublishQueryProfile(index, queryName, actionID, responseID, spaceID string, profile map[string]any, reqData any)
 }
 
 type liveProfileRecorder interface {
@@ -172,7 +172,7 @@ func (a *actionHandler) executeQuery(ctx context.Context, index string, ac actio
 				a.profiles.RecordLiveProfile(ac.Query, profile)
 			}
 			if publishProfile {
-				a.publisher.PublishQueryProfile(config.QueryProfileDatastream(a.namespace()), "", ac.ID, responseID, profile, req["data"])
+				a.publisher.PublishQueryProfile(config.QueryProfileDatastream(a.namespace()), "", ac.ID, responseID, ac.SpaceID, profile, req["data"])
 			}
 		}
 	} else if shouldCollect && !beforeReady {
@@ -190,7 +190,7 @@ func (a *actionHandler) executeQuery(ctx context.Context, index string, ac actio
 
 	a.log.Debugf("Completed query in: %v", duration)
 
-	a.publisher.Publish(index, ac.ID, "action_id", responseID, "", "", "", "", nil, hits, ac.ECSMapping, req["data"])
+	a.publisher.Publish(index, ac.ID, "action_id", responseID, ac.SpaceID, "", "", "", nil, hits, ac.ECSMapping, req["data"])
 
 	return len(hits), nil
 }

--- a/x-pack/osquerybeat/beater/action_handler_test.go
+++ b/x-pack/osquerybeat/beater/action_handler_test.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/elastic/beats/v7/x-pack/osquerybeat/internal/ecs"
 	"github.com/elastic/beats/v7/x-pack/osquerybeat/internal/osqdcli"
-	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 )
 
 type mockExecutor struct {
@@ -32,19 +32,20 @@ func (e *mockExecutor) Query(ctx context.Context, sql string, to time.Duration) 
 }
 
 type mockPublisher struct {
-	index      string
-	idValue    string
-	idFieldKey string
-	responseID string
-	spaceID    string
-	packID     string
-	packName   string
-	queryName  string
-	meta       map[string]any
-	hits       []map[string]any
-	ecsm       ecs.Mapping
-	reqData    any
-	profile    map[string]any
+	index          string
+	idValue        string
+	idFieldKey     string
+	responseID     string
+	spaceID        string
+	packID         string
+	packName       string
+	queryName      string
+	meta           map[string]any
+	hits           []map[string]any
+	ecsm           ecs.Mapping
+	reqData        any
+	profile        map[string]any
+	profileSpaceID string
 }
 
 func (p *mockPublisher) Publish(index, idValue, idFieldKey, responseID, spaceID, packID, packName, queryName string, meta map[string]any, hits []map[string]any, ecsm ecs.Mapping, reqData any) {
@@ -62,12 +63,13 @@ func (p *mockPublisher) Publish(index, idValue, idFieldKey, responseID, spaceID,
 	p.reqData = reqData
 }
 
-func (p *mockPublisher) PublishQueryProfile(index, queryName, actionID, responseID string, profile map[string]any, reqData any) {
+func (p *mockPublisher) PublishQueryProfile(index, queryName, actionID, responseID, spaceID string, profile map[string]any, reqData any) {
 	p.profile = profile
+	p.profileSpaceID = spaceID
 }
 
 func TestActionHandlerExecute(t *testing.T) {
-	validLogger := logp.NewLogger("action_test")
+	validLogger := logptest.NewTestingLogger(t, t.Name())
 	inputType := osqueryInputType
 
 	ctx := context.Background()
@@ -212,5 +214,49 @@ func TestActionHandlerExecute(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestActionHandlerExecuteSpaceID(t *testing.T) {
+	// collectRuntimeSnapshot issues its own Query calls, so the executor must
+	// return non-empty results or the snapshot will fail and no profile is collected.
+	osqueryInfoRow := map[string]any{
+		"pid":           "1",
+		"resident_size": "1000",
+		"user_time":     "10",
+		"system_time":   "5",
+	}
+	exec := &mockExecutor{result: []map[string]any{osqueryInfoRow}}
+	pub := &mockPublisher{}
+
+	id, err := uuid.NewV4()
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := map[string]any{
+		"id":       id.String(),
+		"space_id": "my-space",
+		"data": map[string]any{
+			"query":   "select * from uptime",
+			"profile": true,
+		},
+	}
+
+	ac := &actionHandler{
+		log:       logptest.NewTestingLogger(t, t.Name()),
+		inputType: osqueryInputType,
+		queryExec: exec,
+		publisher: pub,
+	}
+
+	if _, err := ac.Execute(t.Context(), req); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	if pub.spaceID != "my-space" {
+		t.Errorf("Publish spaceID = %q; want %q", pub.spaceID, "my-space")
+	}
+	if pub.profileSpaceID != "my-space" {
+		t.Errorf("PublishQueryProfile spaceID = %q; want %q", pub.profileSpaceID, "my-space")
 	}
 }

--- a/x-pack/osquerybeat/beater/osquerybeat.go
+++ b/x-pack/osquerybeat/beater/osquerybeat.go
@@ -831,7 +831,7 @@ func (bt *osquerybeat) handleQueryResult(ctx context.Context, cli *osqdcli.Clien
 		if err != nil {
 			bt.log.Debugf("failed to collect scheduled query profile for %s: %v", res.Name, err)
 		} else {
-			bt.pub.PublishQueryProfile(config.QueryProfileDatastream(ns), res.Name, "", responseID, profile, nil)
+			bt.pub.PublishQueryProfile(config.QueryProfileDatastream(ns), res.Name, "", responseID, qi.SpaceID, profile, nil)
 		}
 	}
 

--- a/x-pack/osquerybeat/beater/osquerybeat_publisher_test.go
+++ b/x-pack/osquerybeat/beater/osquerybeat_publisher_test.go
@@ -30,7 +30,7 @@ func (m *mockBeatPublisher) PublishActionResult(req map[string]any, res map[stri
 func (m *mockBeatPublisher) PublishScheduledResponse(scheduleID, packID, packName, queryName, spaceID, responseID string, startedAt, completedAt, plannedScheduleTime time.Time, resultCount int, scheduleExecutionCount int64) {
 }
 
-func (m *mockBeatPublisher) PublishQueryProfile(index, queryName, actionID, responseID string, profile map[string]any, reqData any) {
+func (m *mockBeatPublisher) PublishQueryProfile(index, queryName, actionID, responseID, spaceID string, profile map[string]any, reqData any) {
 }
 
 func (m *mockBeatPublisher) Configure(inputs []config.InputConfig) error {

--- a/x-pack/osquerybeat/beater/recurrence_query_handler.go
+++ b/x-pack/osquerybeat/beater/recurrence_query_handler.go
@@ -34,6 +34,7 @@ type rruleRuntimeProfileState struct {
 	queryName            string
 	ns                   string
 	responseID           string
+	spaceID              string
 	sql                  string
 	shouldPublishProfile bool
 	shouldCollectProfile bool
@@ -247,10 +248,15 @@ func (h *recurrenceQueryHandler) retainDiffState(queries []*scheduler.ScheduledQ
 // initRRuleRuntimeProfiling collects a pre-query process snapshot when profiling is enabled
 // for this query (publish flag and/or local profile store).
 func (h *recurrenceQueryHandler) initRRuleRuntimeProfiling(ctx context.Context, name, ns, responseID, sql string) rruleRuntimeProfileState {
+	var spaceID string
+	if qi, ok := h.configPlugin.LookupQueryInfo(name); ok {
+		spaceID = qi.SpaceID
+	}
 	st := rruleRuntimeProfileState{
 		queryName:            name,
 		ns:                   ns,
 		responseID:           responseID,
+		spaceID:              spaceID,
 		sql:                  sql,
 		shouldPublishProfile: h.configPlugin.LookupQueryProfile(name),
 	}
@@ -292,7 +298,7 @@ func (h *recurrenceQueryHandler) completeRRuleRuntimeProfiling(ctx context.Conte
 		h.profiles.RecordLiveProfile(st.sql, prof)
 	}
 	if st.shouldPublishProfile {
-		h.publisher.PublishQueryProfile(config.QueryProfileDatastream(st.ns), st.queryName, "", st.responseID, prof, nil)
+		h.publisher.PublishQueryProfile(config.QueryProfileDatastream(st.ns), st.queryName, "", st.responseID, st.spaceID, prof, nil)
 	}
 }
 

--- a/x-pack/osquerybeat/internal/action/action.go
+++ b/x-pack/osquerybeat/internal/action/action.go
@@ -20,10 +20,13 @@ var (
 )
 
 type Action struct {
-	Query     string
-	ID        string
+	Query string
+	ID    string
+	// SpaceID is the optional Kibana space the action originated from.
+	// It scopes query results and responses to that space in Kibana.
+	SpaceID   string
 	Platforms []string
-	// The optional action timeout
+	// Timeout is the optional query timeout.
 	Timeout    time.Duration
 	ECSMapping ecs.Mapping
 	// Profile is the optional per-action profiling override. When nil the global
@@ -99,9 +102,14 @@ func FromMap(m map[string]any) (a Action, err error) {
 		return a, fmt.Errorf("missing query: %w", ErrActionRequest)
 	}
 
+	// A non-string space_id is ignored rather than failing the action;
+	// losing the field only affects space-scoped reads in Kibana.
+	spaceID, _ := m["space_id"].(string)
+
 	a = Action{
 		Query:      query,
 		ID:         id,
+		SpaceID:    strings.TrimSpace(spaceID),
 		Platforms:  platforms,
 		ECSMapping: ecsm,
 		Profile:    profile,

--- a/x-pack/osquerybeat/internal/action/action_test.go
+++ b/x-pack/osquerybeat/internal/action/action_test.go
@@ -146,6 +146,35 @@ func TestActionFromMap(t *testing.T) {
 			},
 			Err: ErrActionRequest,
 		},
+		{
+			Name: "valid space_id",
+			Map: map[string]any{
+				"id":       "123456789",
+				"space_id": "my-space",
+				"data": map[string]any{
+					"query": "select * from foo",
+				},
+			},
+		},
+		{
+			Name: "absent space_id",
+			Map: map[string]any{
+				"id": "123456789",
+				"data": map[string]any{
+					"query": "select * from foo",
+				},
+			},
+		},
+		{
+			Name: "non-string space_id is ignored",
+			Map: map[string]any{
+				"id":       "123456789",
+				"space_id": 42,
+				"data": map[string]any{
+					"query": "select * from foo",
+				},
+			},
+		},
 	}
 
 	for _, tc := range tests {
@@ -170,6 +199,16 @@ func TestActionFromMap(t *testing.T) {
 			if tc.Name == "valid platform" {
 				if diff := cmp.Diff([]string{"linux", "windows"}, a.Platforms); diff != "" {
 					t.Errorf("unexpected platforms (-want +got):\n%s", diff)
+				}
+			}
+			if tc.Name == "valid space_id" {
+				if a.SpaceID != "my-space" {
+					t.Errorf("FromMap SpaceID = %q; want %q", a.SpaceID, "my-space")
+				}
+			}
+			if tc.Name == "absent space_id" || tc.Name == "non-string space_id is ignored" {
+				if a.SpaceID != "" {
+					t.Errorf("FromMap SpaceID = %q; want %q", a.SpaceID, "")
 				}
 			}
 		})

--- a/x-pack/osquerybeat/internal/pub/publisher.go
+++ b/x-pack/osquerybeat/internal/pub/publisher.go
@@ -249,7 +249,7 @@ func (p *Publisher) publishActionResponseEvent(fields map[string]any, timestamp 
 	p.actionResponsesClient.Publish(event)
 }
 
-func (p *Publisher) PublishQueryProfile(index, queryName, actionID, responseID string, profile map[string]any, reqData any) {
+func (p *Publisher) PublishQueryProfile(index, queryName, actionID, responseID, spaceID string, profile map[string]any, reqData any) {
 	p.mx.Lock()
 	defer p.mx.Unlock()
 
@@ -261,6 +261,23 @@ func (p *Publisher) PublishQueryProfile(index, queryName, actionID, responseID s
 		return
 	}
 
+	fields := queryProfileToEvent(queryName, actionID, responseID, spaceID, profile, reqData)
+
+	event := beat.Event{
+		Timestamp: time.Now(),
+		Fields:    fields,
+	}
+	if index != "" {
+		event.Meta = mapstr.M{events.FieldMetaRawIndex: index}
+	}
+
+	p.log.Debugf("Query profile event is sent, fields: %#v", fields)
+
+	p.queryProfileClient.Publish(event)
+}
+
+// queryProfileToEvent builds the field set for a query profile document.
+func queryProfileToEvent(queryName, actionID, responseID, spaceID string, profile map[string]any, reqData any) mapstr.M {
 	fields := mapstr.M{
 		"type": "osquery_profile",
 		"event": map[string]any{
@@ -279,21 +296,13 @@ func (p *Publisher) PublishQueryProfile(index, queryName, actionID, responseID s
 	if responseID != "" {
 		fields["response_id"] = responseID
 	}
+	if spaceID != "" {
+		fields["space_id"] = spaceID
+	}
 	if reqData != nil {
 		fields["action_data"] = reqData
 	}
-
-	event := beat.Event{
-		Timestamp: time.Now(),
-		Fields:    fields,
-	}
-	if index != "" {
-		event.Meta = mapstr.M{events.FieldMetaRawIndex: index}
-	}
-
-	p.log.Debugf("Query profile event is sent, fields: %#v", fields)
-
-	p.queryProfileClient.Publish(event)
+	return fields
 }
 
 func actionResultToEvent(req, res map[string]any) map[string]any {

--- a/x-pack/osquerybeat/internal/pub/publisher_test.go
+++ b/x-pack/osquerybeat/internal/pub/publisher_test.go
@@ -331,6 +331,35 @@ func TestHitToEvent_NoPackNameOrQueryName(t *testing.T) {
 	}
 }
 
+func TestQueryProfileToEvent_SpaceID(t *testing.T) {
+	tests := []struct {
+		name    string
+		spaceID string
+		present bool
+	}{
+		{name: "present", spaceID: "production", present: true},
+		{name: "absent", spaceID: "", present: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fields := queryProfileToEvent("", "", "", tc.spaceID, map[string]any{"key": "val"}, nil)
+			got, ok := fields["space_id"]
+			if tc.present {
+				if !ok {
+					t.Errorf("expected space_id %q, field not present", tc.spaceID)
+				} else if got != tc.spaceID {
+					t.Errorf("space_id mismatch: got=%q want=%q", got, tc.spaceID)
+				}
+			} else {
+				if ok {
+					t.Errorf("expected no space_id field, got %v", got)
+				}
+			}
+		})
+	}
+}
+
 func toMap(t *testing.T, s string) map[string]any {
 	var m map[string]any
 	err := json.Unmarshal([]byte(s), &m)


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message
```
x-pack/osquerybeat: stamp space_id on live query result and profile documents

Live query results published from a non-default Kibana space were
missing space_id, so the Osquery UI showed an empty results table.
The field was already present on scheduled and RRULE query documents;
only the live-query path passed an empty literal.

Parse space_id in action.FromMap alongside id (it is a top-level
sibling in the Fleet action document). A non-string value is silently
ignored so a malformed field cannot abort a live query. Carry the
field on action.Action and pass it to Publish at the live call site
in action_handler.go.

Also add spaceID to PublishQueryProfile and wire it on all three
callers (live, native-scheduled, and RRULE) so profile documents
are space-scoped too. Extract queryProfileToEvent to make the new
field independently testable.
```
<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Fixes #52873

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
