### PR TITLE
[libbeat][pipeline][consumer] shutdown queueReader gracefully

### DIFF
--- a/changelog/fragments/1788205995-52947-shutdown-queuereader-gracefully.yaml
+++ b/changelog/fragments/1788205995-52947-shutdown-queuereader-gracefully.yaml
@@ -1,0 +1,50 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: enhancement
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: Wait for queueReader goroutine to exit on eventConsumer close.
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+description: |
+    The queueReader would continue to run even after the close() function has
+    been called. This was causing a test in apm-server to be flaky due to a
+    goroutine attempting to log with t.Log after the test function has returned.
+    A separate WaitGroup is added to track and wait for the queueReader to close
+    before close() returns.
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: libbeat
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+pr: https://github.com/elastic/beats/pull/52949
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: https://github.com/elastic/beats/issues/52947

--- a/libbeat/publisher/pipeline/consumer.go
+++ b/libbeat/publisher/pipeline/consumer.go
@@ -94,17 +94,9 @@ func newEventConsumer(
 		c.run()
 	})
 
-	// queueReader is tracked in its own WaitGroup rather than wg.
-	// Previously this goroutine was left to run asynchronously because
-	// waiting on it risked deadlock: if the queue was not yet closed,
-	// queueReader could be blocked indefinitely in queue.Get, and joining
-	// it from consumer.close() would hang. All callers of consumer.close()
-	// (processOutputController.waitClose and the OTel equivalent) now close
-	// the queue before calling consumer.close(), so any in-flight queue.Get
-	// is guaranteed to return first. The two-WaitGroup split preserves the
-	// safe ordering: wg drains first (which closes queueReader.req), then
-	// queueReaderWg ensures the goroutine has fully exited before close()
-	// returns — preventing goroutine log calls after the caller has torn down.
+	// Use two WaitGroups for safe ordering: wg drains first
+	// (which closes queueReader.req), then queueReaderWg ensures the
+	// goroutine has fully exited before close() returns.
 	c.queueReaderWg.Go(func() {
 		c.queueReader.run(c.logger)
 	})

--- a/libbeat/publisher/pipeline/consumer.go
+++ b/libbeat/publisher/pipeline/consumer.go
@@ -50,9 +50,14 @@ type eventConsumer struct {
 	// separate goroutine so we don't block on the control path.
 	queueReader queueReader
 
-	// This waitgroup is released when this eventConsumer's worker
-	// goroutines return.
+	// wg is released when the main eventConsumer worker goroutine returns.
 	wg sync.WaitGroup
+
+	// queueReaderWg is released when the queueReader goroutine returns.
+	// It is kept separate from wg because queueReader can only exit after
+	// eventConsumer.run() closes queueReader.req — which happens after wg
+	// is done — so combining them into one WaitGroup would deadlock.
+	queueReaderWg sync.WaitGroup
 }
 
 // consumerTarget specifies the queue to read from, the parameters needed
@@ -89,15 +94,22 @@ func newEventConsumer(
 		c.run()
 	})
 
-	// Even though we start a goroutine here, we don't include it in the
-	// waitGroup used for shutdown: if the queue itself is not closed yet,
-	// then the queueReader may be blocked in a read call to the queue,
-	// and waiting on it would deadlock. (This scenario is common; the
-	// queue is rarely closed properly on shutdown.) The queueReader itself
-	// has no independent state to clean up, and can safely shut down
-	// after the eventConsumer is already gone, so nothing is lost by
-	// letting it happen asynchronously.
-	go c.queueReader.run(c.logger)
+	// queueReader is tracked in its own WaitGroup rather than wg.
+	// Previously this goroutine was left to run asynchronously because
+	// waiting on it risked deadlock: if the queue was not yet closed,
+	// queueReader could be blocked indefinitely in queue.Get, and joining
+	// it from consumer.close() would hang. All callers of consumer.close()
+	// (processOutputController.waitClose and the OTel equivalent) now close
+	// the queue before calling consumer.close(), so any in-flight queue.Get
+	// is guaranteed to return first. The two-WaitGroup split preserves the
+	// safe ordering: wg drains first (which closes queueReader.req), then
+	// queueReaderWg ensures the goroutine has fully exited before close()
+	// returns — preventing goroutine log calls after the caller has torn down.
+	c.queueReaderWg.Add(1)
+	go func() {
+		defer c.queueReaderWg.Done()
+		c.queueReader.run(c.logger)
+	}()
 
 	return c
 }
