### PR TITLE
packetbeat: fix flow collection under the Elastic Agent OTel runtime

### DIFF
--- a/changelog/fragments/1788187531-fix-otel-packetbeat-flows.yaml
+++ b/changelog/fragments/1788187531-fix-otel-packetbeat-flows.yaml
@@ -41,7 +41,7 @@ component: packetbeat
 # If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
 # NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
 # Please provide it if you are adding a fragment for a different PR.
-# pr: https://github.com/owner/repo/1234
+pr: https://github.com/elastic/beats/pull/52932
 
 # AUTOMATED
 # OPTIONAL to manually add other issue URLs

--- a/changelog/fragments/1788187531-fix-otel-packetbeat-flows.yaml
+++ b/changelog/fragments/1788187531-fix-otel-packetbeat-flows.yaml
@@ -1,0 +1,50 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: Fix network flow collection under the Elastic Agent OTel runtime.
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+description: |
+  Under the Elastic Agent OTel runtime, the flows stream is delivered in the
+  protocols list, where Packetbeat dropped it as an unknown protocol plugin,
+  collecting no flow events. Flow entries in the protocols list are now routed
+  to the flows configuration, and unknown protocol entries mark Packetbeat as
+  degraded instead of being silently ignored.
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: packetbeat
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: https://github.com/elastic/beats/issues/52931

