### PR TITLE
[docs] Remove UBI9 revert entry from release notes for 9.4.6

### DIFF
--- a/changelog/9.4.6.yaml
+++ b/changelog/9.4.6.yaml
@@ -205,16 +205,3 @@ entries:
       file:
         name: 1787267404-fix-httpjson-cel-cursor-migration-set-id.yaml
         checksum: 219c6f11bc18db2d081b367da6222fa70d9ae46d
-    - kind: bug-fix
-      summary: Revert non-Ironbank container images to UBI9.
-      description: ""
-      component: all
-      pr:
-        - https://github.com/elastic/beats/pull/52823
-      issue: []
-      impact: ""
-      action: ""
-      timestamp: 1787598969
-      file:
-        name: 1787598969-revert-non-ironbank-container-images-to-ubi9.yaml
-        checksum: 1b0e1c935a59e1ea06727e2264e452f7921c2c61

--- a/docs/release-notes/_snippets/9.4.6/index.md
+++ b/docs/release-notes/_snippets/9.4.6/index.md
@@ -17,7 +17,6 @@
 
 * Add support for index in inputs for Beat receivers. [#52662](https://github.com/elastic/beats/pull/52662) 
 * Correct disk queue metrics after blocked publishes. [#52666](https://github.com/elastic/beats/pull/52666) 
-* Revert non-Ironbank container images to UBI9. [#52823](https://github.com/elastic/beats/pull/52823) 
 
 **Auditbeat**
 


### PR DESCRIPTION
The changelog for https://github.com/elastic/beats/pull/52823 was included in 9.4.6, but it won't be available until 9.4.7.

Resolves https://github.com/elastic/beats/issues/53014#issuecomment-5530687525