### PR TITLE
[8.19] Document Azure credential controls for add_cloud_metadata

### DIFF
--- a/libbeat/processors/add_cloud_metadata/docs/add_cloud_metadata.asciidoc
+++ b/libbeat/processors/add_cloud_metadata/docs/add_cloud_metadata.asciidoc
@@ -71,11 +71,6 @@ List of names the `providers` setting supports:
 
 - "alibaba", or "ecs" for the Alibaba Cloud provider (disabled by default).
 - "azure" for Azure Virtual Machine (enabled by default).
-   If the virtual machine is part of an AKS managed cluster, the fields
-   `orchestrator.cluster.name` and `orchestrator.cluster.id` can also be
-   retrieved. "TENANT_ID", "CLIENT_ID" and "CLIENT_SECRET" environment
-   variables need to be set for authentication purposes. If not set we
-   fallback to https://learn.microsoft.com/en-us/azure/developer/go/azure-sdk-authentication?tabs=bash#2-authenticate-with-azure[DefaultAzureCredential] and user can choose different authentication methods (e.g. workload identity).
 - "digitalocean" for Digital Ocean (enabled by default).
 - "aws", or "ec2" for Amazon Web Services (enabled by default).
 - "gcp" for Google Copmute Enging (enabled by default).
@@ -83,6 +78,38 @@ List of names the `providers` setting supports:
 - "openstack-ssl", or "nova-ssl" for Openstack Nova when SSL metadata APIs are enabled (enabled by default).
 - "tencent", or "qcloud" for Tencent Cloud (disabled by default).
 - "hetzner" for Hetzner Cloud (enabled by default).
+
+[float]
+==== Azure Resource Manager authentication
+
+After Azure VM metadata is detected, `add_cloud_metadata` automatically makes a
+best-effort Azure Resource Manager (ARM) lookup for the optional
+`orchestrator.cluster.name` and `orchestrator.cluster.id` fields. This lookup is
+attempted on every Azure VM, including VMs that are not part of an AKS cluster.
+Failure to retrieve the optional AKS fields does not prevent the processor from
+adding the Azure VM metadata.
+
+When all three `TENANT_ID`, `CLIENT_ID`, and `CLIENT_SECRET` environment
+variables are set, the processor authenticates the ARM lookup explicitly with
+those service principal credentials. Otherwise it uses
+https://learn.microsoft.com/en-us/azure/developer/go/sdk/authentication/credential-chains[DefaultAzureCredential],
+which tries a chain of credentials. On Windows, development-focused credentials
+in that chain can invoke child tools. Starting in Beats 8.19.8,
+`AzurePowerShellCredential` is included in the chain and invokes PowerShell with
+an encoded command.
+
+Starting in Beats 8.19.3, set `AZURE_TOKEN_CREDENTIALS=prod` to exclude
+development-focused credential providers while retaining
+`EnvironmentCredential`, `WorkloadIdentityCredential`, and
+`ManagedIdentityCredential`. This environment variable has process-wide scope
+and affects every `DefaultAzureCredential` instance in the Beat process, not
+only `add_cloud_metadata`. Restart the Beat after changing environment
+variables. For an Elastic Agent running as a Windows service, follow the
+https://www.elastic.co/docs/reference/fleet/host-proxy-env-vars#where-to-set-proxy-env-vars[Windows service environment procedure].
+
+Setting `AZURE_TOKEN_CREDENTIALS=prod` does not disable the ARM lookup. To
+disable the lookup, exclude `azure` from `providers`; doing so also disables all
+Azure VM metadata enrichment.
 
 For example, configuration below only utilize `aws` metadata retrival mechanism,
 


### PR DESCRIPTION
## Proposed commit message

Document the Azure authentication behavior of `add_cloud_metadata` for Beats 8.19. The processor performs a best-effort AKS metadata lookup after detecting an Azure VM. Explain that `AZURE_TOKEN_CREDENTIALS=prod` is supported from 8.19.3 and that `AzurePowerShellCredential` enters the default chain in 8.19.8.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files — not applicable, documentation-only change
- [x] I have added tests that prove my fix is effective or that my feature works — not applicable, documentation-only change
- [x] I have added an entry in `./changelog/fragments` — not applicable; `skip-changelog` requested

## Disruptive User Impact

None. This documents existing behavior and supported Azure SDK configuration.

## How to test this PR locally

- Run `git diff --check origin/8.19...HEAD`.
- Verify azidentity is v1.10.1 in Beats 8.19.3 and v1.13.1 in Beats 8.19.8.

## Related issues

- Relates to https://github.com/elastic/sdh-beats/issues/7522

## Use cases

Production users running Elastic Agent or Beats on Azure Windows VMs can identify the affected 8.19 patch versions and prevent `DefaultAzureCredential` from trying development-focused credentials.

## Screenshots

Not applicable.

## Logs

Not applicable.

Made with [Cursor](https://cursor.com)