--- a/packetbeat/beater/processor.go
+++ b/packetbeat/beater/processor.go
@@ -19,6 +19,7 @@ package beater
 
 import (
 	"fmt"
+	"slices"
 	"sync"
 	"time"
 
@@ -57,9 +58,14 @@ type processor struct {
 	statusMu       sync.RWMutex
 	status         status.StatusReporter
 	publishTimeout time.Duration
+	// degradedReason is a non-fatal configuration problem detected at
+	// creation time. It is reported when the processor starts, rather
+	// than at creation, because under OTel management the status
+	// reporter is only injected after the runner has been created.
+	degradedReason string
 }
 
-func newProcessor(publishTimeout time.Duration, publisher *publish.TransactionPublisher, flows *flows.Flows, sniffer *sniffer.Sniffer, err chan error, status status.StatusReporter) *processor {
+func newProcessor(publishTimeout time.Duration, publisher *publish.TransactionPublisher, flows *flows.Flows, sniffer *sniffer.Sniffer, err chan error, degradedReason string, status status.StatusReporter) *processor {
 	return &processor{
 		publisher:      publisher,
 		flows:          flows,
@@ -67,6 +73,7 @@ func newProcessor(publishTimeout time.Duration, publisher *publish.TransactionPu
 		err:            err,
 		status:         status,
 		publishTimeout: publishTimeout,
+		degradedReason: degradedReason,
 	}
 }
 
@@ -82,7 +89,11 @@ func (p *processor) Start() {
 	p.wg.Go(func() {
 		defer p.wg.Done()
 
-		p.UpdateStatus(status.Running, "running packetbeat processor")
+		if p.degradedReason != "" {
+			p.UpdateStatus(status.Degraded, p.degradedReason)
+		} else {
+			p.UpdateStatus(status.Running, "running packetbeat processor")
+		}
 		err := p.sniffer.Run()
 		if err != nil {
 			p.err <- fmt.Errorf("sniffer loop failed: %w", err)
@@ -154,11 +165,11 @@ func (p *processorFactory) CreateWithReporter(pipeline beat.PipelineConnector, c
 		statusReporter = noopReporter{}
 	}
 	statusReporter.UpdateStatus(status.Configuring, "starting packetbeat processor configuration")
-	publishTimeout, publisher, flows, sniffer, errChan, err := p.create(pipeline, cfg, statusReporter)
+	publishTimeout, publisher, flows, sniffer, errChan, degradedReason, err := p.create(pipeline, cfg, statusReporter)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create packetbeat processor: %w", err)
 	}
-	return newProcessor(publishTimeout, publisher, flows, sniffer, errChan, statusReporter), nil
+	return newProcessor(publishTimeout, publisher, flows, sniffer, errChan, degradedReason, statusReporter), nil
 }
 
 // Create returns a new module runner that publishes to the provided pipeline, configured from cfg.
@@ -166,16 +177,20 @@ func (p *processorFactory) Create(pipeline beat.PipelineConnector, cfg *conf.C) 
 	return p.CreateWithReporter(pipeline, cfg, nil)
 }
 
-func (p *processorFactory) create(pipeline beat.PipelineConnector, cfg *conf.C, reporter status.StatusReporter) (time.Duration, *publish.TransactionPublisher, *flows.Flows, *sniffer.Sniffer, chan error, error) {
+func (p *processorFactory) create(pipeline beat.PipelineConnector, cfg *conf.C, reporter status.StatusReporter) (time.Duration, *publish.TransactionPublisher, *flows.Flows, *sniffer.Sniffer, chan error, string, error) {
 	config, err := p.configurator(cfg, p.logger)
 	if err != nil {
 		p.logger.Errorf("Failed to read the beat config: %v, %v", err, config)
-		return 0, nil, nil, nil, nil, err
+		return 0, nil, nil, nil, nil, "", err
+	}
+	degradedReason, err := unknownProtocolsReason(config)
+	if err != nil {
+		return 0, nil, nil, nil, nil, "", err
 	}
 	id, err := configID(cfg)
 	if err != nil {
 		p.logger.Errorf("Failed to generate ID from config: %v, %v", err, config)
-		return 0, nil, nil, nil, nil, err
+		return 0, nil, nil, nil, nil, "", err
 	}
 	if len(config.Interfaces) != 0 {
 		// Install Npcap if needed. This needs to happen before any other
@@ -192,13 +207,13 @@ func (p *processorFactory) create(pipeline beat.PipelineConnector, cfg *conf.C, 
 		// interface.
 		err := installNpcap(p.beat, cfg)
 		if err != nil {
-			return 0, nil, nil, nil, nil, err
+			return 0, nil, nil, nil, nil, "", err
 		}
 		// Ensure the DLL is loaded whether Npcap was just installed above
 		// or was already present from a previous run.
 		err = npcap.LoadNpcap()
 		if err != nil {
-			return 0, nil, nil, nil, nil, err
+			return 0, nil, nil, nil, nil, "", err
 		}
 	}
 
@@ -211,7 +226,7 @@ func (p *processorFactory) create(pipeline beat.PipelineConnector, cfg *conf.C, 
 		p.logger,
 	)
 	if err != nil {
-		return 0, nil, nil, nil, nil, err
+		return 0, nil, nil, nil, nil, "", err
 	}
 
 	var watch procs.ProcessesWatcher
@@ -220,7 +235,7 @@ func (p *processorFactory) create(pipeline beat.PipelineConnector, cfg *conf.C, 
 		err = watch.Init(config.Procs, p.logger)
 		if err != nil {
 			p.logger.Errorf("%s", err.Error())
-			return 0, nil, nil, nil, nil, err
+			return 0, nil, nil, nil, nil, "", err
 		}
 	} else {
 		p.logger.Info("Process watcher disabled when file input is used")
@@ -228,14 +243,45 @@ func (p *processorFactory) create(pipeline beat.PipelineConnector, cfg *conf.C, 
 
 	flows, err := setupFlows(pipeline, &watch, config, p.beat.Info.Logger)
 	if err != nil {
-		return 0, nil, nil, nil, nil, err
+		return 0, nil, nil, nil, nil, "", err
 	}
 	sniffer, err := setupSniffer(id, config, publisher, &watch, flows, reporter, p.logger)
 	if err != nil {
-		return 0, nil, nil, nil, nil, err
+		return 0, nil, nil, nil, nil, "", err
 	}
 
-	return config.PublishTimeout, publisher, flows, sniffer, p.err, nil
+	return config.PublishTimeout, publisher, flows, sniffer, p.err, degradedReason, nil
+}
+
+// unknownProtocolsReason returns a status message if the configuration holds
+// protocol entries that have no registered protocol plugin. Such entries are
+// logged and ignored during protocol setup rather than causing a hard
+// failure, so they are surfaced by marking the processor degraded.
+func unknownProtocolsReason(cfg config.Config) (string, error) {
+	var unknown []string
+	for name := range cfg.Protocols {
+		// icmp is special-cased during protocol setup, so it is never
+		// an unknown protocol.
+		if name != "icmp" && protos.Lookup(name) == protos.UnknownProtocol {
+			unknown = append(unknown, name)
+		}
+	}
+	for _, protocol := range cfg.ProtocolsList {
+		module := struct {
+			Type string `config:"type"`
+		}{}
+		if err := protocol.Unpack(&module); err != nil {
+			return "", err
+		}
+		if module.Type != "" && module.Type != "icmp" && protos.Lookup(module.Type) == protos.UnknownProtocol {
+			unknown = append(unknown, module.Type)
+		}
+	}
+	if len(unknown) == 0 {
+		return "", nil
+	}
+	slices.Sort(unknown)
+	return fmt.Sprintf("configuration ignored for unknown protocol plugins: %v", slices.Compact(unknown)), nil
 }
 
 // setupFlows returns a *flows.Flows that will publish to the provided pipeline,

--- a/packetbeat/beater/processor_test.go
+++ b/packetbeat/beater/processor_test.go
@@ -1,0 +1,85 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package beater
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/beats/v7/packetbeat/config"
+	"github.com/elastic/beats/v7/packetbeat/procs"
+	"github.com/elastic/beats/v7/packetbeat/protos"
+	conf "github.com/elastic/elastic-agent-libs/config"
+	"github.com/elastic/elastic-agent-libs/logp"
+)
+
+func TestUnknownProtocolsReason(t *testing.T) {
+	protos.Register("knowntest", func(testMode bool, results protos.Reporter, watcher *procs.ProcessesWatcher, cfg *conf.C, logger *logp.Logger) (protos.Plugin, error) {
+		return nil, nil
+	})
+
+	tests := []struct {
+		name string
+		cfg  config.Config
+		want string
+	}{
+		{
+			name: "empty",
+			cfg:  config.Config{},
+			want: "",
+		},
+		{
+			name: "known_and_icmp",
+			cfg: config.Config{
+				ProtocolsList: []*conf.C{
+					conf.MustNewConfigFrom(map[string]any{"type": "icmp"}),
+					conf.MustNewConfigFrom(map[string]any{"type": "knowntest"}),
+				},
+			},
+			want: "",
+		},
+		{
+			name: "unknown_in_list",
+			cfg: config.Config{
+				ProtocolsList: []*conf.C{
+					conf.MustNewConfigFrom(map[string]any{"type": "knowntest"}),
+					conf.MustNewConfigFrom(map[string]any{"type": "nosuchproto"}),
+				},
+			},
+			want: "configuration ignored for unknown protocol plugins: [nosuchproto]",
+		},
+		{
+			name: "unknown_in_map",
+			cfg: config.Config{
+				Protocols: map[string]*conf.C{
+					"icmp":  conf.MustNewConfigFrom(map[string]any{"enabled": true}),
+					"bogus": conf.MustNewConfigFrom(map[string]any{"enabled": true}),
+				},
+			},
+			want: "configuration ignored for unknown protocol plugins: [bogus]",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := unknownProtocolsReason(test.cfg)
+			assert.NoError(t, err, "unexpected error extracting protocol types")
+			assert.Equal(t, test.want, got, "unexpected degraded reason")
+		})
+	}
+}

--- a/packetbeat/config/config.go
+++ b/packetbeat/config/config.go
@@ -72,6 +72,27 @@ func (c Config) FromStatic(cfg *conf.C, _ *logp.Logger) (Config, error) {
 	if err != nil {
 		return c, err
 	}
+	// Under agent semantics the flows stream is delivered alongside the
+	// protocols streams, so it may arrive as a protocols list entry with
+	// type "flow". Route it to the flows configuration, consistent with
+	// NewAgentConfig.
+	protocols := c.ProtocolsList[:0]
+	for _, protocol := range c.ProtocolsList {
+		module := struct {
+			Type string `config:"type"`
+		}{}
+		if err := protocol.Unpack(&module); err != nil {
+			return c, err
+		}
+		if module.Type == "flow" {
+			if err := protocol.Unpack(&c.Flows); err != nil {
+				return c, err
+			}
+			continue
+		}
+		protocols = append(protocols, protocol)
+	}
+	c.ProtocolsList = protocols
 	iface, err := cfg.Child("interfaces", -1)
 	if err == nil {
 		if !iface.IsArray() {

--- a/packetbeat/config/config_test.go
+++ b/packetbeat/config/config_test.go
@@ -425,6 +425,42 @@ protocols:
 		},
 	},
 	{
+		// Agent semantics deliver the flows stream in the protocols
+		// list; it must be routed to the flows configuration.
+		name: "flow_in_protocols_list",
+		config: `
+interfaces.device: default_route
+
+protocols:
+- type: flow
+  timeout: 30s
+  period: -1s
+  index: logs-network_traffic.flow-default
+
+- type: amqp
+  ports: [5672]
+`,
+		want: Config{
+			Interfaces: []InterfaceConfig{{
+				Device: "default_route",
+			}},
+			Flows: &Flows{
+				Timeout: "30s",
+				Period:  "-1s",
+				Index:   "logs-network_traffic.flow-default",
+			},
+			Protocols: map[string]*config.C{},
+			ProtocolsList: []*config.C{
+				config.MustNewConfigFrom(map[string]any{
+					"type": "amqp",
+					"ports": []int{
+						5672,
+					},
+				}),
+			},
+		},
+	},
+	{
 		name: "duplicated_interface",
 		config: `
 interfaces:


### PR DESCRIPTION
## Proposed commit message

```
packetbeat: fix flow collection under the Elastic Agent OTel runtime

Under the Elastic Agent OTel runtime, the agent rewrites the packet
input's policy into receiver configuration that delivers every stream,
including the flows stream, as an entry in the packetbeat.protocols
list. Packetbeat parses incoming configuration into an internal Config
in which flow tracking (Flows) is kept separate from protocol
analyzers (ProtocolsList), so the config loader must recognize the
flow entry and route it to the right place.

FromStatic, the loader used by the OTel receiver (and standalone
Packetbeat), did no such routing: the flow entry stayed in the parsed
protocols list, where protocol setup rejected it as an unknown
protocol plugin ("Unknown protocol plugin: flow"), and the parsed
flows section stayed empty, so flow setup was skipped entirely. No
flow events were collected and status remained healthy. This broke
network_traffic.flow collection when agents switched to the OTel
runtime in 9.5.

Two changes:

- FromStatic now unpacks type: flow entries from the incoming
  protocols list into the parsed flows configuration and drops them
  from the parsed protocols list. This parallels the existing handling
  in NewAgentConfig, the loader used by the non-OTel (process runtime)
  implementation, which has always special-cased the flow stream this
  way. Both loaders now produce the same parsed configuration from
  agent-delivered input.
- Entries in the incoming protocols list whose type has no registered
  protocol plugin now mark the Packetbeat processor as degraded rather
  than being logged and silently ignored, so a future misrouted or
  misspelled stream surfaces in Agent health instead of quietly
  dropping data. It does not fail hard; other streams keep collecting.
  The report happens at processor start because under OTel management
  the status reporter is only injected after the runner is created.
```

## Note to reviewers

The two changes are in separate commits for easier review.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works. ~~Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.~~
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

None expected for flow collection — it restores the 9.4.x behavior for agents on the OTel runtime. One visible status change: configurations containing protocol types with no registered plugin previously ran with a healthy status and an error log; they now report the Packetbeat processor as degraded (collection of valid streams is unaffected).

## How to test this PR locally

Unit tests:

```bash
cd packetbeat
go test -race -run 'TestFromStatic|TestUnknownProtocolsReason' ./config/... ./beater/...
```

Manual reproduction of the bug shape (flow config in the protocols list, as generated by the agent's OTel translation), using standalone Packetbeat since it shares the `FromStatic` config path:

```yaml
packetbeat.interfaces.device: any
packetbeat.protocols:
  - type: flow
    period: 10s
    timeout: 30s
output.console.enabled: true
```

Before this change: "Unknown protocol plugin: flow" is logged and no flow events are emitted.
After: flow events appear on the console.

## Related issues

- Closes #52931

## Use cases

- Elastic Agent 9.5+ running the `network_traffic` integration on the OTel runtime collects `network_traffic.flow` documents again.
- Any Packetbeat config that carries the flow stream inside the protocols list is interpreted consistently with the process-runtime agent path.
- A stream type that Packetbeat does not recognize degrades the component health instead of failing silently.

## Logs

Error from the logs of the agent affected by the bug (9.5.2):

```
Unknown protocol plugin: flow
```