### PR TITLE
feat(autoops_es): collect allowlisted node attributes in node_stats

### DIFF
--- a/changelog/fragments/1788703667-autoops-es-node-attributes.yaml
+++ b/changelog/fragments/1788703667-autoops-es-node-attributes.yaml
@@ -1,0 +1,3 @@
+kind: enhancement
+summary: Collect logical_availability_zone and instance_configuration node attributes in the autoops_es node_stats metricset
+component: metricbeat

--- a/x-pack/metricbeat/module/autoops_es/node_stats/_meta/test/nodes_stats.8.15.3.json
+++ b/x-pack/metricbeat/module/autoops_es/node_stats/_meta/test/nodes_stats.8.15.3.json
@@ -904,6 +904,9 @@
             "host": "172.22.233.43",
             "ip": "172.22.233.43:19261",
             "roles": ["master", "remote_cluster_client"],
+            "attributes": {
+                "logical_availability_zone": "zone-2"
+            },
             "indices": {
                 "docs": {
                     "count": 0,
@@ -1359,6 +1362,10 @@
                 "remote_cluster_client",
                 "transform"
             ],
+            "attributes": {
+                "logical_availability_zone": "zone-0",
+                "instance_configuration": "aws.es.datahot.i3"
+            },
             "indices": {
                 "docs": {
                     "count": 3836668558,

--- a/x-pack/metricbeat/module/autoops_es/node_stats/_meta/test/nodes_stats.9.2.0.json
+++ b/x-pack/metricbeat/module/autoops_es/node_stats/_meta/test/nodes_stats.9.2.0.json
@@ -13,6 +13,10 @@
                 "remote_cluster_client",
                 "transform"
             ],
+            "attributes": {
+                "logical_availability_zone": "zone-1",
+                "instance_configuration": "gcp.es.datahot.n2.68x10x45"
+            },
             "indices": {
                 "docs": {
                     "count": 2902603,

--- a/x-pack/metricbeat/module/autoops_es/node_stats/data.go
+++ b/x-pack/metricbeat/module/autoops_es/node_stats/data.go
@@ -32,6 +32,12 @@ var (
 		"roles": c.Ifc("roles", s.Optional),
 		"host":  c.Str("host", s.Required),
 		"ip":    c.Str("ip", s.IgnoreAllErrors),
+		// Only the attributes explicitly requested by the filter_path are mapped; the
+		// node `attributes` map is operator-defined and otherwise unbounded.
+		"attributes": c.Dict("attributes", s.Schema{
+			"logical_availability_zone": c.Str("logical_availability_zone", s.IgnoreAllErrors),
+			"instance_configuration":    c.Str("instance_configuration", s.IgnoreAllErrors),
+		}, c.DictOptional),
 		"indices": c.Dict("indices", s.Schema{
 			"docs": c.Dict("docs", s.Schema{
 				"count": c.Int("count", s.IgnoreAllErrors),

--- a/x-pack/metricbeat/module/autoops_es/node_stats/data_test.go
+++ b/x-pack/metricbeat/module/autoops_es/node_stats/data_test.go
@@ -87,6 +87,9 @@ func expectValidParsedDetailed(t *testing.T, data metricset.FetcherData[NodesSta
 		require.EqualValues(t, 1777, auto_ops_testing.GetObjectValue(node1MetricSet, "thread_pool.write.completed"))
 		require.EqualValues(t, 1, auto_ops_testing.GetObjectValue(node1MetricSet, "thread_pool.snapshot.threads"))
 		require.EqualValues(t, 397269, auto_ops_testing.GetObjectValue(node1MetricSet, "thread_pool.snapshot.completed"))
+
+		// no node in this fixture advertises the allowlisted attributes
+		require.Nil(t, auto_ops_testing.GetObjectValue(node1MetricSet, "attributes"))
 	} else if data.Version == "8.15.3" {
 		require.Equal(t, 59, len(nodeStatsEvents))
 		require.EqualValues(t, 59, nodeStatsEvents[0].ModuleFields["total_amount_of_fractions"])
@@ -112,6 +115,19 @@ func expectValidParsedDetailed(t *testing.T, data metricset.FetcherData[NodesSta
 		require.EqualValues(t, 24175874622, auto_ops_testing.GetObjectValue(node1MetricSet, "thread_pool.write.completed"))
 		require.EqualValues(t, 1, auto_ops_testing.GetObjectValue(node1MetricSet, "thread_pool.snapshot.threads"))
 		require.EqualValues(t, 383009, auto_ops_testing.GetObjectValue(node1MetricSet, "thread_pool.snapshot.completed"))
+
+		// both allowlisted attributes present
+		require.Equal(t, "zone-0", auto_ops_testing.GetObjectValue(node1MetricSet, "attributes.logical_availability_zone"))
+		require.Equal(t, "aws.es.datahot.i3", auto_ops_testing.GetObjectValue(node1MetricSet, "attributes.instance_configuration"))
+
+		// only one of the two present: the missing one must not fail the node
+		node105MetricSet := nodeStatsEvents[slices.IndexFunc(nodeStatsEvents, func(event mb.Event) bool { return event.MetricSetFields["name"] == "instance-0000000105" })].MetricSetFields
+		require.Equal(t, "zone-2", auto_ops_testing.GetObjectValue(node105MetricSet, "attributes.logical_availability_zone"))
+		require.Nil(t, auto_ops_testing.GetObjectValue(node105MetricSet, "attributes.instance_configuration"))
+
+		// neither present: no empty attributes object is emitted
+		node107MetricSet := nodeStatsEvents[slices.IndexFunc(nodeStatsEvents, func(event mb.Event) bool { return event.MetricSetFields["name"] == "instance-0000000107" })].MetricSetFields
+		require.Nil(t, auto_ops_testing.GetObjectValue(node107MetricSet, "attributes"))
 	} else if data.Version == "9.2.0" {
 		require.Equal(t, 1, len(nodeStatsEvents))
 		require.EqualValues(t, 1, nodeStatsEvents[0].ModuleFields["total_amount_of_fractions"])
@@ -125,6 +141,10 @@ func expectValidParsedDetailed(t *testing.T, data metricset.FetcherData[NodesSta
 		require.EqualValues(t, 646725, auto_ops_testing.GetObjectValue(node1MetricSet, "indices.bulk.total_operations"))
 		require.EqualValues(t, 2818360, auto_ops_testing.GetObjectValue(node1MetricSet, "indices.dense_vector.count"))
 		require.EqualValues(t, 4510292000, auto_ops_testing.GetObjectValue(node1MetricSet, "indices.dense_vector.off_heap.total_size_bytes"))
+
+		// both allowlisted attributes present
+		require.Equal(t, "zone-1", auto_ops_testing.GetObjectValue(node1MetricSet, "attributes.logical_availability_zone"))
+		require.Equal(t, "gcp.es.datahot.n2.68x10x45", auto_ops_testing.GetObjectValue(node1MetricSet, "attributes.instance_configuration"))
 	}
 
 	// some ignored values

--- a/x-pack/metricbeat/module/autoops_es/node_stats/node_stats.go
+++ b/x-pack/metricbeat/module/autoops_es/node_stats/node_stats.go
@@ -11,7 +11,7 @@ import (
 const (
 	ClusterStateMasterNodePath = "/_cluster/state/master_node?filter_path=master_node"
 	NodesStatsMetricSet        = "node_stats"
-	NodesStatsPath             = "/_nodes/stats/breaker,fs,http,indices,jvm,os,process,thread_pool,transport?filter_path=**.host,**.http.current_open,**.http.total_opened,**.transport.*_size_in_bytes,**.transport.*_count,**.fs,**.jvm,**.process,**.os,**.breaker,**.breakers,**.thread_pool.generic,**.thread_pool.get,**.thread_pool.management,**.thread_pool.search,**.thread_pool.watcher,**.thread_pool.write,**.thread_pool.snapshot,**.indices,**.name,**.ip,**.roles,**.transport_address"
+	NodesStatsPath             = "/_nodes/stats/breaker,fs,http,indices,jvm,os,process,thread_pool,transport?filter_path=**.host,**.http.current_open,**.http.total_opened,**.transport.*_size_in_bytes,**.transport.*_count,**.fs,**.jvm,**.process,**.os,**.breaker,**.breakers,**.thread_pool.generic,**.thread_pool.get,**.thread_pool.management,**.thread_pool.search,**.thread_pool.watcher,**.thread_pool.write,**.thread_pool.snapshot,**.indices,**.name,**.ip,**.roles,**.transport_address,**.attributes.logical_availability_zone,**.attributes.instance_configuration"
 )
 
 // init registers the MetricSet with the central registry as soon as the program


### PR DESCRIPTION
## Proposed commit message

Closes #52408

Adds `logical_availability_zone` and `instance_configuration` from the `_nodes/stats`
response to `autoops_es.node_stats` events.

**WHAT**

- `node_stats.go` — the two keys are added to the existing `filter_path` as an explicit
  allowlist (`**.attributes.logical_availability_zone,**.attributes.instance_configuration`),
  rather than requesting the whole `attributes` object.
- `data.go` — an optional `attributes` dict is mapped in the schema, nested to mirror the
  Elasticsearch response shape.
- Fixtures + `data_test.go` — coverage for a node with both attributes, a node with only
  one, and nodes with neither.

**WHY**

- *Allowlisting at the `filter_path`, not in the schema.* Node `attributes` is an
  operator-defined, unbounded map that also carries identifying values such as
  `server_name` and `region`. Fetching all of it on every poll of a large cluster just to
  discard most of it costs bandwidth and needlessly pulls customer-defined data into the
  collection path. Every other metricset in this module (`cluster_settings`,
  `index_template`, `tasks_management`) uses a tight `filter_path` for the same reason.
- *Nested rather than flattened.* The emitted shape mirrors `_nodes/stats` exactly, so the
  document needs no reshaping downstream. Flattening would be a transformation, just
  relocated into Beats.
- *Optional at every level.* `c.DictOptional` plus `s.IgnoreAllErrors` on both keys means a
  node advertising one attribute, or neither, is mapped without error — and no empty
  `attributes` object is emitted. Self-managed clusters simply won't have these fields.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments`

Note on documentation: `node_stats/_meta/fields.yml` is intentionally not updated. It
already omits the sibling node identity fields (`name`, `roles`, `host`, `ip`,
`is_elected_master`), and the most recent field addition to this metricset (#52226) did not
touch it either. Happy to add it if reviewers would prefer.

## Disruptive User Impact

None. Two optional fields are added to `node_stats` documents; nothing existing changes
shape or meaning. Clusters that do not advertise these attributes — self-managed
deployments in particular — emit documents identical to today's.

## How to test this PR locally

```
go test ./x-pack/metricbeat/module/autoops_es/node_stats/... -count=1
```

Fixture coverage:

| Fixture | Nodes | Case |
|---|---|---|
| `nodes_stats.7.17.0.json` | 1 | neither attribute present |
| `nodes_stats.8.15.3.json` | 59 | both present, only one present, neither present |
| `nodes_stats.9.2.0.json` | 1 | both present |

**One thing worth a reviewer's attention:** the `filter_path` change is not covered by the
unit tests — the test harness replays fixtures regardless of the request URL, so
`**.attributes.logical_availability_zone` is only verified as a string. I'd suggest
confirming it against a real Elastic Cloud cluster before merge:

```
GET /_nodes/stats/os?filter_path=**.name,**.attributes.logical_availability_zone,**.attributes.instance_configuration
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
