### PR TITLE
filebeat: follow every CrowdStrike discover feed

### DIFF
--- a/changelog/fragments/1788162892-crowdstrike-follow-all-feeds.yaml
+++ b/changelog/fragments/1788162892-crowdstrike-follow-all-feeds.yaml
@@ -1,0 +1,8 @@
+kind: bug-fix
+summary: Follow every CrowdStrike discover resource instead of only the first feed.
+description: |
+  FalconHose followSession iterated discovered resources but blocked in the
+  first feed's decode loop and returned on EOF, so additional feeds in the same
+  discover response were never read. Each resource is now followed
+  concurrently with a merged per-feed cursor.
+component: filebeat

--- a/docs/reference/filebeat/filebeat-input-streaming.md
+++ b/docs/reference/filebeat/filebeat-input-streaming.md
@@ -52,9 +52,11 @@ On start the `state` will be something like this:
 }
 ```
 
-The `streaming` input websocket handler creates a `response` field in the state map and attaches the websocket message to this field. All `CEL` programs written should act on this `response` field. Additional fields may be present at the root of the object and if the program tolerates it, the cursor value may be absent. Only the cursor is persisted over restarts, but all fields in state are retained between iterations of the processing loop except for the produced events array, see below.
+The `streaming` input websocket handler creates a `response` field in the state map and attaches the websocket message to this field. All `CEL` programs written should act on this `response` field. For the CrowdStrike handler, `state.feed` contains the original `dataFeedURL` of the resource that produced the message. Additional fields may be present at the root of the object and if the program tolerates it, the cursor value may be absent. Only the cursor is persisted over restarts, but all fields in state are retained between iterations of the processing loop except for the produced events array, see below.
 
 If the cursor is present the program should process or filter out responses based on its value. If cursor is not present all responses should be processed as per the program’s logic.
+
+The CrowdStrike discover endpoint can return multiple feed resources. Each resource is followed concurrently, so a long-lived feed cannot starve the others. A CrowdStrike cursor must therefore be a single object keyed by `state.feed`, with each value storing that feed's offset. When producing a new cursor, merge the current feed's offset into `state.cursor` so that offsets for the other feeds are retained. A flat cursor such as `{"offset": 123}` cannot track more than one feed.
 
 After completion of a program’s execution it should return a single object with a structure looking like this:
 
@@ -72,7 +74,7 @@ After completion of a program’s execution it should return a single object wit
 ```
 
 1. The `events` field must be present, but may be empty or null. If it is not empty, it must only have objects as elements. The field could be an array or a single object that will be treated as an array with a single element. This depends completely on the streaming data source. The `events` field is the array of events to be published to the output. Each event must be a JSON object.
-2. If `cursor` is present it must be either be a single object or an array with the same length as events; each element *i* of the `cursor` will be the details for obtaining the events at and beyond event *i* in the `events` array. If the `cursor` is a single object, it will be the details for obtaining events after the last event in the `events` array and will only be retained on successful publication of all the events in the `events` array. Note that the Crowdstrike streaming input does not support array cursors.
+2. If `cursor` is present it must be either be a single object or an array with the same length as events; each element *i* of the `cursor` will be the details for obtaining the events at and beyond event *i* in the `events` array. If the `cursor` is a single object, it will be the details for obtaining events after the last event in the `events` array and will only be retained on successful publication of all the events in the `events` array. Note that the CrowdStrike streaming input does not support array cursors and requires the per-feed single-object cursor described earlier on this page.
 
 
 Example configurations:
