### PR TITLE
x-pack/filebeat/input/entityanalytics: log cancelled syncs as interruptions, not errors

### DIFF
--- a/changelog/fragments/1788204683-entityanalytics-canceled-sync-logging.yaml
+++ b/changelog/fragments/1788204683-entityanalytics-canceled-sync-logging.yaml
@@ -1,0 +1,19 @@
+kind: bug-fix
+
+summary: Log entity analytics sync interruption by input shutdown or reconfiguration at info level instead of error, and no longer mark the input degraded for it.
+
+description: |
+  When an entity analytics sync was interrupted because the input's
+  context was cancelled — agent shutdown, restart, or a policy change
+  re-rendering the input mid-sync — the failure was logged as an error
+  such as "Error running full sync: ... context canceled" and the
+  input was marked Degraded. This routine lifecycle event is now
+  logged at info level as a sync interruption and no longer degrades
+  the input's status. All entity analytics providers
+  (activedirectory, azuread, jamf, okta) and the minimal-state runner
+  are covered. Other errors, including context deadline expiry, keep
+  the previous error treatment.
+
+component: filebeat
+
+issue: https://github.com/elastic/beats/issues/52945

--- a/x-pack/filebeat/input/entityanalytics/minimal.go
+++ b/x-pack/filebeat/input/entityanalytics/minimal.go
@@ -21,6 +21,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/features"
 	"github.com/elastic/beats/v7/libbeat/statestore"
 	"github.com/elastic/beats/v7/x-pack/filebeat/input/entityanalytics/internal/kvstore"
+	"github.com/elastic/beats/v7/x-pack/filebeat/input/entityanalytics/provider"
 	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/paths"
 	"github.com/elastic/entcollect"
