### PR TITLE
Route OTel registry bridge logs to component streams

### DIFF
--- a/x-pack/libbeat/cmd/instance/receiver.go
+++ b/x-pack/libbeat/cmd/instance/receiver.go
@@ -28,6 +28,7 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/receiver"
+	"go.uber.org/zap"
 )
 
 // contextStopper is an optional extension of beat.Beater for beaters that can
@@ -52,7 +53,11 @@ type BeatReceiver struct {
 // NewBeatReceiver creates a BeatReceiver.  This will also create the beater and start the monitoring server if configured
 func NewBeatReceiver(ctx context.Context, b *instance.Beat, creator beat.Creator, set receiver.Settings) (BeatReceiver, error) {
 	receiverID := set.ID
-	ts := set.TelemetrySettings
+	bridgeTelemetrySettings := set.TelemetrySettings
+	// The Beat logger is built from the collector logger core and includes the
+	// component.* fields configured for this receiver, they're necessary to
+	// route the logs to the correct datastream.
+	bridgeTelemetrySettings.Logger = zap.New(b.Info.Logger.Core())
 	beatConfig, err := b.BeatConfig()
 	if err != nil {
 		return BeatReceiver{}, fmt.Errorf("error getting beat config: %w", err)
@@ -103,12 +108,15 @@ func NewBeatReceiver(ctx context.Context, b *instance.Beat, creator beat.Creator
 		return BeatReceiver{}, fmt.Errorf("error getting %s creator:%w", b.Info.Beat, err)
 	}
 
-	bridge, err := oteltelemetry.NewRegistryBridge(ts, receiverID.String(), b.Monitoring.StatsRegistry(), b.Monitoring.InputsRegistry())
+	bridge, err := oteltelemetry.NewRegistryBridge(bridgeTelemetrySettings, receiverID.String(), b.Monitoring.StatsRegistry(), b.Monitoring.InputsRegistry())
 	if err != nil {
 		return BeatReceiver{}, fmt.Errorf("error creating registry bridge: %w", err)
 	}
 
-	releaseSystem, err := oteltelemetry.AcquireSystemBridge(ts)
+	// The system bridge is shared by all receivers. Preserve the original
+	// settings so its logs are not permanently tagged with this receiver's
+	// component.* fields.
+	releaseSystem, err := oteltelemetry.AcquireSystemBridge(set.TelemetrySettings)
 	if err != nil {
 		return BeatReceiver{}, fmt.Errorf("error acquiring system bridge: %w", err)
 	}


### PR DESCRIPTION


## Proposed commit message

```
Use Beat logger for registry bridge logs so they are routed to the correct data streams.

Assisted-by: gpt-5.6-terra-high
```

## Checklist


- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.~~
- [ ] ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).~~

~~## Disruptive User Impact~~


## How to test this PR locally
1. Build Elastic Agent with this Beats commit
2. Create an Elastic Agent policy with Osquery Manager
3. Install Elastic Agent using that policy
4. Check the logs
    Only a few of log lines are fected by this, here is an example:
    
    ```
    elastic-agent logs  -n 500 |grep "registry bridge registering callback"| grep "osquerybeat"|jq -S
    ```
    
    Will see the logs contain the `component.*` fields:
    ```json
    {
      "@timestamp": "2026-08-31T22:36:43.480Z",
      "component": {
        "binary": "osquerybeat",
        "dataset": "elastic_agent.osquerybeat",
        "id": "osquery-default",
        "type": "osquery"
      },
      "ecs.version": "1.6.0",
      "float_gauges": 9,
      "input_float_gauges": 0,
      "input_int_counters": 0,
      "input_int_gauges": 0,
      "int_counters": 20,
      "int_gauges": 9,
      "log": {
        "source": "osquery-default"
      },
      "log.level": "info",
      "message": "registry bridge registering callback",
      "meter_provider_type": "componentattribute.meterProviderWithAttributes",
      "otelcol.component.id": "osquerybeatreceiver/_agent-component/osquery-default/single",
      "otelcol.component.kind": "receiver",
      "otelcol.signal": "logs",
      "resource": {
        "service.instance.id": "b6e1baf3-3ba5-4e1e-b76b-76c79f09b70f",
        "service.name": "/opt/Elastic/Agent/data/elastic-agent-9.6.0-SNAPSHOT-5c5992/components/elastic-otel-collector",
        "service.version": "9.6.0"
      },
      "service.name": "osquerybeat",
      "total_instruments": 38
    }
    ```


~~## Related issues~~
~~## Use cases~~
~~## Screenshots~~
~~## Logs~~