### PR TITLE
filebeat: keep httpjson chain pagination cursor on failure

### DIFF
--- a/changelog/fragments/1788162891-httpjson-chain-pagination-cursor.yaml
+++ b/changelog/fragments/1788162891-httpjson-chain-pagination-cursor.yaml
@@ -1,0 +1,9 @@
+kind: bug-fix
+summary: Prevent httpjson chain pagination from advancing the cursor when a chained request fails.
+description: |
+  When a paginated httpjson root request drives chain steps, a transient chain
+  failure (timeout, 502, connection reset) was logged and ignored after the
+  page cursor had already been committed. Later intervals then skipped the
+  failed page's chain data. The interval now fails and the cursor stays on the
+  last successfully chained page so the next run retries it.
+component: filebeat

--- a/x-pack/filebeat/input/httpjson/cursor.go
+++ b/x-pack/filebeat/input/httpjson/cursor.go
@@ -78,3 +78,14 @@ func (c *cursor) clone() mapstr.M {
 	}
 	return c.state.Clone()
 }
+
+func (c *cursor) restore(state mapstr.M) {
+	if c == nil {
+		return
+	}
+	if len(state) == 0 {
+		c.state = nil
+		return
+	}
+	c.state = state
+}

--- a/x-pack/filebeat/input/httpjson/pagination.go
+++ b/x-pack/filebeat/input/httpjson/pagination.go
@@ -145,13 +145,13 @@ func (iter *pageIterator) next() (*response, bool, error) {
 
 	httpReq, err := iter.pagination.requestFactory.newHTTPRequest(iter.stdCtx, iter.trCtx)
 	if err != nil {
-		// If this error happens here it means a transform
-		// did not find any new value and we can stop paginating without error.
 		var execErr template.ExecError
 		if errors.Is(err, errNewURLValueNotSet) ||
 			errors.Is(err, errEmptyTemplateResult) ||
 			errors.Is(err, errExecutingTemplate) ||
 			errors.As(err, &execErr) {
+			// If this error happens here it means a transform
+			// did not find any new value and we can stop paginating without error.
 			iter.done = true
 			return nil, false, nil
 		}

--- a/x-pack/filebeat/input/httpjson/pagination.go
+++ b/x-pack/filebeat/input/httpjson/pagination.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"text/template"
 
 	"github.com/elastic/beats/v7/libbeat/management/status"
 	"github.com/elastic/mito/lib/xml"
@@ -143,17 +144,17 @@ func (iter *pageIterator) next() (*response, bool, error) {
 	}
 
 	httpReq, err := iter.pagination.requestFactory.newHTTPRequest(iter.stdCtx, iter.trCtx)
-	switch {
-	case err == nil:
-		// OK
-	case errors.Is(err, errNewURLValueNotSet),
-		errors.Is(err, errEmptyTemplateResult),
-		errors.Is(err, errExecutingTemplate):
+	if err != nil {
 		// If this error happens here it means a transform
 		// did not find any new value and we can stop paginating without error.
-		iter.done = true
-		return nil, false, nil
-	default:
+		var execErr template.ExecError
+		if errors.Is(err, errNewURLValueNotSet) ||
+			errors.Is(err, errEmptyTemplateResult) ||
+			errors.Is(err, errExecutingTemplate) ||
+			errors.As(err, &execErr) {
+			iter.done = true
+			return nil, false, nil
+		}
 		return nil, false, err
 	}
 

--- a/x-pack/filebeat/input/httpjson/request.go
+++ b/x-pack/filebeat/input/httpjson/request.go
@@ -230,7 +230,11 @@ func (r *requester) doRequest(ctx context.Context, trCtx *transformContext, publ
 	defer httpResp.Body.Close()
 	// if pagination exists for the parent request along with chaining, then for each page response the chain is processed
 	if isChainWithPageExpected {
-		n += r.processRemainingChainEvents(ctx, trCtx, publisher, initialResponse, chainIndex)
+		nChain, err := r.processRemainingChainEvents(ctx, trCtx, publisher, initialResponse, chainIndex)
+		n += nChain
+		if err != nil {
+			return err
+		}
 	}
 	r.status.UpdateStatus(status.Running, "")
 	r.log.Infof("request finished: %d events published", n)
@@ -658,11 +662,11 @@ func (r *requester) getIdsFromResponses(intermediateResps []*http.Response, repl
 }
 
 // processRemainingChainEvents, processes the remaining pagination events for chain blocks
-func (r *requester) processRemainingChainEvents(stdCtx context.Context, trCtx *transformContext, publisher inputcursor.Publisher, initialResp []*http.Response, chainIndex int) int {
+func (r *requester) processRemainingChainEvents(stdCtx context.Context, trCtx *transformContext, publisher inputcursor.Publisher, initialResp []*http.Response, chainIndex int) (int, error) {
 	// we start from 0, and skip the 1st event since we have already processed it
 	p := newChainProcessor(r, trCtx, publisher, chainIndex, r.status)
 	r.responseProcessors[0].startProcessing(stdCtx, trCtx, initialResp, true, true, p)
-	return p.eventCount()
+	return p.eventCount(), p.err
 }
 
 // chainProcessor is a chained processing handler.
@@ -673,6 +677,7 @@ type chainProcessor struct {
 	idx    int
 	tail   bool
 	n      int
+	err    error
 	status status.StatusReporter
 }
 
@@ -686,8 +691,11 @@ func newChainProcessor(req *requester, trCtx *transformContext, pub inputcursor.
 	}
 }
 
-// handleEvents processes msg as a request body in an execution chain.
+// handleEvent processes msg as a request body in an execution chain.
 func (p *chainProcessor) handleEvent(ctx context.Context, msg mapstr.M) {
+	if p.err != nil {
+		return
+	}
 	if !p.tail {
 		// Skip first event as it has already been processed.
 		p.tail = true
@@ -700,12 +708,16 @@ func (p *chainProcessor) handleEvent(ctx context.Context, msg mapstr.M) {
 	// we construct a new response here from each of the pagination events
 	err := json.NewEncoder(body).Encode(msg)
 	if err != nil {
+		p.setErr(fmt.Errorf("error processing chain event: %w", err))
 		p.req.log.Errorf("error processing chain event: %v", err)
 		return
 	}
 	response.Body = io.NopCloser(body)
+	defer response.Body.Close()
 
-	// updates the cursor for pagination last_event & last_response when chaining is present
+	// Parent-page cursor must be visible to this page's chain transforms,
+	// but it must not stick if the chain itself fails.
+	savedCursor := p.trCtx.cursor.clone()
 	p.trCtx.updateLastEvent(msg)
 	p.trCtx.updateCursor()
 
@@ -716,15 +728,12 @@ func (p *chainProcessor) handleEvent(ctx context.Context, msg mapstr.M) {
 			p.req.log.Debugf("ignored error processing chain event: %v", err)
 			return
 		}
+		p.trCtx.cursor.restore(savedCursor)
+		p.setErr(err)
 		p.req.log.Errorf("error processing chain event: %v", err)
 		return
 	}
 	p.n += n
-
-	err = response.Body.Close()
-	if err != nil {
-		p.req.log.Errorf("error closing http response body: %v", err)
-	}
 }
 
 func (p *chainProcessor) handleError(err error) {
@@ -732,8 +741,15 @@ func (p *chainProcessor) handleError(err error) {
 		p.req.log.Debugf("ignored error processing response: %v", err)
 		return
 	}
+	p.setErr(err)
 	p.status.UpdateStatus(status.Degraded, "error processing response: "+err.Error())
 	p.req.log.Errorf("error processing response: %v", err)
+}
+
+func (p *chainProcessor) setErr(err error) {
+	if p.err == nil {
+		p.err = err
+	}
 }
 
 // notLogged is an error that is not logged except at DEBUG.

--- a/x-pack/filebeat/input/httpjson/request_test.go
+++ b/x-pack/filebeat/input/httpjson/request_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strings"
@@ -560,6 +561,119 @@ func TestChainStepOriginValidation(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestChainPaginationFailureDoesNotAdvanceCursor(t *testing.T) {
+	requester, trCtx, publisher := newChainPaginationTestRequester(t, nil)
+
+	err := requester.doRequest(context.Background(), trCtx, publisher)
+	require.Error(t, err, "interval should fail when a paginated chain request fails")
+	assert.Contains(t, err.Error(), "502", "error should surface the transient chain HTTP failure")
+	assert.Equal(t, "p1", trCtx.cursorMap()["page"], "cursor should remain on the last successfully chained page")
+}
+
+func TestChainPaginationIgnoredFailureAdvancesCursor(t *testing.T) {
+	requester, trCtx, publisher := newChainPaginationTestRequester(t, []any{
+		map[string]any{
+			"set": map[string]any{
+				"target":                 "header.X-Test",
+				"value":                  `[[if eq .parent_last_response.body.page "p1"]]ok[[else]][[.parent_last_response.body.missing]][[end]]`,
+				"fail_on_template_error": true,
+				"do_not_log_failure":     true,
+			},
+		},
+	})
+
+	err := requester.doRequest(context.Background(), trCtx, publisher)
+	require.NoError(t, err, "an intentionally ignored chain error should not fail the interval")
+	assert.Equal(t, "p2", trCtx.cursorMap()["page"], "ignored chain error should retain the advanced page cursor")
+}
+
+func TestChainProcessorHandleErrorPropagates(t *testing.T) {
+	want := errors.New("failed to process paginated response")
+	p := &chainProcessor{
+		req:    &requester{log: logptest.NewTestingLogger(t, "")},
+		status: noopReporter{},
+	}
+
+	p.handleError(want)
+
+	require.ErrorIs(t, p.err, want, "response processing error should fail the interval")
+}
+
+func newChainPaginationTestRequester(t *testing.T, chainTransforms []any) (*requester, *transformContext, statelessPublisher) {
+	t.Helper()
+
+	var serverURL string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/":
+			fmt.Fprintf(w, `{"records":[{"id":"1"}],"page":"p1","nextLink":"%s/page2"}`, serverURL)
+		case "/page2":
+			fmt.Fprintln(w, `{"records":[{"id":"2"}],"page":"p2"}`)
+		case "/1":
+			fmt.Fprintln(w, `{"hello":{"world":"moon"}}`)
+		case "/2":
+			w.WriteHeader(http.StatusBadGateway)
+			fmt.Fprintln(w, `{"error":"transient chain failure"}`)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(server.Close)
+	serverURL = server.URL
+
+	chainStep := map[string]any{
+		"request.method": "GET",
+		"request.url":    server.URL + "/$.records[:].id",
+		"replace":        "$.records[:].id",
+	}
+	if chainTransforms != nil {
+		chainStep["request.transforms"] = chainTransforms
+	}
+	cfg := conf.MustNewConfigFrom(map[string]any{
+		"interval":       1,
+		"request.method": "GET",
+		"request.url":    server.URL,
+		"response.pagination": []any{
+			map[string]any{
+				"set": map[string]any{
+					"target":                 "url.value",
+					"value":                  "[[.last_response.body.nextLink]]",
+					"fail_on_template_error": true,
+				},
+			},
+		},
+		"chain": []any{
+			map[string]any{
+				"step": chainStep,
+			},
+		},
+		"cursor": map[string]any{
+			"page": map[string]any{
+				"value": "[[ .last_event.page ]]",
+			},
+		},
+	})
+
+	config := defaultConfig()
+	require.NoError(t, cfg.Unpack(&config), "unpacking test config should succeed")
+
+	log := logptest.NewTestingLogger(t, "")
+	ctx := context.Background()
+	client, err := newHTTPClient(ctx, config.Auth, config.Request, noopReporter{}, log, nil, nil)
+	require.NoError(t, err, "creating http client should succeed")
+
+	requestFactory, err := newRequestFactory(ctx, config, noopReporter{}, log, nil, nil, "")
+	require.NoError(t, err, "creating request factory should succeed")
+	pagination := newPagination(config, client, noopReporter{}, log, "")
+	responseProcessor := newResponseProcessor(config, pagination, nil, nil, noopReporter{}, log)
+	requester := newRequester(client, requestFactory, responseProcessor, nil, noopReporter{}, log)
+
+	trCtx := emptyTransformContext()
+	trCtx.cursor = newCursor(config.Cursor, noopReporter{}, log)
+
+	return requester, trCtx, statelessPublisher{&beattest.FakeClient{}}
 }
 
 func TestPaginationRequestFactorySetsUserAgent(t *testing.T) {

--- a/x-pack/filebeat/input/httpjson/request_test.go
+++ b/x-pack/filebeat/input/httpjson/request_test.go
@@ -566,7 +566,7 @@ func TestChainStepOriginValidation(t *testing.T) {
 func TestChainPaginationFailureDoesNotAdvanceCursor(t *testing.T) {
 	requester, trCtx, publisher := newChainPaginationTestRequester(t, nil)
 
-	err := requester.doRequest(context.Background(), trCtx, publisher)
+	err := requester.doRequest(t.Context(), trCtx, publisher)
 	require.Error(t, err, "interval should fail when a paginated chain request fails")
 	assert.Contains(t, err.Error(), "502", "error should surface the transient chain HTTP failure")
 	assert.Equal(t, "p1", trCtx.cursorMap()["page"], "cursor should remain on the last successfully chained page")
@@ -584,7 +584,7 @@ func TestChainPaginationIgnoredFailureAdvancesCursor(t *testing.T) {
 		},
 	})
 
-	err := requester.doRequest(context.Background(), trCtx, publisher)
+	err := requester.doRequest(t.Context(), trCtx, publisher)
 	require.NoError(t, err, "an intentionally ignored chain error should not fail the interval")
 	assert.Equal(t, "p2", trCtx.cursorMap()["page"], "ignored chain error should retain the advanced page cursor")
 }
@@ -660,11 +660,10 @@ func newChainPaginationTestRequester(t *testing.T, chainTransforms []any) (*requ
 	require.NoError(t, cfg.Unpack(&config), "unpacking test config should succeed")
 
 	log := logptest.NewTestingLogger(t, "")
-	ctx := context.Background()
-	client, err := newHTTPClient(ctx, config.Auth, config.Request, noopReporter{}, log, nil, nil)
+	client, err := newHTTPClient(t.Context(), config.Auth, config.Request, noopReporter{}, log, nil, nil)
 	require.NoError(t, err, "creating http client should succeed")
 
-	requestFactory, err := newRequestFactory(ctx, config, noopReporter{}, log, nil, nil, "")
+	requestFactory, err := newRequestFactory(t.Context(), config, noopReporter{}, log, nil, nil, "")
 	require.NoError(t, err, "creating request factory should succeed")
 	pagination := newPagination(config, client, noopReporter{}, log, "")
 	responseProcessor := newResponseProcessor(config, pagination, nil, nil, noopReporter{}, log)


### PR DESCRIPTION
## Proposed commit message

Prevent silent data loss in httpjson chain pagination: when a chained request for a paginated parent page fails, fail the interval and restore the last successful cursor so the failed page is retried instead of skipped.

Also treat missing next-page template results (including `template.ExecError`) as end-of-pagination so intervals do not falsely fail after error propagation.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

Failed chained pages are retried on the next interval instead of being skipped. Callers may see temporary interval failures that previously were only logged.

## How to test this PR locally

```bash
cd x-pack/filebeat
go test -v -race -count=1 -run 'TestChainPaginationFailureDoesNotAdvanceCursor|TestCtxAfterDoRequest' ./input/httpjson/
```

## Related issues

- Relates #52632
- Split from #52875

## Use cases

N/A

## Screenshots

N/A

## Logs

N/A