### PR TITLE
Add default limit and override to http response body reader

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -9680,207 +9680,6 @@ Contents of probable licence file $GOMODCACHE/github.com/docker/go-plugins-helpe
 
 
 --------------------------------------------------------------------------------
-Dependency : github.com/docker/go-units
-Version: v0.5.0
-Licence type (autodetected): Apache-2.0
---------------------------------------------------------------------------------
-
-Contents of probable licence file $GOMODCACHE/github.com/docker/go-units@v0.5.0/LICENSE:
-
-
-                                 Apache License
-                           Version 2.0, January 2004
-                        https://www.apache.org/licenses/
-
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
-
-   1. Definitions.
-
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
-
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
-
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
-
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
-
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
-
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
-
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
-
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
-
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
-
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
-
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
-
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
-
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
-
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
-
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
-
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
-
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
-
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
-
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
-
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
-
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
-
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   Copyright 2015 Docker, Inc.
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       https://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
-
-
---------------------------------------------------------------------------------
 Dependency : github.com/elastic/goja
 Version: v0.0.0-20190128172624-dd2ac4456e20
 Licence type (autodetected): MIT
@@ -51760,6 +51559,207 @@ Contents of probable licence file $GOMODCACHE/github.com/docker/go-metrics@v0.0.
    END OF TERMS AND CONDITIONS
 
    Copyright 2013-2016 Docker, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       https://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+--------------------------------------------------------------------------------
+Dependency : github.com/docker/go-units
+Version: v0.5.0
+Licence type (autodetected): Apache-2.0
+--------------------------------------------------------------------------------
+
+Contents of probable licence file $GOMODCACHE/github.com/docker/go-units@v0.5.0/LICENSE:
+
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        https://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2015 Docker, Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/docs/reference/heartbeat/monitor-http-options.md
+++ b/docs/reference/heartbeat/monitor-http-options.md
@@ -86,7 +86,14 @@ On by default. Set `response.include_headers` to `false` to disable.
 
 ## `response` [monitor-http-response]
 
-Controls the indexing of the HTTP response body contents to the `http.response.body.contents` field.
+Controls the processing and ingestion of the HTTP response body contents to the `http.response.body.contents` field.
+
+### `check_body_max_bytes`
+
+Sets the upper boundary for the HTTP responso body length (in bytes). Defaults to 4096 bytes.
+This limit is overriden when `response.include_body_max_bytes` is set to a higher value.
+
+### `include_body`
 
 Set `response.include_body` to one of the options listed below.
 
@@ -99,8 +106,10 @@ Set `response.include_body` to one of the options listed below.
 **`always`**
 :   Always include the body with checks.
 
-Set `response.include_body_max_bytes` to control the maximum size of the stored body contents. Defaults to 1024 bytes.
 
+### `include_body_max_bytes`
+
+Set `response.include_body_max_bytes` to control the maximum size of the stored body contents. Defaults to 1024 bytes.
 
 ### `check` [monitor-http-check]
 

--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 	github.com/digitalocean/go-libvirt v0.0.0-20240709142323-d8406205c752
 	github.com/docker/go-connections v0.7.0
 	github.com/docker/go-plugins-helpers v0.0.0-20181025120712-1e6269c305b8
-	github.com/docker/go-units v0.5.0
+	github.com/docker/go-units v0.5.0 // indirect
 	github.com/dop251/goja v0.0.0-20200831102558-9af81ddcf0e1
 	github.com/dop251/goja_nodejs v0.0.0-20171011081505-adff31b136e6
 	github.com/dustin/go-humanize v1.0.1

--- a/heartbeat/monitors/active/http/checkjson_test.go
+++ b/heartbeat/monitors/active/http/checkjson_test.go
@@ -100,7 +100,7 @@ func TestCheckJsonExpression(t *testing.T) {
 		},
 	}
 