@@ -237,4 +249,5 @@ func (c *eventConsumer) retry(batch *ttlBatch, decreaseTTL bool) {
 func (c *eventConsumer) close() {
 	close(c.done)
 	c.wg.Wait()
+	c.queueReaderWg.Wait()
 }

--- a/libbeat/publisher/pipeline/consumer.go
+++ b/libbeat/publisher/pipeline/consumer.go
@@ -105,11 +105,9 @@ func newEventConsumer(
 	// safe ordering: wg drains first (which closes queueReader.req), then
 	// queueReaderWg ensures the goroutine has fully exited before close()
 	// returns — preventing goroutine log calls after the caller has torn down.
-	c.queueReaderWg.Add(1)
-	go func() {
-		defer c.queueReaderWg.Done()
+	c.queueReaderWg.Go(func() {
 		c.queueReader.run(c.logger)
-	}()
+	})
 
 	return c
 }

--- a/libbeat/publisher/pipeline/consumer_test.go
+++ b/libbeat/publisher/pipeline/consumer_test.go
@@ -200,11 +200,7 @@ type blockingGetQueue struct {
 }
 
 func (q *blockingGetQueue) Get(n int) (queue.Batch[publisher.Event], error) {
-	select {
-	case <-q.entered:
-	default:
-		close(q.entered)
-	}
+	close(q.entered)
 	<-q.unblock
 	return q.Queue.Get(n)
 }
@@ -251,7 +247,7 @@ func TestEventConsumerCloseReleasesQueueReaderBatch(t *testing.T) {
 	}()
 
 	// c.wg.Wait() returns only after run() has exited, which means
-	// close(c.queueReader.req) has already been called. qr.req is now closed.
+	// close(c.queueReader.req) has already been called. c.queueReader.req is now closed.
 	c.wg.Wait()
 
 	// Unblock queueReader. It calls the real Get() (returns immediately —

--- a/libbeat/publisher/pipeline/consumer_test.go
+++ b/libbeat/publisher/pipeline/consumer_test.go
@@ -188,3 +188,84 @@ func TestEventConsumerCloseReleasesHeldBatches(t *testing.T) {
 		"all slots must return to the pool after consumer close (got %d/%d)",
 		pool.Available(), capacity)
 }
+
+// blockingGetQueue wraps a queue.Queue so that Get() blocks until unblock is
+// closed, signalling via entered when a caller first lands inside Get(). This
+// gives tests precise control over the moment queueReader holds a fetched batch
+// so they can race the consumer shutdown against the batch delivery.
+type blockingGetQueue struct {
+	queue.Queue[publisher.Event]
+	entered chan struct{}
+	unblock chan struct{}
+}
+
+func (q *blockingGetQueue) Get(n int) (queue.Batch[publisher.Event], error) {
+	select {
+	case <-q.entered:
+	default:
+		close(q.entered)
+	}
+	<-q.unblock
+	return q.Queue.Get(n)
+}
+
+// TestEventConsumerCloseReleasesQueueReaderBatch verifies that when a consumer
+// shuts down while queueReader has data inflight, the batch is released.
+func TestEventConsumerCloseReleasesQueueReaderBatch(t *testing.T) {
+	const capacity = 8
+	pool := slabqueue.NewPool[publisher.Event](slabqueue.Settings{Events: capacity}, nil)
+	defer pool.Shutdown()
+	q := pool.Connect()
+	defer q.Close(true)
+
+	p := q.Producer(queue.ProducerConfig{})
+	for i := range capacity {
+		_, ok := p.Publish(publisher.Event{Content: beat.Event{Private: i}})
+		require.True(t, ok)
+	}
+	require.Equal(t, 0, pool.Available(), "pool should be full before test")
+
+	bq := &blockingGetQueue{
+		Queue:   q,
+		entered: make(chan struct{}),
+		unblock: make(chan struct{}),
+	}
+
+	c := newEventConsumer(logp.NewNopLogger(), nilObserver)
+	out := make(chan publisher.Batch)
+	c.setTarget(consumerTarget{queue: bq, ch: out, batchSize: capacity, timeToLive: 3})
+
+	// Wait until queueReader is inside Get() so we know it will receive a
+	// batch the moment we unblock it.
+	select {
+	case <-bq.entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("queueReader never entered Get()")
+	}
+
+	// trigger a shutdown
+	closeDone := make(chan struct{})
+	go func() {
+		defer close(closeDone)
+		c.close()
+	}()
+
+	// c.wg.Wait() returns only after run() has exited, which means
+	// close(c.queueReader.req) has already been called. qr.req is now closed.
+	c.wg.Wait()
+
+	// Unblock queueReader. It calls the real Get() (returns immediately —
+	// the pool is full), then enters its select. Because qr.req is already
+	// closed, case <-qr.req fires: the batch is Released and queueReader exits.
+	close(bq.unblock)
+
+	select {
+	case <-closeDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("consumer.close() hung after unblocking queueReader")
+	}
+
+	require.Equal(t, capacity, pool.Available(),
+		"batch held by queueReader must be Released on shutdown (got %d/%d)",
+		pool.Available(), capacity)
+}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

