### PR TITLE
packetbeat/protos/tls: fix rendering of TLS certificate serial numbers

### DIFF
--- a/changelog/fragments/1788474519-52995-packetbeat-tls.yaml
+++ b/changelog/fragments/1788474519-52995-packetbeat-tls.yaml
@@ -1,0 +1,3 @@
+kind: bug-fix
+summary: Fix rendering of TLS serial numbers to match OpenSSL byte-for-byte output.
+component: packetbeat

--- a/changelog/fragments/1788474519-52995-packetbeat-tls.yaml
+++ b/changelog/fragments/1788474519-52995-packetbeat-tls.yaml
@@ -1,3 +1,3 @@
 kind: bug-fix
-summary: Fix rendering of TLS serial numbers to match OpenSSL byte-for-byte output.
+summary: Fix rendering of TLS certificate serial numbers so each byte is always represented as two hex digits, matching OpenSSL output.
 component: packetbeat

--- a/packetbeat/protos/tls/parse.go
+++ b/packetbeat/protos/tls/parse.go
@@ -23,6 +23,7 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/asn1"
 	"encoding/hex"
 	"fmt"
 	"strings"
@@ -636,10 +637,17 @@ func getKeySize(key any) int {
 
 // certToMap takes an x509 cert and converts it into a map.
 func certToMap(cert *x509.Certificate) mapstr.M {
+	serial, err := rawSerialBytes(cert.Raw)
+	if err != nil {
+		// Best effort to get the serial. If the DER parsing
+		// fails, try to get as much as we can from the cert
+		// directly.
+		serial = cert.SerialNumber.Bytes()
+	}
 	certMap := mapstr.M{
 		"signature_algorithm":  cert.SignatureAlgorithm.String(),
 		"public_key_algorithm": toString(cert.PublicKeyAlgorithm),
-		"serial_number":        strings.ToUpper(cert.SerialNumber.Text(16)),
+		"serial_number":        strings.ToUpper(hex.EncodeToString(serial)),
 		"issuer":               toMap(&cert.Issuer),
 		"subject":              toMap(&cert.Subject),
 		"not_before":           cert.NotBefore,
@@ -658,6 +666,29 @@ func certToMap(cert *x509.Certificate) mapstr.M {
 		certMap["alternative_names"] = san
 	}
 	return certMap
+}
+
+// rawSerialBytes returns the content octets of the serialNumber INTEGER from
+// the certificate's DER encoding. This matches the byte-for-byte representation
+// used by OpenSSL's i2a_ASN1_INTEGER (crypto/asn1/f_int.c), preserving any
+// leading zero bytes and the sign byte that big.Int.Bytes discards.
+func rawSerialBytes(certDER []byte) ([]byte, error) {
+	var cert struct {
+		TBSCert asn1.RawValue
+	}
+	_, err := asn1.Unmarshal(certDER, &cert)
+	if err != nil {
+		return nil, err
+	}
+	var tbs struct {
+		Version asn1.RawValue `asn1:"optional,explicit,tag:0"`
+		Serial  asn1.RawValue
+	}
+	_, err = asn1.Unmarshal(cert.TBSCert.FullBytes, &tbs)
+	if err != nil {
+		return nil, err
+	}
+	return tbs.Serial.Bytes, nil
 }
 
 func toMap(name *pkix.Name) mapstr.M {

--- a/packetbeat/protos/tls/parse.go
+++ b/packetbeat/protos/tls/parse.go
@@ -23,9 +23,9 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"crypto/x509/pkix"
-	"encoding/asn1"
 	"encoding/hex"
 	"fmt"
+	"math/big"
 	"strings"
 
 	"github.com/elastic/beats/v7/libbeat/common/streambuf"
@@ -637,17 +637,10 @@ func getKeySize(key any) int {
 
 // certToMap takes an x509 cert and converts it into a map.
 func certToMap(cert *x509.Certificate) mapstr.M {
-	serial, err := rawSerialBytes(cert.Raw)
-	if err != nil {
-		// Best effort to get the serial. If the DER parsing
-		// fails, try to get as much as we can from the cert
-		// directly.
-		serial = cert.SerialNumber.Bytes()
-	}
 	certMap := mapstr.M{
 		"signature_algorithm":  cert.SignatureAlgorithm.String(),
 		"public_key_algorithm": toString(cert.PublicKeyAlgorithm),
-		"serial_number":        strings.ToUpper(hex.EncodeToString(serial)),
+		"serial_number":        serialHex(cert.SerialNumber),
 		"issuer":               toMap(&cert.Issuer),
 		"subject":              toMap(&cert.Subject),
 		"not_before":           cert.NotBefore,
@@ -668,27 +661,20 @@ func certToMap(cert *x509.Certificate) mapstr.M {
 	return certMap
 }
 
-// rawSerialBytes returns the content octets of the serialNumber INTEGER from
-// the certificate's DER encoding. This matches the byte-for-byte representation
-// used by OpenSSL's i2a_ASN1_INTEGER (crypto/asn1/f_int.c), preserving any
-// leading zero bytes and the sign byte that big.Int.Bytes discards.
-func rawSerialBytes(certDER []byte) ([]byte, error) {
-	var cert struct {
-		TBSCert asn1.RawValue
+// serialHex returns the certificate serial number as an uppercase hex string
+// with each byte zero-padded to two digits, matching OpenSSL's output format.
+// Zero serials render as "00"; negative serials (only reachable when
+// GODEBUG=x509negativeserial=1 is set) are prefixed with "-".
+func serialHex(n *big.Int) string {
+	b := n.Bytes()
+	if len(b) == 0 {
+		return "00"
 	}
-	_, err := asn1.Unmarshal(certDER, &cert)
-	if err != nil {
-		return nil, err
+	s := strings.ToUpper(hex.EncodeToString(b))
+	if n.Sign() < 0 {
+		return "-" + s
 	}
-	var tbs struct {
-		Version asn1.RawValue `asn1:"optional,explicit,tag:0"`
-		Serial  asn1.RawValue
-	}
-	_, err = asn1.Unmarshal(cert.TBSCert.FullBytes, &tbs)
-	if err != nil {
-		return nil, err
-	}
-	return tbs.Serial.Bytes, nil
+	return s
 }
 
 func toMap(name *pkix.Name) mapstr.M {

--- a/packetbeat/protos/tls/parse_test.go
+++ b/packetbeat/protos/tls/parse_test.go
@@ -290,7 +290,7 @@ func TestCertificates(t *testing.T) {
 		"not_before":                  "2015-11-03 00:00:00 +0000 UTC",
 		"public_key_algorithm":        "RSA",
 		"public_key_size":             "2048",
-		"serial_number":               "E64C5FBC236ADE14B172AEB41C78CB0",
+		"serial_number":               "0E64C5FBC236ADE14B172AEB41C78CB0",
 		"signature_algorithm":         "SHA256-RSA",
 		"issuer.common_name":          "DigiCert SHA2 High Assurance Server CA",
 		"issuer.country":              "US",

--- a/packetbeat/protos/tls/parse_test.go
+++ b/packetbeat/protos/tls/parse_test.go
@@ -22,6 +22,7 @@ package tls
 import (
 	"encoding/hex"
 	"fmt"
+	"math/big"
 	"strconv"
 	"testing"
 	"time"
@@ -512,5 +513,29 @@ func TestBadCertMessage(t *testing.T) {
 		log := fmt.Sprintf("Message %d : '%s'", idx, msg)
 		assert.Equal(t, resultOK, parser.parse(sBuf(t, msg)), log)
 		assert.Nil(t, parser.certificates, log)
+	}
+}
+
+func TestSerialHex(t *testing.T) {
+	tests := []struct {
+		serial *big.Int
+		want   string
+	}{
+		{serial: new(big.Int), want: "00"},
+		{serial: big.NewInt(1), want: "01"},
+		{serial: new(big.Int).SetBytes([]byte{0x7f}), want: "7F"},
+		// MSB set: must not acquire a spurious leading 00 byte.
+		{serial: new(big.Int).SetBytes([]byte{0x80}), want: "80"},
+		{serial: new(big.Int).SetBytes([]byte{0xff, 0x00}), want: "FF00"},
+		// Leading zero nibble: the original reported bug.
+		{serial: new(big.Int).SetBytes([]byte{0x0e, 0x64, 0xc5, 0xfb, 0xc2, 0x36, 0xad, 0xe1, 0x4b, 0x17, 0x2a, 0xeb, 0x41, 0xc7, 0x8c, 0xb0}), want: "0E64C5FBC236ADE14B172AEB41C78CB0"},
+		// Negative serial (only reachable with GODEBUG=x509negativeserial=1).
+		{serial: big.NewInt(-1), want: "-01"},
+	}
+	for _, test := range tests {
+		got := serialHex(test.serial)
+		if got != test.want {
+			t.Errorf("serialHex(%v) = %q; want %q", test.serial, got, test.want)
+		}
 	}
 }

--- a/packetbeat/tests/system/golden/established_tls-expected.json
+++ b/packetbeat/tests/system/golden/established_tls-expected.json
@@ -127,7 +127,7 @@
                 "not_before": "2013-03-08T12:00:00.000Z",
                 "public_key_algorithm": "RSA",
                 "public_key_size": 2048,
-                "serial_number": "1FDA3EB6ECA75C888438B724BCFBC91",
+                "serial_number": "01FDA3EB6ECA75C888438B724BCFBC91",
                 "signature_algorithm": "SHA256-RSA",
                 "subject": {
                     "common_name": "DigiCert SHA2 Secure Server CA",
@@ -149,7 +149,7 @@
                 "not_before": "2006-11-10T00:00:00.000Z",
                 "public_key_algorithm": "RSA",
                 "public_key_size": 2048,
-                "serial_number": "83BE056904246B1A1756AC95991C74A",
+                "serial_number": "083BE056904246B1A1756AC95991C74A",
                 "signature_algorithm": "SHA1-RSA",
                 "subject": {
                     "common_name": "DigiCert Global Root CA",
@@ -205,7 +205,7 @@
         "tls.server.x509.not_before": "2018-11-28T00:00:00.000Z",
         "tls.server.x509.public_key_algorithm": "RSA",
         "tls.server.x509.public_key_size": 2048,
-        "tls.server.x509.serial_number": "FD078DD48F1A2BD4D0F2BA96B6038FE",
+        "tls.server.x509.serial_number": "0FD078DD48F1A2BD4D0F2BA96B6038FE",
         "tls.server.x509.signature_algorithm": "SHA256-RSA",
         "tls.server.x509.subject.common_name": "www.example.org",
         "tls.server.x509.subject.country": "US",

--- a/packetbeat/tests/system/golden/tls_all_options-expected.json
+++ b/packetbeat/tests/system/golden/tls_all_options-expected.json
@@ -127,7 +127,7 @@
                 "not_before": "2013-03-08T12:00:00.000Z",
                 "public_key_algorithm": "RSA",
                 "public_key_size": 2048,
-                "serial_number": "1FDA3EB6ECA75C888438B724BCFBC91",
+                "serial_number": "01FDA3EB6ECA75C888438B724BCFBC91",
                 "signature_algorithm": "SHA256-RSA",
                 "subject": {
                     "common_name": "DigiCert SHA2 Secure Server CA",
@@ -149,7 +149,7 @@
                 "not_before": "2006-11-10T00:00:00.000Z",
                 "public_key_algorithm": "RSA",
                 "public_key_size": 2048,
-                "serial_number": "83BE056904246B1A1756AC95991C74A",
+                "serial_number": "083BE056904246B1A1756AC95991C74A",
                 "signature_algorithm": "SHA1-RSA",
                 "subject": {
                     "common_name": "DigiCert Global Root CA",
@@ -212,7 +212,7 @@
         "tls.server.x509.not_before": "2018-11-28T00:00:00.000Z",
         "tls.server.x509.public_key_algorithm": "RSA",
         "tls.server.x509.public_key_size": 2048,
-        "tls.server.x509.serial_number": "FD078DD48F1A2BD4D0F2BA96B6038FE",
+        "tls.server.x509.serial_number": "0FD078DD48F1A2BD4D0F2BA96B6038FE",
         "tls.server.x509.signature_algorithm": "SHA256-RSA",
         "tls.server.x509.subject.common_name": "www.example.org",
         "tls.server.x509.subject.country": "US",


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message
```
packetbeat/protos/tls: fix rendering of TLS certificate serial numbers

Use big.Int.Bytes to format the serial number so that each byte is
always represented as two hex digits. big.Int.Text(16) drops leading
zero nibbles (affecting ~1/16 certificates); big.Int.Bytes fixes this
because it works at the byte level.

The zero and negative cases are handled explicitly: zero renders as
"00" and negative serials (only reachable when
GODEBUG=x509negativeserial=1 is set since Go 1.23) are prefixed with
"-". Both match OpenSSL's output for those cases.
```
<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Fixes #52995

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
