### PR TITLE
ci: add DRA prep pipeline

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1178,7 +1178,7 @@ apiVersion: backstage.io/v1alpha1
 kind: Resource
 metadata:
   name: beats-dra-prep-pipeline
-  description: Buildkite pipeline for DRA prep + publishing, triggered by beats-packaging-pipeline
+  description: Buildkite pipeline for DRA prep
   links:
     - title: Pipeline
       url: https://buildkite.com/elastic/beats-dra-prep-pipeline
@@ -1191,7 +1191,7 @@ spec:
     kind: Pipeline
     metadata:
       name: beats-dra-prep-pipeline
-      description: Runs elastic/dra-prep + annotation for beats, triggered by beats-packaging-pipeline
+      description: Runs elastic/dra-prep
     spec:
       repository: elastic/beats
       pipeline_file: ".buildkite/dra-prep.pipeline.yml"
@@ -1212,7 +1212,7 @@ spec:
       teams:
         streams:
           access_level: MANAGE_BUILD_AND_READ
-        release-eng:
+        artifact-management:
           access_level: BUILD_AND_READ
         everyone:
           access_level: BUILD_AND_READ

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1201,8 +1201,7 @@ spec:
       maximum_timeout_in_minutes: 90
       provider_settings:
         # Only ever run via the trigger step in packaging.pipeline.yml, or
-        # manually from the Buildkite UI for testing (see teams below) --
-        # matches unified-release-dra-processing's config for the same shape.
+        # manually from the Buildkite UI for testing
         build_pull_requests: false
         trigger_mode: none
       env:

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1177,6 +1177,54 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Resource
 metadata:
+  name: beats-dra-prep-pipeline
+  description: Buildkite pipeline for DRA prep + publishing, triggered by beats-packaging-pipeline
+  links:
+    - title: Pipeline
+      url: https://buildkite.com/elastic/beats-dra-prep-pipeline
+spec:
+  type: buildkite-pipeline
+  owner: group:streams
+  system: platform-ingest
+  implementation:
+    apiVersion: buildkite.elastic.dev/v1
+    kind: Pipeline
+    metadata:
+      name: beats-dra-prep-pipeline
+      description: Runs elastic/dra-prep + annotation for beats, triggered by beats-packaging-pipeline
+    spec:
+      repository: elastic/beats
+      pipeline_file: ".buildkite/dra-prep.pipeline.yml"
+      branch_configuration: "main 8.19 9.*"
+      cancel_intermediate_builds: false
+      skip_intermediate_builds: false
+      maximum_timeout_in_minutes: 90
+      provider_settings:
+        # Only ever run via the trigger step in packaging.pipeline.yml, or
+        # manually from the Buildkite UI for testing (see teams below) --
+        # matches unified-release-dra-processing's config for the same shape.
+        build_pull_requests: false
+        trigger_mode: none
+      env:
+        ELASTIC_SLACK_NOTIFICATIONS_ENABLED: 'true'
+        SLACK_NOTIFICATIONS_CHANNEL: '#ingest-notifications'
+        SLACK_NOTIFICATIONS_ON_SUCCESS: 'false'
+        SLACK_NOTIFICATIONS_SKIP_FOR_RETRIES: 'true'
+      teams:
+        streams:
+          access_level: MANAGE_BUILD_AND_READ
+        release-eng:
+          access_level: BUILD_AND_READ
+        everyone:
+          access_level: BUILD_AND_READ
+        observablt-ci:
+          access_level: MANAGE_BUILD_AND_READ
+
+---
+# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/rre.schema.json
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
   name: beats-ironbank-validation
   description: Buildkite pipeline for validating the Ironbank docker context
   links:

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1194,7 +1194,7 @@ spec:
       description: Runs elastic/dra-prep
     spec:
       repository: elastic/beats
-      pipeline_file: ".buildkite/dra-prep.pipeline.yml"
+      pipeline_file: ".buildkite/dra-prep-pipeline.yml"
       branch_configuration: "main 8.19 9.*"
       cancel_intermediate_builds: false
       skip_intermediate_builds: false


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

PR to add a secondary pipeline for the DRA prep plugin. This pipeline will be triggered by the [packaging pipeline](https://github.com/elastic/beats/blob/main/.buildkite/packaging.pipeline.yml). 

Related PR: https://github.com/elastic/beats/pull/52694

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