Previously consumer.close() would return while queueReader is still running.This caused a test to become flaky on apm-server: https://github.com/elastic/apm-server/issues/21375.

This commit tracks queueReader in a separate WaitGroup and waits for it in close() after the main goroutine exits and closes qr.req. The 2 WaitGroup approach is used to preserve the safe shutdown ordering: wg waits first (closing qr.req), then queueReaderWg ensures queueReader has fully existed.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact
N/A
<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## How to test this PR locally
- Ran the local tests on lib beats to test for regression
- On apm-server I test the fix replacing `libbeats` version with a this version locally then ran the impacted test
```go test ./internal/publish/... -v -count=100 -run "TestPublisherStop" ```
- Compared the execution before and after the library has been replaced and the panics have went away.

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues
Relates https://github.com/elastic/apm-server/issues/21375
Closes: https://github.com/elastic/beats/issues/52947


<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
```
=== RUN   TestPublisherStop
    logger.go:146: 2026-07-07T10:12:48.194Z	DEBUG	beat.publish	start pipeline event consumer
    logger.go:146: 2026-07-07T10:12:48.194Z	DEBUG	beat.publish	pipeline event consumer queue reader: start
    logger.go:146: 2026-07-07T10:12:49.297Z	DEBUG	beat.publish.memqueue	ackloop: return ack to broker loop:3
    logger.go:146: 2026-07-07T10:12:49.297Z	DEBUG	beat.publish.memqueue	ackloop:  done send ack
    logger.go:146: 2026-07-07T10:12:49.297Z	DEBUG	beat.publish.memqueue	ackloop: return ack to broker loop:16
    logger.go:146: 2026-07-07T10:12:49.297Z	DEBUG	beat.publish.memqueue	ackloop:  done send ack
    logger.go:146: 2026-07-07T10:12:49.297Z	DEBUG	beat.publish.memqueue	ackloop: return ack to broker loop:16
    logger.go:146: 2026-07-07T10:12:49.297Z	DEBUG	beat.publish.memqueue	ackloop:  done send ack
    logger.go:146: 2026-07-07T10:12:49.297Z	DEBUG	beat.publish.memqueue	ackloop: return ack to broker loop:1
    logger.go:146: 2026-07-07T10:12:49.297Z	DEBUG	beat.publish.memqueue	ackloop:  done send ack
    logger.go:146: 2026-07-07T10:12:49.298Z	DEBUG	beat.publish.memqueue	ackloop: return ack to broker loop:2
    logger.go:146: 2026-07-07T10:12:49.298Z	DEBUG	beat.publish.memqueue	ackloop:  done send ack
    logger.go:146: 2026-07-07T10:12:49.298Z	DEBUG	beat.publish.memqueue	ackloop: return ack to broker loop:1
    logger.go:146: 2026-07-07T10:12:49.298Z	DEBUG	beat.publish.memqueue	ackloop:  done send ack
    logger.go:146: 2026-07-07T10:12:49.298Z	DEBUG	beat.publish	client: close queue producer
    logger.go:146: 2026-07-07T10:12:49.298Z	DEBUG	beat.publish	client: done producer close
    logger.go:146: 2026-07-07T10:12:49.298Z	DEBUG	beat.publish	close pipeline
    logger.go:146: 2026-07-07T10:12:49.298Z	INFO	beat.processOutputController	Output shutdown started. Waiting for enqueued events to be published.
    logger.go:146: 2026-07-07T10:12:49.298Z	INFO	beat.processOutputController	Continue shutdown: Time out waiting for events to be published.
    logger.go:146: 2026-07-07T10:12:49.298Z	DEBUG	beat.publish.memqueue	ackloop: return ack to broker loop:1
    logger.go:146: 2026-07-07T10:12:49.298Z	DEBUG	beat.publish.memqueue	ackloop:  done send ack
    logger.go:146: 2026-07-07T10:12:49.298Z	DEBUG	beat.publish	client: done closing acker
--- PASS: TestPublisherStop (1.11s)
=== RUN   TestPublisherStopShutdownInactive
    logger.go:146: 2026-07-07T10:12:49.299Z	DEBUG	beat.publish	start pipeline event consumer
    logger.go:146: 2026-07-07T10:12:49.299Z	DEBUG	beat.publish	pipeline event consumer queue reader: start
    logger.go:146: 2026-07-07T10:12:49.300Z	DEBUG	beat.publish	client: close queue producer
    logger.go:146: 2026-07-07T10:12:49.300Z	DEBUG	beat.publish	client: done producer close
    logger.go:146: 2026-07-07T10:12:49.300Z	DEBUG	beat.publish	close pipeline
    logger.go:146: 2026-07-07T10:12:49.300Z	INFO	beat.processOutputController	Output shutdown started. Waiting for enqueued events to be published.
    logger.go:146: 2026-07-07T10:12:49.300Z	DEBUG	beat.publish	client: done closing acker
    logger.go:146: 2026-07-07T10:12:49.300Z	INFO	beat.processOutputController	Continue shutdown: Time out waiting for events to be published.
--- PASS: TestPublisherStopShutdownInactive (0.01s)
PASS
panic: Log in goroutine after TestPublisherStopShutdownInactive has completed: 2026-07-07T10:12:49.303Z	DEBUG	beat.publish	pipeline event consumer queue reader: stop
	

goroutine 23 [running]:
testing.(*common).log(0xc00032a008, {0xc0003a61e0, 0x56})
	/opt/hostedtoolcache/go/1.26.4/x64/src/testing/testing.go:1039 +0x1df
testing.(*common).Logf(0xc00032a008, {0x1a95ce2, 0x2}, {0xc0003980d0, 0x1, 0x1})
	/opt/hostedtoolcache/go/1.26.4/x64/src/testing/testing.go:1200 +0x8f
go.uber.org/zap/zaptest.TestingWriter.Write({{0x7f26609b57e8?, 0xc00032a008?}, 0xc0?}, {0xc000390000, 0x57, 0x400})
	/home/runner/go/pkg/mod/go.uber.org/zap@v1.28.0/zaptest/logger.go:146 +0x11a
go.uber.org/zap/zapcore.(*ioCore).Write(0xc0002fb050, {0xff, {0xc28b52285219e293, 0x429862cf, 0x24a3140}, {0xc0002e6400, 0xc}, {0x1abdfa9, 0x2a}, {0x0, ...}, ...}, ...)
	/home/runner/go/pkg/mod/go.uber.org/zap@v1.28.0/zapcore/core.go:99 +0x202
go.uber.org/zap/zapcore.(*CheckedEntry).Write(0xc00038e0e0, {0x0, 0x0, 0x0})
	/home/runner/go/pkg/mod/go.uber.org/zap@v1.28.0/zapcore/entry.go:276 +0x568
go.uber.org/zap.(*SugaredLogger).log(0xc0003040b8, 0xff, {0x0, 0x0}, {0xc000121f18, 0x1, 0x1}, {0x0, 0x0, 0x0})
	/home/runner/go/pkg/mod/go.uber.org/zap@v1.28.0/sugar.go:355 +0x12d
go.uber.org/zap.(*SugaredLogger).Debug(...)
	/home/runner/go/pkg/mod/go.uber.org/zap@v1.28.0/sugar.go:149
github.com/elastic/elastic-agent-libs/logp.(*Logger).Debug(...)
	/home/runner/go/pkg/mod/github.com/elastic/elastic-agent-libs@v0.46.0/logp/logger.go:197
github.com/elastic/beats/v7/libbeat/publisher/pipeline.(*queueReader).run(0xc0003063a0, 0xc0002e47c8)
	/home/runner/go/pkg/mod/github.com/elastic/beats/v7@v7.0.0-alpha2.0.20260706144519-3b40a86c8426/libbeat/publisher/pipeline/queue_reader.go:76 +0x356
created by github.com/elastic/beats/v7/libbeat/publisher/pipeline.newEventConsumer in goroutine 21
	/home/runner/go/pkg/mod/github.com/elastic/beats/v7@v7.0.0-alpha2.0.20260706144519-3b40a86c8426/libbeat/publisher/pipeline/consumer.go:102 +0x3bd
FAIL	github.com/elastic/apm-server/internal/publish	1.135s
```
An example of the test logs in apm-server when the panic happens