### PR TITLE
Add Pubsub api endpoint override for filebeats

### DIFF
--- a/changelog/fragments/1778600000-gcppubsub-api-endpoint.yaml
+++ b/changelog/fragments/1778600000-gcppubsub-api-endpoint.yaml
@@ -1,0 +1,3 @@
+kind: enhancement
+summary: Add api_endpoint configuration option to gcp-pubsub input to allow overriding the default Pub/Sub API endpoint.
+component: filebeat

--- a/docs/reference/filebeat/filebeat-input-gcp-pubsub.md
+++ b/docs/reference/filebeat/filebeat-input-gcp-pubsub.md
@@ -1,0 +1,198 @@
+---
+navigation_title: "GCP Pub/Sub"
+mapped_pages:
+  - https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-gcp-pubsub.html
+applies_to:
+  stack: ga
+  serverless: ga
+---
+
+# GCP Pub/Sub input [filebeat-input-gcp-pubsub]
+
+
+Use the `gcp-pubsub` input to read messages from a Google Cloud Pub/Sub topic subscription.
+
+This input can, for example, be used to receive Stackdriver logs that have been exported to a Google Cloud Pub/Sub topic.
+
+Multiple Filebeat instances can be configured to read from the same subscription to achieve high-availability or increased throughput.
+
+Example configuration:
+
+```yaml
+filebeat.inputs:
+- type: gcp-pubsub
+  project_id: my-gcp-project-id
+  topic: vpc-firewall-logs-topic
+  subscription.name: filebeat-vpc-firewall-logs-sub
+  credentials_file: ${path.config}/my-pubsub-subscriber-credentials.json
+```
+
+## Configuration options [_configuration_options_9]
+
+The `gcp-pubsub` input supports the following configuration options plus the [Common options](#filebeat-input-gcp-pubsub-common-options) described later.
+
+
+### `project_id` [_project_id]
+
+Google Cloud project ID. Required.
+
+
+### `topic` [_topic]
+
+Google Cloud Pub/Sub topic name. Required.
+
+
+### `subscription.name` [_subscription_name]
+
+Name of the subscription to read from. Required.
+
+
+### `subscription.create` [_subscription_create]
+
+Boolean value that configures the input to create the subscription if it does not exist. The default value is `true`.
+
+
+### `subscription.num_goroutines` [_subscription_num_goroutines]
+
+Number of goroutines to create to read from the subscription. This does not limit the number of messages that can be processed concurrently or the maximum number of goroutines the input will create. Even with one goroutine, many messages might be processed at once, because that goroutine may continually receive messages. To limit the number of messages being processed concurrently, set `subscription.max_outstanding_messages`. Default is 1.
+
+
+### `subscription.max_outstanding_messages` [_subscription_max_outstanding_messages]
+
+The maximum number of unprocessed messages (unacknowledged but not yet expired). If the value is negative, then there will be no limit on the number of unprocessed messages. Due to the presence of internal queue, the input gets blocked until `queue.mem.flush.min_events` or `queue.mem.flush.timeout` is reached. To prevent this blockage, this option must be at least `queue.mem.flush.min_events`. Default is 1600.
+
+
+### `credentials_file` [_credentials_file]
+
+Path to a JSON file containing the credentials and key used to subscribe. As an alternative you can use the `credentials_json` config option or rely on [Google Application Default Credentials](https://cloud.google.com/docs/authentication/production) (ADC).
+
+
+### `credentials_json` [_credentials_json]
+
+JSON blob containing the credentials and key used to subscribe. This can be as an alternative to `credentials_file` if you want to embed the credential data within your config file or put the information into a keystore. You may also use [Google Application Default Credentials](https://cloud.google.com/docs/authentication/production) (ADC).
+
+
+### `proxy_url` [_proxy_url]
+
+```{applies_to}
+stack: ga 9.1.0
+```
+
+This specifies proxy configuration in the form of `http[s]://<user>:<password>@<server name/ip>:<port>`. Proxy headers may be configured using the `resource.proxy_headers` field which accepts a set of key/value pairs.
+
+```yaml
+filebeat.inputs:
+- type: gcp-pubsub
+  . . .
+  proxy_url: http://proxy.example:8080
+```
+
+
+### `api_endpoint` [_api_endpoint]
+
+```{applies_to}
+stack: ga 8.19.22
+```
+
+Optional Google Cloud Pub/Sub API endpoint to connect to. When specified, Filebeat connects to this endpoint instead of the default `pubsub.googleapis.com:443`. This is useful for connecting through Private Service Connect (PSC), custom Universe Domains, or reverse proxies.
+
+```yaml
+filebeat.inputs:
+- type: gcp-pubsub
+  . . .
+  api_endpoint: custom-pubsub-endpoint.googleapis.com:443
+```
+
+
+## Common options [filebeat-input-gcp-pubsub-common-options]
+
+The following configuration options are supported by all inputs.
+
+
+#### `enabled` [_enabled_10]
+
+Use the `enabled` option to enable and disable inputs. By default, enabled is set to true.
+
+
+#### `tags` [_tags_10]
+
+A list of tags that Filebeat includes in the `tags` field of each published event. Tags make it easy to select specific events in Kibana or apply conditional filtering in Logstash. These tags will be appended to the list of tags specified in the general configuration.
+
+Example:
+
+```yaml
+filebeat.inputs:
+- type: gcp-pubsub
+  . . .
+  tags: ["json"]
+```
+
+
+#### `fields` [filebeat-input-gcp-pubsub-fields]
+
+Optional fields that you can specify to add additional information to the output. For example, you might add fields that you can use for filtering log data. Fields can be scalar values, arrays, dictionaries, or any nested combination of these. By default, the fields that you specify here will be grouped under a `fields` sub-dictionary in the output document. To store the custom fields as top-level fields, set the `fields_under_root` option to true. If a duplicate field is declared in the general configuration, then its value will be overwritten by the value declared here.
+
+```yaml
+filebeat.inputs:
+- type: gcp-pubsub
+  . . .
+  fields:
+    app_id: query_engine_12
+```
+
+
+#### `fields_under_root` [fields-under-root-gcp-pubsub]
+
+If this option is set to true, the custom [fields](#filebeat-input-gcp-pubsub-fields) are stored as top-level fields in the output document instead of being grouped under a `fields` sub-dictionary. If the custom field names conflict with other field names added by Filebeat, then the custom fields overwrite the other fields.
+
+
+#### `processors` [_processors_10]
+
+A list of processors to apply to the input data.
+
+See [Processors](/reference/filebeat/filtering-enhancing-data.md) for information about specifying processors in your config.
+
+
+#### `pipeline` [_pipeline_10]
+
+The ingest pipeline ID to set for the events generated by this input.
+
+::::{note}
+The pipeline ID can also be configured in the Elasticsearch output, but this option usually results in simpler configuration files. If the pipeline is configured both in the input and output, the option from the input is used.
+::::
+
+
+::::{important}
+The `pipeline` is always lowercased. If `pipeline: Foo-Bar`, then the pipeline name in {{es}} needs to be defined as `foo-bar`.
+::::
+
+
+
+#### `keep_null` [_keep_null_10]
+
+If this option is set to true, fields with `null` values will be published in the output document. By default, `keep_null` is set to `false`.
+
+
+#### `index` [_index_10]
+
+If present, this formatted string overrides the index for events from this input (for elasticsearch outputs), or sets the `raw_index` field of the event’s metadata (for other outputs). This string can only refer to the agent name and version and the event timestamp; for access to dynamic fields, use `output.elasticsearch.index` or a processor.
+
+Example value: `"%{[agent.name]}-myindex-%{+yyyy.MM.dd}"` might expand to `"filebeat-myindex-2019.11.01"`.
+
+
+#### `publisher_pipeline.disable_host` [_publisher_pipeline_disable_host_10]
+
+By default, all events contain `host.name`. This option can be set to `true` to disable the addition of this field to all events. The default value is `false`.
+
+
+## Metrics [_metrics_9]
+
+This input exposes metrics under the [HTTP monitoring endpoint](/reference/filebeat/http-endpoint.md). These metrics are exposed under the `/inputs` path. They can be used to observe the activity of the input.
+
+| Metric | Description |
+| --- | --- |
+| `acked_message_total` | Number of successfully ACKed messages. |
+| `failed_acked_message_total` | Number of failed ACKed messages. |
+| `nacked_message_total` | Number of NACKed messages. |
+| `bytes_processed_total` | Number of bytes processed. |
+| `processing_time` | Histogram of the elapsed time for processing an event in nanoseconds. |

--- a/x-pack/filebeat/_meta/config/filebeat.inputs.reference.xpack.yml.tmpl
+++ b/x-pack/filebeat/_meta/config/filebeat.inputs.reference.xpack.yml.tmpl
@@ -63,6 +63,9 @@
   # Path to a JSON file containing the credentials and key used to subscribe.
   credentials_file: ${path.config}/my-pubsub-subscriber-credentials.json
 
+  # Optional API endpoint to override the default Google Cloud Pub/Sub endpoint.
+  #api_endpoint: custom-pubsub-endpoint.googleapis.com:443
+
 #------------------------------ AWS S3 input --------------------------------
 # Beta: Config options for AWS S3 input
 #- type: aws-s3

--- a/x-pack/filebeat/docs/inputs/input-gcp-pubsub.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-gcp-pubsub.asciidoc
@@ -110,6 +110,22 @@ filebeat.inputs:
   proxy_url: http://proxy.example:8080
 ----
 
+[float]
+==== `api_endpoint`
+
+Optional Google Cloud Pub/Sub API endpoint to connect to. When specified, Filebeat
+connects to this endpoint instead of the default `pubsub.googleapis.com:443`.
+This is useful for connecting through Private Service Connect (PSC), custom
+Universe Domains, or reverse proxies.
+
+["source","yaml",subs="attributes"]
+----
+{beatname_lc}.inputs:
+- type: gcp-pubsub
+  . . .
+  api_endpoint: custom-pubsub-endpoint.googleapis.com:443
+----
+
 
 [id="{beatname_lc}-input-{type}-common-options"]
 include::../../../../filebeat/docs/inputs/input-common-options.asciidoc[]

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -3004,6 +3004,9 @@ filebeat.inputs:
   # Path to a JSON file containing the credentials and key used to subscribe.
   credentials_file: ${path.config}/my-pubsub-subscriber-credentials.json
 
+  # Optional API endpoint to override the default Google Cloud Pub/Sub endpoint.
+  #api_endpoint: custom-pubsub-endpoint.googleapis.com:443
+
 #------------------------------ AWS S3 input --------------------------------
 # Beta: Config options for AWS S3 input
 #- type: aws-s3

--- a/x-pack/filebeat/input/gcppubsub/config.go
+++ b/x-pack/filebeat/input/gcppubsub/config.go
@@ -42,6 +42,9 @@ type config struct {
 	// JSON blob containing authentication credentials and key.
 	CredentialsJSON common.JSONBlob `config:"credentials_json"`
 
+	// Pub/Sub API endpoint to override the default Google Cloud Pub/Sub endpoint.
+	APIEndpoint string `config:"api_endpoint"`
+
 	// Overrides the default Pub/Sub service address and disables TLS. For testing.
 	AlternativeHost string `config:"alternative_host"`
 

--- a/x-pack/filebeat/input/gcppubsub/config_test.go
+++ b/x-pack/filebeat/input/gcppubsub/config_test.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	conf "github.com/elastic/elastic-agent-libs/config"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -34,4 +35,20 @@ func TestConfigValidateGoogleAppDefaultCreds(t *testing.T) {
 	os.Setenv(googleApplicationCredentialsVar, filepath.Clean("testdata/fake.json"))
 	c := defaultConfig()
 	assert.NoError(t, c.Validate())
+}
+
+func TestConfigAPIEndpoint(t *testing.T) {
+	cfg, err := conf.NewConfigFrom(map[string]interface{}{
+		"project_id":       "test-project",
+		"topic":            "test-topic",
+		"subscription":     map[string]interface{}{"name": "test-sub"},
+		"api_endpoint":     "custom-endpoint.googleapis.com:443",
+		"credentials_file": filepath.Clean("testdata/fake.json"),
+	})
+	assert.NoError(t, err, "failed to create config from map")
+
+	c := defaultConfig()
+	err = cfg.Unpack(&c)
+	assert.NoError(t, err, "failed to unpack config")
+	assert.Equal(t, "custom-endpoint.googleapis.com:443", c.APIEndpoint, "APIEndpoint does not match expected value")
 }

--- a/x-pack/filebeat/input/gcppubsub/config_test.go
+++ b/x-pack/filebeat/input/gcppubsub/config_test.go
@@ -11,8 +11,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	conf "github.com/elastic/elastic-agent-libs/config"
 	"github.com/stretchr/testify/assert"
+
+	conf "github.com/elastic/elastic-agent-libs/config"
 )
 
 //nolint:gosec // false positive
@@ -38,12 +39,12 @@ func TestConfigValidateGoogleAppDefaultCreds(t *testing.T) {
 }
 
 func TestConfigAPIEndpoint(t *testing.T) {
-	cfg, err := conf.NewConfigFrom(map[string]interface{}{
+	cfg, err := conf.NewConfigFrom(map[string]any{
 		"project_id":       "test-project",
 		"topic":            "test-topic",
-		"subscription":     map[string]interface{}{"name": "test-sub"},
+		"subscription":     map[string]any{"name": "test-sub"},
 		"api_endpoint":     "custom-endpoint.googleapis.com:443",
-		"credentials_file": filepath.Clean("testdata/fake.json"),
+		"credentials_file": "testdata/fake.json",
 	})
 	assert.NoError(t, err, "failed to create config from map")
 

--- a/x-pack/filebeat/input/gcppubsub/input.go
+++ b/x-pack/filebeat/input/gcppubsub/input.go
@@ -362,7 +362,10 @@ func (in *pubsubInput) newPubsubClient(ctx context.Context) (*pubsub.Client, err
 	}
 
 	if in.APIEndpoint != "" {
+		in.log.Infof("Configuring GCP Pub/Sub client with custom API endpoint: %s", in.APIEndpoint)
 		opts = append(opts, option.WithEndpoint(in.APIEndpoint))
+	} else {
+		in.log.Info("Configuring GCP Pub/Sub client with default Google Cloud API endpoint")
 	}
 
 	if in.CredentialsFile != "" {

--- a/x-pack/filebeat/input/gcppubsub/input.go
+++ b/x-pack/filebeat/input/gcppubsub/input.go
@@ -361,6 +361,10 @@ func (in *pubsubInput) newPubsubClient(ctx context.Context) (*pubsub.Client, err
 		opts = append(opts, option.WithGRPCConn(conn), option.WithTelemetryDisabled())
 	}
 
+	if in.APIEndpoint != "" {
+		opts = append(opts, option.WithEndpoint(in.APIEndpoint))
+	}
+
 	if in.CredentialsFile != "" {
 		opts = append(opts, option.WithCredentialsFile(in.CredentialsFile))
 	} else if len(in.CredentialsJSON) > 0 {

--- a/x-pack/filebeat/input/gcppubsub/pubsub_test.go
+++ b/x-pack/filebeat/input/gcppubsub/pubsub_test.go
@@ -8,6 +8,7 @@ package gcppubsub
 
 import (
 	"context"
+	"os"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -312,6 +313,47 @@ func TestEndToEndACK(t *testing.T) {
 
 		input.Stop()
 		out.Close()
+		if err := group.Wait(); err != nil {
+			t.Fatal(err)
+		}
+	})
+}
+
+func TestAPIEndpointOverride(t *testing.T) {
+	cfg := defaultTestConfig()
+	err := cfg.SetString("api_endpoint", -1, "invalid-custom-endpoint.example.com:443")
+	assert.NoError(t, err, "failed to set api_endpoint configuration")
+
+	runTest(t, cfg, func(client *pubsub.Client, input *pubsubInput, out *stubOutleter, t *testing.T) {
+		err := input.run()
+		assert.Error(t, err, "expected input.run() to fail when using an unreachable custom API endpoint")
+	})
+}
+
+func TestAPIEndpointOverrideSuccess(t *testing.T) {
+	cfg := defaultTestConfig()
+	host := os.Getenv("PUBSUB_EMULATOR_HOST")
+	if host == "" {
+		host = "localhost:8432"
+	}
+	err := cfg.SetString("api_endpoint", -1, host)
+	assert.NoError(t, err, "failed to set api_endpoint configuration")
+
+	runTest(t, cfg, func(client *pubsub.Client, input *pubsubInput, out *stubOutleter, t *testing.T) {
+		testutil.CreateTopic(t, client)
+		testutil.CreateSubscription(t, emulatorSubscription, client)
+		testutil.PublishMessages(t, client, 5)
+
+		var group errgroup.Group
+		group.Go(input.run)
+
+		time.AfterFunc(10*time.Second, func() { out.Close() })
+		events, ok := out.waitForEvents(5)
+		if !ok {
+			t.Fatalf("Expected 5 events, but got %d.", len(events))
+		}
+		input.Stop()
+
 		if err := group.Wait(); err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Enhancement
-->

## Proposed commit message
[gcp-pubsub] Add api_endpoint configuration option to support custom endpoints

WHAT:
- Added an optional `api_endpoint` configuration field to the GCP Pub/Sub input (`x-pack/filebeat/input/gcppubsub/config.go`).
- Configured the Google Cloud Pub/Sub client constructor (`x-pack/filebeat/input/gcppubsub/input.go`) to apply `option.WithEndpoint(in.APIEndpoint)` when `api_endpoint` is specified.
- Added info log statements indicating whether a custom or default API endpoint is in use.
- Updated documentation and reference configurations in `x-pack/filebeat/filebeat.reference.yml` and `x-pack/filebeat/_meta/config/filebeat.inputs.reference.xpack.yml.tmpl`.
- Added unit test `TestConfigAPIEndpoint` and integration tests `TestAPIEndpointOverride` / `TestAPIEndpointOverrideSuccess` in `x-pack/filebeat/input/gcppubsub/`.
- Created changelog fragment `changelog/fragments/1778600000-gcppubsub-api-endpoint.yaml`.

WHY:
Enables users to override the default Google Cloud Pub/Sub endpoint (`pubsub.googleapis.com:443`). This is required for connecting through custom enterprise endpoints, Google Cloud Private Service Connect (PSC), custom Universe Domains (such as isolated cloud regions or testing environments), or reverse proxies where direct public internet egress to default endpoints is prohibited.


<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->
None. The api_endpoint setting is optional and defaults to empty. When omitted, Filebeat preserves existing behavior by utilizing the default Google Cloud Pub/Sub API endpoint.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

1. Run Unit Tests
Run the configuration validation tests:
`go test -v -run TestConfigAPIEndpoint ./x-pack/filebeat/input/gcppubsub/...`

2. Run Integration Tests (Emulator)
Start the Pub/Sub emulator and run the integration test suite:
`cd x-pack/filebeat/input/gcppubsub/_meta
docker compose up -d
export PUBSUB_EMULATOR_HOST=localhost:8432
go test -v -run 'TestAPIEndpointOverride.*' ./x-pack/filebeat/input/gcppubsub/...
docker compose down
`

3. Manual Verification with Filebeat
Add the option to your filebeat.yml:
`filebeat.inputs:
- type: gcp-pubsub
  project_id: "my-project"
  topic: "my-topic"
  subscription.name: "my-subscription"
  api_endpoint: "custom-pubsub-endpoint.googleapis.com:443"
  credentials_file: "${path.config}/credentials.json"
`

Launch Filebeat and verify the log output:
`Configuring GCP Pub/Sub client with custom API endpoint: custom-pubsub-endpoint.googleapis.com:443
`

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #48923 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

1. Private Service Connect (PSC) / VPC Service Controls: Organizations that route Google Cloud Pub/Sub traffic over dedicated internal IP endpoints or private endpoints rather than over public internet gateways.
2. Custom Universe Domains / Government Clouds: Deployments in custom Google Cloud Universe domains or isolated regions that expose service endpoints outside standard .googleapis.com.
3. Enterprise Proxies & Gateways: Environments routing outbound telemetry traffic through local API gateways or reverse proxies.

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->
<img width="1110" height="124" alt="Screenshot 2026-09-03 at 10 50 16 AM" src="https://github.com/user-attachments/assets/55e8341f-8ab2-4c3e-9009-1652273a3284" />

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
{"log.level":"info","@timestamp":"2026-09-03T...","log.logger":"gcp.pubsub","log.origin":{"file.name":"gcppubsub/input.go","file.line":365},"message":"Configuring GCP Pub/Sub client with custom API endpoint: custom-pubsub-endpoint.googleapis.com:443",...}
