### PR TITLE
Fix CockroachDB status endpoint health check

### DIFF
--- a/x-pack/metricbeat/module/cockroachdb/_meta/Dockerfile
+++ b/x-pack/metricbeat/module/cockroachdb/_meta/Dockerfile
@@ -1,6 +1,6 @@
 ARG COCKROACHDB_VERSION
 FROM cockroachdb/cockroach:v${COCKROACHDB_VERSION}
 
-HEALTHCHECK --interval=1s --retries=90 CMD curl -q http://localhost:8080/_status/vars
+HEALTHCHECK --interval=1s --retries=90 CMD curl --fail -q http://localhost:8080/_status/vars
 
 CMD ["start-single-node", "--insecure"]


### PR DESCRIPTION
## Proposed commit message

```
Make curl fail on HTTP errors so integration tests wait for /_status/vars readiness.

Assisted-by: Cursor, Model: GPT-5.6 Terra (Agent Mode)
```

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.~~
- [ ] ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).~~

~~## Disruptive User Impact~~

## How to test this PR locally

```
go test -count=1 -tags=integration -run=TestFetch  ./x-pack/metricbeat/module/cockroachdb/...
```

## Related issues

- Closes https://github.com/elastic/beats/issues/50539

~~## Use cases~~
~~## Screenshots~~
~~## Logs~~