@@ -88,7 +89,11 @@ func (n *minimalStateInput) Run(runCtx v2.Context, connector beat.PipelineConnec
 
 		case <-syncTimer.C:
 			if err := syncer.runSync(runCtx, n.provider, client, slogger, true); err != nil {
-				log.Errorw("Error running full sync", "error", err)
+				if provider.SyncInterrupted(runCtx, err) {
+					log.Infow(provider.SyncInterruptedMsg, "error", err)
+				} else {
+					log.Errorw("Error running full sync", "error", err)
+				}
 			}
 			syncTimer.Reset(n.fullSyncInterval)
 			log.Debugf("Next full sync expected at: %v", time.Now().Add(n.fullSyncInterval))
@@ -103,7 +108,11 @@ func (n *minimalStateInput) Run(runCtx v2.Context, connector beat.PipelineConnec
 
 		case <-incrTimer.C:
 			if err := syncer.runSync(runCtx, n.provider, client, slogger, false); err != nil {
-				log.Errorw("Error running incremental sync", "error", err)
+				if provider.SyncInterrupted(runCtx, err) {
+					log.Infow(provider.SyncInterruptedMsg, "error", err)
+				} else {
+					log.Errorw("Error running incremental sync", "error", err)
+				}
 			}
 			incrTimer.Reset(n.incrSyncInterval)
 			log.Debugf("Next incremental sync expected at: %v", time.Now().Add(n.incrSyncInterval))

--- a/x-pack/filebeat/input/entityanalytics/provider/activedirectory/activedirectory.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/activedirectory/activedirectory.go
@@ -152,9 +152,13 @@ func (p *adInput) Run(inputCtx v2.Context, store *kvstore.Store, client beat.Cli
 		case start := <-syncTimer.C:
 			last, err = p.runFullSync(inputCtx, store, client)
 			if err != nil {
-				msg := "Error running full sync"
-				p.logger.Errorw(msg, "error", err)
-				inputCtx.UpdateStatus(status.Degraded, fmt.Sprintf("%s: %v", msg, err))
+				if provider.SyncInterrupted(inputCtx, err) {
+					p.logger.Infow(provider.SyncInterruptedMsg, "error", err)
+				} else {
+					msg := "Error running full sync"
+					p.logger.Errorw(msg, "error", err)
+					inputCtx.UpdateStatus(status.Degraded, fmt.Sprintf("%s: %v", msg, err))
+				}
 				p.metrics.syncError.Inc()
 			} else {
 				inputCtx.UpdateStatus(status.Running, "Successful full sync")
@@ -176,9 +180,13 @@ func (p *adInput) Run(inputCtx v2.Context, store *kvstore.Store, client beat.Cli
 		case start := <-updateTimer.C:
 			last, err = p.runIncrementalUpdate(inputCtx, store, last, client)
 			if err != nil {
-				msg := "Error running incremental update"
-				p.logger.Errorw(msg, "error", err)
-				inputCtx.UpdateStatus(status.Degraded, fmt.Sprintf("%s: %v", msg, err))
+				if provider.SyncInterrupted(inputCtx, err) {
+					p.logger.Infow(provider.SyncInterruptedMsg, "error", err)
+				} else {
+					msg := "Error running incremental update"
+					p.logger.Errorw(msg, "error", err)
+					inputCtx.UpdateStatus(status.Degraded, fmt.Sprintf("%s: %v", msg, err))
+				}
 				p.metrics.updateError.Inc()
 			} else {
 				inputCtx.UpdateStatus(status.Running, "Successful incremental update")

--- a/x-pack/filebeat/input/entityanalytics/provider/azuread/azure.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/azuread/azure.go
@@ -139,9 +139,13 @@ func (p *azure) Run(inputCtx v2.Context, store *kvstore.Store, client beat.Clien
 		case <-syncTimer.C:
 			start := time.Now()
 			if err := p.runFullSync(inputCtx, store, client); err != nil {
-				msg := "Error running full sync"
-				p.logger.Errorw(msg, "error", err)
-				inputCtx.UpdateStatus(status.Degraded, fmt.Sprintf("%s: %v", msg, err))
+				if provider.SyncInterrupted(inputCtx, err) {
+					p.logger.Infow(provider.SyncInterruptedMsg, "error", err)
+				} else {
+					msg := "Error running full sync"
+					p.logger.Errorw(msg, "error", err)
+					inputCtx.UpdateStatus(status.Degraded, fmt.Sprintf("%s: %v", msg, err))
+				}
 				p.metrics.syncError.Inc()
 			} else {
 				inputCtx.UpdateStatus(status.Running, "Successful full sync")
@@ -163,9 +167,13 @@ func (p *azure) Run(inputCtx v2.Context, store *kvstore.Store, client beat.Clien
 		case <-updateTimer.C:
 			start := time.Now()
 			if err := p.runIncrementalUpdate(inputCtx, store, client); err != nil {
-				msg := "Error running incremental update"
-				p.logger.Errorw(msg, "error", err)
-				inputCtx.UpdateStatus(status.Degraded, fmt.Sprintf("%s: %v", msg, err))
+				if provider.SyncInterrupted(inputCtx, err) {
+					p.logger.Infow(provider.SyncInterruptedMsg, "error", err)
+				} else {
+					msg := "Error running incremental update"
+					p.logger.Errorw(msg, "error", err)
+					inputCtx.UpdateStatus(status.Degraded, fmt.Sprintf("%s: %v", msg, err))
+				}
 				p.metrics.updateError.Inc()
 			} else {
 				inputCtx.UpdateStatus(status.Running, "Successful incremental update")

--- a/x-pack/filebeat/input/entityanalytics/provider/interrupted.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/interrupted.go
@@ -1,0 +1,27 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package provider
+
+import (
+	"context"
+	"errors"
+
+	v2 "github.com/elastic/beats/v7/filebeat/input/v2"
+)
+
+// SyncInterruptedMsg is the log message to use when SyncInterrupted
+// reports true, so the event is worded identically across providers.
+const SyncInterruptedMsg = "Sync interrupted by input shutdown or reconfiguration; will retry on next interval"
+
+// SyncInterrupted reports whether err is the benign result of the input's
+// cancellation context being cancelled while a sync was in flight — the
+// agent stopping, restarting, or reconfiguring the input — rather than a
+// failure of the sync itself. Callers should log this condition at info
+// level and leave the input's status untouched: the interrupted sync has
+// been rolled back and collection resumes on the next interval, or in the
+// replacement input.
+func SyncInterrupted(inputCtx v2.Context, err error) bool {
+	return errors.Is(err, context.Canceled) && inputCtx.Cancelation.Err() != nil
+}

--- a/x-pack/filebeat/input/entityanalytics/provider/interrupted_test.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/interrupted_test.go
@@ -1,0 +1,38 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package provider
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	v2 "github.com/elastic/beats/v7/filebeat/input/v2"
+)
+
+func TestSyncInterrupted(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	inputCtx := v2.Context{Cancelation: ctx}
+
+	if SyncInterrupted(inputCtx, context.Canceled) {
+		t.Error("SyncInterrupted = true for context.Canceled before the input is cancelled")
+	}
+	if SyncInterrupted(inputCtx, errors.New("boom")) {
+		t.Error("SyncInterrupted = true for unrelated error before the input is cancelled")
+	}
+
+	cancel()
+
+	if !SyncInterrupted(inputCtx, fmt.Errorf("okta: get users: %w", context.Canceled)) {
+		t.Error("SyncInterrupted = false for wrapped context.Canceled after the input is cancelled")
+	}
+	if SyncInterrupted(inputCtx, errors.New("boom")) {
+		t.Error("SyncInterrupted = true for unrelated error after the input is cancelled")
+	}
+	if SyncInterrupted(inputCtx, context.DeadlineExceeded) {
+		t.Error("SyncInterrupted = true for context.DeadlineExceeded")
+	}
+}

--- a/x-pack/filebeat/input/entityanalytics/provider/jamf/jamf.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/jamf/jamf.go
@@ -137,9 +137,13 @@ func (p *jamfInput) Run(inputCtx v2.Context, store *kvstore.Store, client beat.C
 		case <-syncTimer.C:
 			start := time.Now()
 			if err := p.runFullSync(inputCtx, store, client); err != nil {
-				msg := "Error running full sync"
-				p.logger.Errorw(msg, "error", err)
-				inputCtx.UpdateStatus(status.Degraded, fmt.Sprintf("%s: %v", msg, err))
+				if provider.SyncInterrupted(inputCtx, err) {
+					p.logger.Infow(provider.SyncInterruptedMsg, "error", err)
+				} else {
+					msg := "Error running full sync"
+					p.logger.Errorw(msg, "error", err)
+					inputCtx.UpdateStatus(status.Degraded, fmt.Sprintf("%s: %v", msg, err))
+				}
 				p.metrics.syncError.Inc()
 			} else {
 				inputCtx.UpdateStatus(status.Running, "Successful full sync")
@@ -161,9 +165,13 @@ func (p *jamfInput) Run(inputCtx v2.Context, store *kvstore.Store, client beat.C
 		case <-updateTimer.C:
 			start := time.Now()
 			if err := p.runIncrementalUpdate(inputCtx, store, client); err != nil {
-				msg := "Error running incremental update"
-				p.logger.Errorw(msg, "error", err)
-				inputCtx.UpdateStatus(status.Degraded, fmt.Sprintf("%s: %v", msg, err))
+				if provider.SyncInterrupted(inputCtx, err) {
+					p.logger.Infow(provider.SyncInterruptedMsg, "error", err)
+				} else {
+					msg := "Error running incremental update"
+					p.logger.Errorw(msg, "error", err)
+					inputCtx.UpdateStatus(status.Degraded, fmt.Sprintf("%s: %v", msg, err))
+				}
 				p.metrics.updateError.Inc()
 			} else {
 				inputCtx.UpdateStatus(status.Running, "Successful incremental update")

--- a/x-pack/filebeat/input/entityanalytics/provider/okta/okta.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/okta/okta.go
@@ -143,9 +143,13 @@ func (p *oktaInput) Run(inputCtx v2.Context, store *kvstore.Store, client beat.C
 		case <-syncTimer.C:
 			start := time.Now()
 			if err := p.runFullSync(inputCtx, store, client); err != nil {
-				msg := "Error running full sync"
-				p.logger.Errorw(msg, "error", err)
-				inputCtx.UpdateStatus(status.Degraded, fmt.Sprintf("%s: %v", msg, err))
+				if provider.SyncInterrupted(inputCtx, err) {
+					p.logger.Infow(provider.SyncInterruptedMsg, "error", err)
+				} else {
+					msg := "Error running full sync"
+					p.logger.Errorw(msg, "error", err)
+					inputCtx.UpdateStatus(status.Degraded, fmt.Sprintf("%s: %v", msg, err))
+				}
 				p.metrics.syncError.Inc()
 			} else {
 				inputCtx.UpdateStatus(status.Running, "Successful full sync")
@@ -167,9 +171,13 @@ func (p *oktaInput) Run(inputCtx v2.Context, store *kvstore.Store, client beat.C
 		case <-updateTimer.C:
 			start := time.Now()
 			if err := p.runIncrementalUpdate(inputCtx, store, client); err != nil {
-				msg := "Error running incremental update"
-				p.logger.Errorw(msg, "error", err)
-				inputCtx.UpdateStatus(status.Degraded, fmt.Sprintf("%s: %v", msg, err))
+				if provider.SyncInterrupted(inputCtx, err) {
+					p.logger.Infow(provider.SyncInterruptedMsg, "error", err)
+				} else {
+					msg := "Error running incremental update"
+					p.logger.Errorw(msg, "error", err)
+					inputCtx.UpdateStatus(status.Degraded, fmt.Sprintf("%s: %v", msg, err))
+				}
 				p.metrics.updateError.Inc()
 			} else {
 				inputCtx.UpdateStatus(status.Running, "Successful incremental update")


### PR DESCRIPTION


<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message
```
x-pack/filebeat/input/entityanalytics: log cancelled syncs as interruptions, not errors

When a sync was interrupted because the input's context was cancelled —
the agent stopping, restarting, or reconfiguring the input mid-sync —
the failure was logged as "Error running full sync: ... context
canceled" and the input was marked Degraded. This routine lifecycle
event reads like an infrastructure or timeout failure and has
repeatedly sent users toward tuning http_client_timeout, which is a
per-request timeout and can never produce context cancellation.

Add provider.SyncInterrupted to classify this condition (the error is
context.Canceled and the input's cancellation context is done) and use
it in all provider run loops (activedirectory, azuread, jamf, okta) and
the minimal-state runner: log the shared provider.SyncInterruptedMsg at
info level and leave the input's status untouched. All other errors,
including context deadline expiry, keep the previous error treatment,
and the sync error metrics still count interrupted syncs.

Fixes #52945
```

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #52945