@@ -105,9 +107,11 @@ filebeat.inputs:
     state.response.decode_json().as(body,{
       "events": [body],
       ?"cursor": has(body.?metadata.offset) ?
-        optional.of({"offset": body.metadata.offset})
+        optional.of(state.?cursor.orValue({}).with({
+          ?state.feed: body.?metadata.optMap(m, {"offset": m.offset}),
+        }))
       :
-        optional.none(),
+        state.?cursor,
     })
 ```
 

--- a/docs/reference/filebeat/filebeat-input-streaming.md
+++ b/docs/reference/filebeat/filebeat-input-streaming.md
@@ -56,7 +56,7 @@ The `streaming` input websocket handler creates a `response` field in the state 
 
 If the cursor is present the program should process or filter out responses based on its value. If cursor is not present all responses should be processed as per the program’s logic.
 
-The CrowdStrike discover endpoint can return multiple feed resources. Each resource is followed concurrently, so a long-lived feed cannot starve the others. A CrowdStrike cursor must therefore be a single object keyed by `state.feed`, with each value storing that feed's offset. When producing a new cursor, merge the current feed's offset into `state.cursor` so that offsets for the other feeds are retained. A flat cursor such as `{"offset": 123}` cannot track more than one feed.
+{applies_to}`stack: ga 9.4+` The CrowdStrike discover endpoint can return multiple feed resources. Each resource is followed concurrently, so a long-lived feed cannot starve the others. A CrowdStrike cursor must therefore be a single object keyed by `state.feed`, with each value storing that feed's offset. When producing a new cursor, merge the current feed's offset into `state.cursor` so that offsets for the other feeds are retained. A flat cursor such as `{"offset": 123}` cannot track more than one feed.
 
 After completion of a program’s execution it should return a single object with a structure looking like this:
 

--- a/x-pack/filebeat/input/streaming/crowdstrike.go
+++ b/x-pack/filebeat/input/streaming/crowdstrike.go
@@ -11,10 +11,12 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"net"
 	"net/http"
 	"net/url"
 	"strconv"
+	"sync"
 	"time"
 
 	"golang.org/x/net/publicsuffix"
@@ -401,17 +403,8 @@ func (s *falconHoseStream) followSession(ctx context.Context, cli *http.Client, 
 
 	dec := json.NewDecoder(resp.Body)
 
-	type resource struct {
-		FeedURL string `json:"dataFeedURL"`
-		Session struct {
-			Token   string    `json:"token"`
-			Expires time.Time `json:"expiration"`
-		} `json:"sessionToken"`
-		RefreshURL   string `json:"refreshActiveSessionURL"`
-		RefreshAfter int    `json:"refreshActiveSessionInterval"`
-	}
 	var body struct {
-		Resources []resource     `json:"resources"`
+		Resources []hoseResource `json:"resources"`
 		Meta      map[string]any `json:"meta"`
 	}
 	err = dec.Decode(&body)
@@ -433,10 +426,13 @@ func (s *falconHoseStream) followSession(ctx context.Context, cli *http.Client, 
 		return state, fmt.Errorf("failed to parse discover url for origin check: %w", err)
 	}
 
+	type preparedFeed struct {
+		resource hoseResource
+		feedName string
+		offset   int
+	}
 	cursors, _ := state["cursor"].(map[string]any)
-	// Clean up state feed annotation. This unfortunate code placement
-	// is in order to avoid allocating defers in a loop.
-	defer delete(state, "feed")
+	feeds := make([]preparedFeed, 0, len(body.Resources))
 	for _, r := range body.Resources {
 		feedURL, err := url.Parse(r.FeedURL)
 		if err != nil {
@@ -463,109 +459,200 @@ func (s *falconHoseStream) followSession(ctx context.Context, cli *http.Client, 
 				offset = int(off)
 			}
 		}
-		refreshAfter := time.Duration(r.RefreshAfter) * time.Second
-		go func() {
-			runRefreshLoopWithAfter(sessionCtx, refreshSessionWait(refreshAfter), time.After, func() error {
-				s.log.Debugw("session refresh", "url", r.RefreshURL)
-				req, err := http.NewRequestWithContext(sessionCtx, http.MethodPost, r.RefreshURL, nil)
-				if err != nil {
-					s.metrics.errorsTotal.Inc()
-					s.status.UpdateStatus(status.Failed, "failed to prepare refresh stream request: "+err.Error())
-					s.log.Errorw("failed to prepare refresh stream request", "error", err)
-					return err
-				}
-				req.Header.Set("Content-Type", "application/json")
-				resp, err := cli.Do(req)
-				if err != nil {
-					s.metrics.errorsTotal.Inc()
-					s.status.UpdateStatus(status.Failed, "failed to refresh stream connection: "+err.Error())
-					s.log.Errorw("failed to refresh stream connection", "error", err)
-					return err
-				}
-				err = resp.Body.Close()
-				if err != nil {
-					s.metrics.errorsTotal.Inc()
-					s.status.UpdateStatus(status.Failed, "failed to close refresh response body: "+err.Error())
-					s.log.Warnw("failed to close refresh response body", "error", err)
-				}
-				return nil
-			})
-		}()
+		feeds = append(feeds, preparedFeed{resource: r, feedName: feedName, offset: offset})
+	}
 
-		if offset > 0 {
-			feedQuery, err := url.ParseQuery(feedURL.RawQuery)
-			if err != nil {
-				return state, fmt.Errorf("failed to parse feed query: %w", err)
-			}
-			feedQuery.Set("offset", strconv.Itoa(offset))
-			feedURL.RawQuery = feedQuery.Encode()
-			r.FeedURL = feedURL.String()
+	merged := &feedCursors{cursor: cloneStringMap(cursors)}
+	var (
+		wg       sync.WaitGroup
+		errOnce  sync.Once
+		firstErr error
+	)
+	fail := func(err error) {
+		if err == nil {
+			return
 		}
-
-		s.log.Debugw("stream request", "url", r.FeedURL)
-		req, err := http.NewRequestWithContext(sessionCtx, "GET", r.FeedURL, nil)
-		if err != nil {
-			return state, fmt.Errorf("failed to make firehose request to %s: %w", r.FeedURL, err)
+		errOnce.Do(func() {
+			firstErr = err
+			sessionCancel()
+		})
+	}
+	for _, f := range feeds {
+		wg.Add(1)
+		go func(f preparedFeed) {
+			defer wg.Done()
+			feedState := cloneState(state)
+			feedState["feed"] = f.feedName
+			fail(s.consumeFeed(sessionCtx, cli, f.resource, f.feedName, f.offset, feedState, merged))
+		}(f)
+	}
+	wg.Wait()
+	delete(state, "feed")
+	if merged.cursor != nil {
+		state["cursor"] = merged.cursor
+	}
+	if firstErr != nil {
+		if errors.Is(firstErr, hardError{}) {
+			return nil, firstErr
 		}
-		req.Header = make(http.Header)
-		req.Header.Add("Accept", "application/json")
-		req.Header.Add("Authorization", "Token "+r.Session.Token)
-
-		resp, err := s.plainClient.Do(req)
-		if err != nil {
-			return state, fmt.Errorf("failed to get firehose from %s: %w", r.FeedURL, err)
-		}
-		defer resp.Body.Close()
-
-		if resp.StatusCode != http.StatusOK {
-			var buf bytes.Buffer
-			_, _ = io.Copy(&buf, resp.Body)
-			s.log.Errorw("unsuccessful firehose request", "status_code", resp.StatusCode, "status", resp.Status, "body", buf.String())
-			return state, fmt.Errorf("unsuccessful firehose request: %s: %s", resp.Status, &buf)
-		}
-
-		// Prepare state to understand which feed is being processed.
-		// This is cleared by the deferred delete above the loop.
-		state["feed"] = feedName
-		dec := json.NewDecoder(resp.Body)
-		for {
-			var msg json.RawMessage
-			err := dec.Decode(&msg)
-			if err != nil {
-				s.metrics.errorsTotal.Inc()
-				//nolint:errorlint // will not be a wrapped error here.
-				if err == io.EOF {
-					s.log.Info("stream ended, restarting")
-					return state, nil
-				}
-				return state, fmt.Errorf("error decoding event: %w", err)
-			}
-			s.metrics.receivedBytesTotal.Add(uint64(len(msg)))
-			if len(msg) == 0 || msg[0] != '{' {
-				s.metrics.errorsTotal.Inc()
-				s.log.Warnw("skipping non-object message from firehose", logp.Namespace(s.ns), "msg", debugMsg(msg))
-				continue
-			}
-			state["response"] = []byte(msg)
-			s.log.Debugw("received firehose message", logp.Namespace(s.ns), "msg", debugMsg(msg))
-			currentCursor, ok := state["cursor"].(map[string]any)
-			if !ok {
-				currentCursor = s.cursor
-			}
-			newCursor, err := s.process(ctx, state, currentCursor, s.now().In(time.UTC))
-			if newCursor != nil {
-				state["cursor"] = newCursor
-			}
-			if err != nil {
-				s.log.Errorw("failed to process and publish data", "error", err)
-				s.status.UpdateStatus(status.Failed, "failed to process and publish data: "+err.Error())
-				// Fail the input so that we do not attempt to progress
-				// while dropping data on the floor.
-				return nil, hardError{err}
-			}
-		}
+		return state, firstErr
 	}
 	return state, nil
+}
+
+type hoseResource struct {
+	FeedURL string `json:"dataFeedURL"`
+	Session struct {
+		Token   string    `json:"token"`
+		Expires time.Time `json:"expiration"`
+	} `json:"sessionToken"`
+	RefreshURL   string `json:"refreshActiveSessionURL"`
+	RefreshAfter int    `json:"refreshActiveSessionInterval"`
+}
+
+// feedCursors serializes CEL evaluation and publication across concurrent
+// feeds and keeps a merged per-feed cursor so each worker sees offsets
+// from the others.
+type feedCursors struct {
+	mu     sync.Mutex
+	cursor map[string]any
+}
+
+func (c *feedCursors) evalAndPublish(s *falconHoseStream, ctx context.Context, state map[string]any) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.cursor != nil {
+		state["cursor"] = maps.Clone(c.cursor)
+	}
+	current, ok := state["cursor"].(map[string]any)
+	if !ok {
+		current = s.cursor
+	}
+	newCursor, err := s.process(ctx, state, current, s.now().In(time.UTC))
+	if newCursor != nil {
+		c.cursor = newCursor
+		state["cursor"] = newCursor
+	}
+	return err
+}
+
+func cloneState(state map[string]any) map[string]any {
+	out := maps.Clone(state)
+	if out == nil {
+		out = make(map[string]any)
+	}
+	if c, ok := state["cursor"].(map[string]any); ok {
+		out["cursor"] = maps.Clone(c)
+	}
+	return out
+}
+
+func cloneStringMap(in map[string]any) map[string]any {
+	if in == nil {
+		return nil
+	}
+	return maps.Clone(in)
+}
+
+// consumeFeed follows a single discovered FalconHose resource until the
+// stream ends, the context is cancelled, or an error occurs.
+func (s *falconHoseStream) consumeFeed(ctx context.Context, cli *http.Client, r hoseResource, feedName string, offset int, state map[string]any, cursors *feedCursors) error {
+	refreshAfter := time.Duration(r.RefreshAfter) * time.Second
+	go func() {
+		runRefreshLoopWithAfter(ctx, refreshSessionWait(refreshAfter), time.After, func() error {
+			s.log.Debugw("session refresh", "url", r.RefreshURL)
+			req, err := http.NewRequestWithContext(ctx, http.MethodPost, r.RefreshURL, nil)
+			if err != nil {
+				s.metrics.errorsTotal.Inc()
+				s.status.UpdateStatus(status.Failed, "failed to prepare refresh stream request: "+err.Error())
+				s.log.Errorw("failed to prepare refresh stream request", "error", err)
+				return err
+			}
+			req.Header.Set("Content-Type", "application/json")
+			resp, err := cli.Do(req)
+			if err != nil {
+				s.metrics.errorsTotal.Inc()
+				s.status.UpdateStatus(status.Failed, "failed to refresh stream connection: "+err.Error())
+				s.log.Errorw("failed to refresh stream connection", "error", err)
+				return err
+			}
+			err = resp.Body.Close()
+			if err != nil {
+				s.metrics.errorsTotal.Inc()
+				s.status.UpdateStatus(status.Failed, "failed to close refresh response body: "+err.Error())
+				s.log.Warnw("failed to close refresh response body", "error", err)
+			}
+			return nil
+		})
+	}()
+
+	feedURL, err := url.Parse(r.FeedURL)
+	if err != nil {
+		return fmt.Errorf("failed to parse feed url: %w", err)
+	}
+	if offset > 0 {
+		feedQuery, err := url.ParseQuery(feedURL.RawQuery)
+		if err != nil {
+			return fmt.Errorf("failed to parse feed query: %w", err)
+		}
+		feedQuery.Set("offset", strconv.Itoa(offset))
+		feedURL.RawQuery = feedQuery.Encode()
+		r.FeedURL = feedURL.String()
+	}
+
+	s.log.Debugw("stream request", "url", r.FeedURL)
+	req, err := http.NewRequestWithContext(ctx, "GET", r.FeedURL, nil)
+	if err != nil {
+		return fmt.Errorf("failed to make firehose request to %s: %w", r.FeedURL, err)
+	}
+	req.Header = make(http.Header)
+	req.Header.Add("Accept", "application/json")
+	req.Header.Add("Authorization", "Token "+r.Session.Token)
+
+	resp, err := s.plainClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to get firehose from %s: %w", r.FeedURL, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, resp.Body)
+		s.log.Errorw("unsuccessful firehose request", "status_code", resp.StatusCode, "status", resp.Status, "body", buf.String())
+		return fmt.Errorf("unsuccessful firehose request: %s: %s", resp.Status, &buf)
+	}
+
+	dec := json.NewDecoder(resp.Body)
+	for {
+		var msg json.RawMessage
+		err := dec.Decode(&msg)
+		if err != nil {
+			s.metrics.errorsTotal.Inc()
+			if errors.Is(err, context.Canceled) || errors.Is(ctx.Err(), context.Canceled) {
+				return ctx.Err()
+			}
+			if errors.Is(err, io.EOF) {
+				s.log.Infow("feed stream ended", "url", feedName)
+				return nil
+			}
+			return fmt.Errorf("error decoding event: %w", err)
+		}
+		s.metrics.receivedBytesTotal.Add(uint64(len(msg)))
+		if len(msg) == 0 || msg[0] != '{' {
+			s.metrics.errorsTotal.Inc()
+			s.log.Warnw("skipping non-object message from firehose", logp.Namespace(s.ns), "msg", debugMsg(msg))
+			continue
+		}
+		state["response"] = []byte(msg)
+		s.log.Debugw("received firehose message", logp.Namespace(s.ns), "msg", debugMsg(msg))
+		if err := cursors.evalAndPublish(s, ctx, state); err != nil {
+			s.log.Errorw("failed to process and publish data", "error", err)
+			s.status.UpdateStatus(status.Failed, "failed to process and publish data: "+err.Error())
+			// Fail the input so that we do not attempt to progress
+			// while dropping data on the floor.
+			return hardError{err}
+		}
+	}
 }
 
 // rateLimitError carries a retry-after duration from a 429 response so

--- a/x-pack/filebeat/input/streaming/crowdstrike.go
+++ b/x-pack/filebeat/input/streaming/crowdstrike.go
@@ -404,7 +404,7 @@ func (s *falconHoseStream) followSession(ctx context.Context, cli *http.Client, 
 	dec := json.NewDecoder(resp.Body)
 
 	var body struct {
-		Resources []hoseResource `json:"resources"`
+		Resources []resource     `json:"resources"`
 		Meta      map[string]any `json:"meta"`
 	}
 	err = dec.Decode(&body)
@@ -427,7 +427,7 @@ func (s *falconHoseStream) followSession(ctx context.Context, cli *http.Client, 
 	}
 
 	type preparedFeed struct {
-		resource hoseResource
+		resource resource
 		feedName string
 		offset   int
 	}
@@ -462,28 +462,19 @@ func (s *falconHoseStream) followSession(ctx context.Context, cli *http.Client, 
 		feeds = append(feeds, preparedFeed{resource: r, feedName: feedName, offset: offset})
 	}
 
-	merged := &feedCursors{cursor: cloneStringMap(cursors)}
-	var (
-		wg       sync.WaitGroup
-		errOnce  sync.Once
-		firstErr error
-	)
-	fail := func(err error) {
-		if err == nil {
-			return
-		}
-		errOnce.Do(func() {
-			firstErr = err
-			sessionCancel()
-		})
-	}
+	merged := &feedCursors{cursor: maps.Clone(cursors)}
+	var wg sync.WaitGroup
+	feedCtx, cancel := context.WithCancelCause(sessionCtx)
 	for _, f := range feeds {
 		wg.Add(1)
 		go func(f preparedFeed) {
 			defer wg.Done()
 			feedState := cloneState(state)
 			feedState["feed"] = f.feedName
-			fail(s.consumeFeed(sessionCtx, cli, f.resource, f.feedName, f.offset, feedState, merged))
+			err := s.consumeFeed(feedCtx, cli, f.resource, f.feedName, f.offset, feedState, merged)
+			if err != nil {
+				cancel(err)
+			}
 		}(f)
 	}
 	wg.Wait()
@@ -491,16 +482,16 @@ func (s *falconHoseStream) followSession(ctx context.Context, cli *http.Client, 
 	if merged.cursor != nil {
 		state["cursor"] = merged.cursor
 	}
-	if firstErr != nil {
-		if errors.Is(firstErr, hardError{}) {
-			return nil, firstErr
+	if err := context.Cause(feedCtx); err != nil {
+		if errors.Is(err, hardError{}) {
+			return nil, err
 		}
-		return state, firstErr
+		return state, err
 	}
 	return state, nil
 }
 
-type hoseResource struct {
+type resource struct {
 	FeedURL string `json:"dataFeedURL"`
 	Session struct {
 		Token   string    `json:"token"`
@@ -547,16 +538,9 @@ func cloneState(state map[string]any) map[string]any {
 	return out
 }
 
-func cloneStringMap(in map[string]any) map[string]any {
-	if in == nil {
-		return nil
-	}
-	return maps.Clone(in)
-}
-
 // consumeFeed follows a single discovered FalconHose resource until the
 // stream ends, the context is cancelled, or an error occurs.
-func (s *falconHoseStream) consumeFeed(ctx context.Context, cli *http.Client, r hoseResource, feedName string, offset int, state map[string]any, cursors *feedCursors) error {
+func (s *falconHoseStream) consumeFeed(ctx context.Context, cli *http.Client, r resource, feedName string, offset int, state map[string]any, cursors *feedCursors) error {
 	refreshAfter := time.Duration(r.RefreshAfter) * time.Second
 	go func() {
 		runRefreshLoopWithAfter(ctx, refreshSessionWait(refreshAfter), time.After, func() error {

--- a/x-pack/filebeat/input/streaming/crowdstrike.go
+++ b/x-pack/filebeat/input/streaming/crowdstrike.go
@@ -465,6 +465,7 @@ func (s *falconHoseStream) followSession(ctx context.Context, cli *http.Client, 
 	merged := &feedCursors{cursor: maps.Clone(cursors)}
 	var wg sync.WaitGroup
 	feedCtx, cancel := context.WithCancelCause(sessionCtx)
+	defer cancel(context.Canceled)
 	for _, f := range feeds {
 		wg.Add(1)
 		go func(f preparedFeed) {

--- a/x-pack/filebeat/input/streaming/crowdstrike_test.go
+++ b/x-pack/filebeat/input/streaming/crowdstrike_test.go
@@ -85,11 +85,14 @@ func TestCrowdstrikeFalconHose(t *testing.T) {
 		Type: "crowdstrike",
 		URL:  &urlConfig{u},
 		Program: `