-	for _, test := range tests[6:] {
+	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
 			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				fmt.Fprintln(w, test.body)

--- a/heartbeat/monitors/active/http/config.go
+++ b/heartbeat/monitors/active/http/config.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/docker/go-units"
 	"github.com/elastic/beats/v7/heartbeat/monitors"
 	"github.com/elastic/beats/v7/libbeat/conditions"
 	"github.com/elastic/elastic-agent-libs/transport/httpcommon"
@@ -51,6 +52,7 @@ type responseConfig struct {
 	IncludeBody         string `config:"include_body"`
 	IncludeBodyMaxBytes int    `config:"include_body_max_bytes"`
 	IncludeHeaders      bool   `config:"include_headers"`
+	CheckBodyMaxBytes   int    `config:"check_body_max_bytes"`
 }
 
 type checkConfig struct {
@@ -99,6 +101,9 @@ func defaultConfig() Config {
 			IncludeBody:         "on_error",
 			IncludeBodyMaxBytes: 2048,
 			IncludeHeaders:      true,
+			// CheckBodyMaxBytes sets a hard limit on how much we're willing to buffer for body validators internally.
+			// This values gets overriden when IncludeBodyMaxBytes is larger.
+			CheckBodyMaxBytes: 4 * units.MiB,
 		},
 		Mode: monitors.DefaultIPSettings,
 		Check: checkConfig{
@@ -130,6 +135,10 @@ func (r *responseConfig) Validate() error {
 
 	if r.IncludeBodyMaxBytes <= 0 {
 		return fmt.Errorf("include_body_max_bytes must be a positive integer, got %d", r.IncludeBodyMaxBytes)
+	}
+
+	if r.CheckBodyMaxBytes <= 0 {
+		return fmt.Errorf("check_body_max_bytes must be a positive integer, got %d", r.CheckBodyMaxBytes)
 	}
 
 	return nil

--- a/heartbeat/monitors/active/http/config.go
+++ b/heartbeat/monitors/active/http/config.go
@@ -24,7 +24,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/docker/go-units"
 	"github.com/elastic/beats/v7/heartbeat/monitors"
 	"github.com/elastic/beats/v7/libbeat/conditions"
 	"github.com/elastic/elastic-agent-libs/transport/httpcommon"
@@ -102,8 +101,8 @@ func defaultConfig() Config {
 			IncludeBodyMaxBytes: 2048,
 			IncludeHeaders:      true,
 			// CheckBodyMaxBytes sets a hard limit on how much we're willing to buffer for body validators internally.
-			// This values gets overriden when IncludeBodyMaxBytes is larger.
-			CheckBodyMaxBytes: 4 * units.MiB,
+			// This values gets overridden when IncludeBodyMaxBytes is larger.
+			CheckBodyMaxBytes: 4 << 20,
 		},
 		Mode: monitors.DefaultIPSettings,
 		Check: checkConfig{

--- a/heartbeat/monitors/active/http/config_test.go
+++ b/heartbeat/monitors/active/http/config_test.go
@@ -74,6 +74,35 @@ var tests = []struct {
 	},
 }
 
+func TestResponseConfigValidateBodyMaxBytes(t *testing.T) {
+	base := responseConfig{
+		IncludeBody:         "never",
+		IncludeBodyMaxBytes: 2048,
+	}
+
+	for _, tc := range []struct {
+		name      string
+		value     int
+		wantError bool
+	}{
+		{"positive value is valid", 1, false},
+		{"default 4MiB is valid", 4 * 1024 * 1024, false},
+		{"zero is invalid", 0, true},
+		{"negative is invalid", -1, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := base
+			cfg.CheckBodyMaxBytes = tc.value
+			err := cfg.Validate()
+			if tc.wantError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestConfigValidate(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {

--- a/heartbeat/monitors/active/http/respbody.go
+++ b/heartbeat/monitors/active/http/respbody.go
@@ -26,18 +26,12 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/docker/go-units"
-
 	"github.com/elastic/beats/v7/heartbeat/reason"
 	"github.com/elastic/beats/v7/libbeat/mime"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 )
 
 const (
-	// maxBufferBodyBytes sets a hard limit on how much we're willing to buffer for any reason internally.
-	// since we must buffer the whole body for body validators this is effectively a cap on that.
-	// 100MiB out to be enough for everybody.
-	maxBufferBodyBytes = 100 * units.MiB
 	// minBufferBytes is the lower bound on how much of the body content we actually read. In order to do
 	// do mime type detection of the response body, we always need a small read buffer.
 	minBufferBodyBytes = 128
@@ -47,8 +41,10 @@ func processBody(resp *http.Response, config responseConfig, validator multiVali
 	// Determine how much of the body to actually buffer in memory
 	var bufferBodyBytes int
 	if validator.wantsBody() {
-		bufferBodyBytes = maxBufferBodyBytes
-	} else if config.IncludeBody == "always" || config.IncludeBody == "on_error" {
+		bufferBodyBytes = config.CheckBodyMaxBytes
+	}
+
+	if (config.IncludeBody == "always" || config.IncludeBody == "on_error") && config.IncludeBodyMaxBytes > bufferBodyBytes {
 		// If the user has asked for bodies to be recorded we only need to buffer that much
 		bufferBodyBytes = config.IncludeBodyMaxBytes
 	}

--- a/heartbeat/monitors/active/http/respbody_test.go
+++ b/heartbeat/monitors/active/http/respbody_test.go
@@ -284,7 +284,7 @@ func TestBodyMaxBytesCapsBodiesSentToValidators(t *testing.T) {
 		fakeResponse(strings.Repeat("x", 3*limit)),
 		responseConfig{IncludeBody: "never", CheckBodyMaxBytes: limit, IncludeBodyMaxBytes: 2048},
 		validator,
-	)
+	) //nolint: errcheck //testcode
 
 	assert.Len(t, *captured, limit, "validator must receive exactly BodyMaxBytes bytes")
 }
@@ -301,7 +301,7 @@ func TestBodyMaxBytesDoesNotTruncateSmallBodies(t *testing.T) {
 		fakeResponse(body),
 		responseConfig{IncludeBody: "never", CheckBodyMaxBytes: limit, IncludeBodyMaxBytes: 2048},
 		validator,
-	)
+	) //nolint: errcheck //testcode
 
 	assert.Equal(t, body, *captured, "validator must receive the full body when it fits within BodyMaxBytes")
 }
@@ -313,11 +313,14 @@ func TestBodyMaxBytesMinimalBufferWithNoValidatorsAndNoIncludeBody(t *testing.T)
 	const bodyMaxBytes = 1024
 	body := strings.Repeat("x", 2*bodyMaxBytes)
 
+	resp := fakeResponse(body)
+	defer resp.Body.Close()
+
 	fields, _, _ := processBody(
-		fakeResponse(body),
+		resp,
 		responseConfig{IncludeBody: "never", CheckBodyMaxBytes: bodyMaxBytes, IncludeBodyMaxBytes: 2048},
 		multiValidator{},
-	)
+	) //nolint: errcheck //testcode
 
 	assert.Equal(t, len(body), fields["bytes"], "bytes must reflect the full response length")
 	_, hasContent := fields["content"]
@@ -331,11 +334,14 @@ func TestBodyMaxBytesIncludeBodyDefaultSizeLessThanBodyMax(t *testing.T) {
 	)
 	body := strings.Repeat("x", 2*bodyMaxBytes)
 
+	resp := fakeResponse(body)
+	defer resp.Body.Close()
+
 	fields, _, _ := processBody(
-		fakeResponse(body),
+		resp,
 		responseConfig{IncludeBody: "always", CheckBodyMaxBytes: bodyMaxBytes, IncludeBodyMaxBytes: includeBodyMaxBytes},
 		multiValidator{}, // no body validators — triggers the bug
-	)
+	) //nolint: errcheck //testcode
 
 	content, ok := fields["content"]
 	require.True(t, ok, "content must be present when include_body is always")
@@ -356,11 +362,14 @@ func TestBodyMaxBytesExpandsWhenIncludeBodyMaxBytesIsLarger(t *testing.T) {
 	v, captured := capturingValidator()
 	validator := multiValidator{bodyValidators: []bodyValidator{v}}
 
+	resp := fakeResponse(body)
+	defer resp.Body.Close()
+
 	fields, _, _ := processBody(
-		fakeResponse(body),
+		resp,
 		responseConfig{IncludeBody: "always", CheckBodyMaxBytes: bodyMaxBytes, IncludeBodyMaxBytes: includeBodyMaxBytes},
 		validator,
-	)
+	) //nolint: errcheck //testcode
 
 	assert.Len(t, *captured, includeBodyMaxBytes, "validator must see includeBodyMaxBytes when it exceeds bodyMaxBytes")
 	content, ok := fields["content"]
@@ -380,11 +389,14 @@ func TestBodyMaxBytesEventContentTrimmedToIncludeBodyMaxBytes(t *testing.T) {
 	v, captured := capturingValidator()
 	validator := multiValidator{bodyValidators: []bodyValidator{v}}
 
+	resp := fakeResponse(body)
+	defer resp.Body.Close()
+
 	fields, _, _ := processBody(
-		fakeResponse(body),
+		resp,
 		responseConfig{IncludeBody: "always", CheckBodyMaxBytes: bodyMaxBytes, IncludeBodyMaxBytes: includeBodyMaxBytes},
 		validator,
-	)
+	) //nolint: errcheck //testcode
 
 	assert.Len(t, *captured, bodyMaxBytes, "validator must receive BodyMaxBytes bytes")
 	content, ok := fields["content"]

--- a/heartbeat/monitors/active/http/respbody_test.go
+++ b/heartbeat/monitors/active/http/respbody_test.go
@@ -258,3 +258,136 @@ func Test_readPrefixAndHash(t *testing.T) {
 func simpleHTTPResponse() *http.Response {
 	return &http.Response{Body: io.NopCloser(strings.NewReader("hello"))}
 }
+
+// capturingValidator returns a bodyValidator that stores the body it receives, and a pointer
+// to that stored value. Use it to assert how many bytes processBody passed to a validator.
+func capturingValidator() (bodyValidator, *string) {
+	var captured string
+	return func(_ *http.Response, body string) error {
+		captured = body
+		return nil
+	}, &captured
+}
+
+func fakeResponse(body string) *http.Response {
+	return &http.Response{Body: io.NopCloser(strings.NewReader(body))}
+}
+
+// TestBodyMaxBytesCapsBodiesSentToValidators verifies that body validators receive at most
+// CheckBodyMaxBytes bytes, regardless of the actual response size.
+func TestBodyMaxBytesCapsBodiesSentToValidators(t *testing.T) {
+	const limit = 200
+	v, captured := capturingValidator()
+	validator := multiValidator{bodyValidators: []bodyValidator{v}}
+
+	processBody(
+		fakeResponse(strings.Repeat("x", 3*limit)),
+		responseConfig{IncludeBody: "never", CheckBodyMaxBytes: limit, IncludeBodyMaxBytes: 2048},
+		validator,
+	)
+
+	assert.Len(t, *captured, limit, "validator must receive exactly BodyMaxBytes bytes")
+}
+
+// TestBodyMaxBytesDoesNotTruncateSmallBodies verifies that a response body smaller than
+// CheckBodyMaxBytes is passed to validators in full.
+func TestBodyMaxBytesDoesNotTruncateSmallBodies(t *testing.T) {
+	const limit = 1024
+	body := strings.Repeat("x", limit/2)
+	v, captured := capturingValidator()
+	validator := multiValidator{bodyValidators: []bodyValidator{v}}
+
+	processBody(
+		fakeResponse(body),
+		responseConfig{IncludeBody: "never", CheckBodyMaxBytes: limit, IncludeBodyMaxBytes: 2048},
+		validator,
+	)
+
+	assert.Equal(t, body, *captured, "validator must receive the full body when it fits within BodyMaxBytes")
+}
+
+// TestBodyMaxBytesMinimalBufferWithNoValidatorsAndNoIncludeBody verifies that when no body
+// validators are registered and include_body is "never", processBody allocates only a minimal
+// prefix buffer (minBufferBodyBytes). The bytes field must still reflect the full response size.
+func TestBodyMaxBytesMinimalBufferWithNoValidatorsAndNoIncludeBody(t *testing.T) {
+	const bodyMaxBytes = 1024
+	body := strings.Repeat("x", 2*bodyMaxBytes)
+
+	fields, _, _ := processBody(
+		fakeResponse(body),
+		responseConfig{IncludeBody: "never", CheckBodyMaxBytes: bodyMaxBytes, IncludeBodyMaxBytes: 2048},
+		multiValidator{},
+	)
+
+	assert.Equal(t, len(body), fields["bytes"], "bytes must reflect the full response length")
+	_, hasContent := fields["content"]
+	assert.False(t, hasContent, "content must be absent when include_body is never")
+}
+
+func TestBodyMaxBytesIncludeBodyDefaultSizeLessThanBodyMax(t *testing.T) {
+	const (
+		bodyMaxBytes        = 1024
+		includeBodyMaxBytes = 200 // default-like value, less than bodyMaxBytes
+	)
+	body := strings.Repeat("x", 2*bodyMaxBytes)
+
+	fields, _, _ := processBody(
+		fakeResponse(body),
+		responseConfig{IncludeBody: "always", CheckBodyMaxBytes: bodyMaxBytes, IncludeBodyMaxBytes: includeBodyMaxBytes},
+		multiValidator{}, // no body validators — triggers the bug
+	)
+
+	content, ok := fields["content"]
+	require.True(t, ok, "content must be present when include_body is always")
+	assert.Len(t, content, includeBodyMaxBytes,
+		"event content should be IncludeBodyMaxBytes bytes; if it is %d (minBufferBodyBytes) the IncludeBody buffer condition is using the wrong comparator",
+		minBufferBodyBytes)
+}
+
+// TestBodyMaxBytesExpandsWhenIncludeBodyMaxBytesIsLarger verifies that when
+// IncludeBodyMaxBytes > BodyMaxBytes and include_body is active, the buffer expands so
+// that the event content is not silently truncated below the configured limit.
+func TestBodyMaxBytesExpandsWhenIncludeBodyMaxBytesIsLarger(t *testing.T) {
+	const (
+		bodyMaxBytes        = 100
+		includeBodyMaxBytes = 300 // explicitly larger than bodyMaxBytes
+	)
+	body := strings.Repeat("x", 500)
+	v, captured := capturingValidator()
+	validator := multiValidator{bodyValidators: []bodyValidator{v}}
+
+	fields, _, _ := processBody(
+		fakeResponse(body),
+		responseConfig{IncludeBody: "always", CheckBodyMaxBytes: bodyMaxBytes, IncludeBodyMaxBytes: includeBodyMaxBytes},
+		validator,
+	)
+
+	assert.Len(t, *captured, includeBodyMaxBytes, "validator must see includeBodyMaxBytes when it exceeds bodyMaxBytes")
+	content, ok := fields["content"]
+	require.True(t, ok)
+	assert.Len(t, content, includeBodyMaxBytes, "event content must be capped at IncludeBodyMaxBytes")
+}
+
+// TestBodyMaxBytesEventContentTrimmedToIncludeBodyMaxBytes verifies that when validators
+// are present and CheckBodyMaxBytes > IncludeBodyMaxBytes, validators see CheckBodyMaxBytes bytes
+// while the event content is trimmed to IncludeBodyMaxBytes.
+func TestBodyMaxBytesEventContentTrimmedToIncludeBodyMaxBytes(t *testing.T) {
+	const (
+		bodyMaxBytes        = 500
+		includeBodyMaxBytes = 100
+	)
+	body := strings.Repeat("x", 1000)
+	v, captured := capturingValidator()
+	validator := multiValidator{bodyValidators: []bodyValidator{v}}
+
+	fields, _, _ := processBody(
+		fakeResponse(body),
+		responseConfig{IncludeBody: "always", CheckBodyMaxBytes: bodyMaxBytes, IncludeBodyMaxBytes: includeBodyMaxBytes},
+		validator,
+	)
+
+	assert.Len(t, *captured, bodyMaxBytes, "validator must receive BodyMaxBytes bytes")
+	content, ok := fields["content"]
+	require.True(t, ok)
+	assert.Len(t, content, includeBodyMaxBytes, "event content must be trimmed to IncludeBodyMaxBytes")
+}

--- a/heartbeat/monitors/active/http/respbody_test.go
+++ b/heartbeat/monitors/active/http/respbody_test.go
@@ -280,11 +280,14 @@ func TestBodyMaxBytesCapsBodiesSentToValidators(t *testing.T) {
 	v, captured := capturingValidator()
 	validator := multiValidator{bodyValidators: []bodyValidator{v}}
 
-	processBody(
-		fakeResponse(strings.Repeat("x", 3*limit)),
+	resp := fakeResponse(strings.Repeat("x", 3*limit))
+	defer resp.Body.Close()
+
+	processBody( //nolint: errcheck //testcode
+		resp,
 		responseConfig{IncludeBody: "never", CheckBodyMaxBytes: limit, IncludeBodyMaxBytes: 2048},
 		validator,
-	) //nolint: errcheck //testcode
+	)
 
 	assert.Len(t, *captured, limit, "validator must receive exactly BodyMaxBytes bytes")
 }
@@ -297,11 +300,14 @@ func TestBodyMaxBytesDoesNotTruncateSmallBodies(t *testing.T) {
 	v, captured := capturingValidator()
 	validator := multiValidator{bodyValidators: []bodyValidator{v}}
 
-	processBody(
-		fakeResponse(body),
+	resp := fakeResponse(body)
+	defer resp.Body.Close()
+
+	processBody( //nolint: errcheck //testcode
+		resp,
 		responseConfig{IncludeBody: "never", CheckBodyMaxBytes: limit, IncludeBodyMaxBytes: 2048},
 		validator,
-	) //nolint: errcheck //testcode
+	)
 
 	assert.Equal(t, body, *captured, "validator must receive the full body when it fits within BodyMaxBytes")
 }
@@ -316,11 +322,11 @@ func TestBodyMaxBytesMinimalBufferWithNoValidatorsAndNoIncludeBody(t *testing.T)
 	resp := fakeResponse(body)
 	defer resp.Body.Close()
 
-	fields, _, _ := processBody(
+	fields, _, _ := processBody( //nolint: errcheck //testcode
 		resp,
 		responseConfig{IncludeBody: "never", CheckBodyMaxBytes: bodyMaxBytes, IncludeBodyMaxBytes: 2048},
 		multiValidator{},
-	) //nolint: errcheck //testcode
+	)
 
 	assert.Equal(t, len(body), fields["bytes"], "bytes must reflect the full response length")
 	_, hasContent := fields["content"]
@@ -337,11 +343,11 @@ func TestBodyMaxBytesIncludeBodyDefaultSizeLessThanBodyMax(t *testing.T) {
 	resp := fakeResponse(body)
 	defer resp.Body.Close()
 
-	fields, _, _ := processBody(
+	fields, _, _ := processBody( //nolint: errcheck //testcode
 		resp,
 		responseConfig{IncludeBody: "always", CheckBodyMaxBytes: bodyMaxBytes, IncludeBodyMaxBytes: includeBodyMaxBytes},
 		multiValidator{}, // no body validators — triggers the bug
-	) //nolint: errcheck //testcode
+	)
 
 	content, ok := fields["content"]
 	require.True(t, ok, "content must be present when include_body is always")
@@ -365,11 +371,11 @@ func TestBodyMaxBytesExpandsWhenIncludeBodyMaxBytesIsLarger(t *testing.T) {
 	resp := fakeResponse(body)
 	defer resp.Body.Close()
 
-	fields, _, _ := processBody(
+	fields, _, _ := processBody( //nolint: errcheck //testcode
 		resp,
 		responseConfig{IncludeBody: "always", CheckBodyMaxBytes: bodyMaxBytes, IncludeBodyMaxBytes: includeBodyMaxBytes},
 		validator,
-	) //nolint: errcheck //testcode
+	)
 
 	assert.Len(t, *captured, includeBodyMaxBytes, "validator must see includeBodyMaxBytes when it exceeds bodyMaxBytes")
 	content, ok := fields["content"]
@@ -392,11 +398,11 @@ func TestBodyMaxBytesEventContentTrimmedToIncludeBodyMaxBytes(t *testing.T) {
 	resp := fakeResponse(body)
 	defer resp.Body.Close()
 
-	fields, _, _ := processBody(
+	fields, _, _ := processBody( //nolint: errcheck //testcode
 		resp,
 		responseConfig{IncludeBody: "always", CheckBodyMaxBytes: bodyMaxBytes, IncludeBodyMaxBytes: includeBodyMaxBytes},
 		validator,
-	) //nolint: errcheck //testcode
+	)
 
 	assert.Len(t, *captured, bodyMaxBytes, "validator must receive BodyMaxBytes bytes")
 	content, ok := fields["content"]


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

Adjust the default limit for http monitor response size from 100MiB to 4 Mib and provide an override `check_body_max_bytes` for cases where it's required.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

Responses larger than the 4 MiB limit introduced in this PR will start being truncated. `check_body_max_bytes` needs to be configured to override this limit.