-				state.response.decode_json().as(body,{
+				state.response.decode_json().as(body, {
 					"events": [body],
-					"cursor": state.cursor.with({
-						?state.feed: body.?metadata.optMap(m, {"offset": m.offset}),
-					}),
+					?"cursor": has(body.metadata) ?
+						optional.of(state.?cursor.orValue({}).with({
+							?state.feed: body.?metadata.optMap(m, {"offset": m.offset}),
+						}))
+					:
+						state.?cursor,
 				})`,
 		Auth: authConfig{
 			OAuth2: oAuth2Config{

--- a/x-pack/filebeat/input/streaming/crowdstrike_unit_test.go
+++ b/x-pack/filebeat/input/streaming/crowdstrike_unit_test.go
@@ -366,7 +366,7 @@ func TestFollowSessionProcessesAllDiscoveredResources(t *testing.T) {
 	pub := new(recordingPublisher)
 	s := newTestStreamWithPublisher(t, discoverSrv.URL, http.DefaultClient, pub)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer cancel()
 
 	done := make(chan error, 1)
@@ -497,8 +497,8 @@ type recordingPublisher struct {
 
 func (p *recordingPublisher) Publish(e beat.Event, _ any) error {
 	p.mu.Lock()
-	defer p.mu.Unlock()
 	p.events = append(p.events, e)
+	p.mu.Unlock()
 	return nil
 }
 

--- a/x-pack/filebeat/input/streaming/crowdstrike_unit_test.go
+++ b/x-pack/filebeat/input/streaming/crowdstrike_unit_test.go
@@ -13,6 +13,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -295,6 +296,120 @@ func TestFollowSession_UserAgent(t *testing.T) {
 	}
 }
 
+func TestFollowSessionProcessesAllDiscoveredResources(t *testing.T) {
+	// Hold the first feed open after one event so a sequential follower
+	// would starve the second resource. Concurrent following should
+	// still publish both events within a bounded time.
+	release := make(chan struct{})
+
+	feed1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			t.Error("ResponseWriter does not implement http.Flusher")
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintln(w, `{"metadata":{"eventType":"Test","offset":1},"event":{"feed":"one"}}`)
+		flusher.Flush()
+		<-release
+	}))
+	t.Cleanup(func() {
+		close(release)
+		feed1.Close()
+	})
+
+	feed2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintln(w, `{"metadata":{"eventType":"Test","offset":2},"event":{"feed":"two"}}`)
+	}))
+	defer feed2.Close()
+
+	refreshSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer refreshSrv.Close()
+
+	discoverSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		resp := map[string]any{
+			"resources": []map[string]any{
+				{
+					"dataFeedURL": feed1.URL + "/firehose",
+					"sessionToken": map[string]any{
+						"token":      "test-token",
+						"expiration": "2099-01-01T00:00:00Z",
+					},
+					"refreshActiveSessionURL":      refreshSrv.URL + "/refresh",
+					"refreshActiveSessionInterval": 1800,
+				},
+				{
+					"dataFeedURL": feed2.URL + "/firehose",
+					"sessionToken": map[string]any{
+						"token":      "test-token",
+						"expiration": "2099-01-01T00:00:00Z",
+					},
+					"refreshActiveSessionURL":      refreshSrv.URL + "/refresh",
+					"refreshActiveSessionInterval": 1800,
+				},
+			},
+			"meta": map[string]any{},
+		}
+		b, err := json.Marshal(resp)
+		if err != nil {
+			t.Errorf("failed to marshal discover response: %v", err)
+			return
+		}
+		_, _ = w.Write(b)
+	}))
+	defer discoverSrv.Close()
+
+	pub := new(recordingPublisher)
+	s := newTestStreamWithPublisher(t, discoverSrv.URL, http.DefaultClient, pub)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := s.followSession(ctx, discoverSrv.Client(), map[string]any{})
+		done <- err
+	}()
+
+	deadline := time.After(3 * time.Second)
+	for pub.published() < 2 {
+		select {
+		case <-deadline:
+			t.Fatalf("expected events from both feeds within 3s, got %d", pub.published())
+		case err := <-done:
+			if pub.published() < 2 {
+				t.Fatalf("followSession returned before both feeds published: err=%v published=%d", err, pub.published())
+			}
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+
+	got := map[string]bool{}
+	for _, e := range pub.snapshot() {
+		ev, _ := e.Fields["event"].(map[string]any)
+		if ev == nil {
+			continue
+		}
+		if name, ok := ev["feed"].(string); ok {
+			got[name] = true
+		}
+	}
+	if !got["one"] || !got["two"] {
+		t.Errorf("expected events from feeds one and two, got %v", got)
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("followSession did not return after context cancel")
+	}
+}
+
 func discoverResponse(t *testing.T, feedURL, refreshURL string) string {
 	t.Helper()
 	resp := map[string]any{
@@ -333,7 +448,12 @@ func newTestStreamWithPublisher(t *testing.T, discoverURL string, firehoseClient
 	prg, ast, err := newProgram(ctx, `
 		state.response.decode_json().as(body, {
 			"events": [body],
-			?"cursor": body.?metadata.optMap(m, {"offset": m.offset}),
+			?"cursor": has(body.metadata) ?
+				optional.of(state.?cursor.orValue({}).with({
+					?state.feed: body.?metadata.optMap(m, {"offset": m.offset}),
+				}))
+			:
+				state.?cursor,
 		})
 	`, root, nil, "", log)
 	if err != nil {
@@ -357,13 +477,41 @@ func newTestStreamWithPublisher(t *testing.T, discoverURL string, firehoseClient
 	}
 }
 
-type countingPublisher int
+type countingPublisher struct {
+	n atomic.Int64
+}
 
 func (p *countingPublisher) Publish(beat.Event, any) error {
-	*p++
+	p.n.Add(1)
 	return nil
 }
 
 func (p *countingPublisher) published() int {
-	return int(*p)
+	return int(p.n.Load())
+}
+
+type recordingPublisher struct {
+	mu     sync.Mutex
+	events []beat.Event
+}
+
+func (p *recordingPublisher) Publish(e beat.Event, _ any) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.events = append(p.events, e)
+	return nil
+}
+
+func (p *recordingPublisher) published() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return len(p.events)
+}
+
+func (p *recordingPublisher) snapshot() []beat.Event {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	out := make([]beat.Event, len(p.events))
+	copy(out, p.events)
+	return out
 }


### PR DESCRIPTION
## Proposed commit message

Follow every resource returned by the CrowdStrike discover endpoint concurrently instead of only the first feed. Serialize CEL evaluation and publication, keep a merged per-feed cursor keyed by `state.feed`, and document the required cursor shape.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

CrowdStrike CEL programs must use a per-feed cursor object keyed by `state.feed`. A flat cursor such as `{"offset": 123}` cannot track more than one feed.

## How to test this PR locally

```bash
cd x-pack/filebeat
go test -v -race -count=1 -run 'TestFollowSession' ./input/streaming/
```

## Related issues

- Relates #52632
- Split from #52875

## Use cases

N/A

## Screenshots

N/A

## Logs

N/A