### PR TITLE
packetbeat: use management.UnderAgent() for OTel receiver config selection

### DIFF
--- a/changelog/fragments/1788729561-53010-packetbeat-otel-stream-config.yaml
+++ b/changelog/fragments/1788729561-53010-packetbeat-otel-stream-config.yaml
@@ -1,0 +1,4 @@
+kind: bug-fix
+summary: Fix per-stream interface, procs, and ignore_outgoing configuration being dropped when packetbeat runs as an OTel receiver
+component: packetbeat
+issue: https://github.com/elastic/beats/issues/53010

--- a/changelog/fragments/1788729562-53009-packetbeat-otel-npcap.yaml
+++ b/changelog/fragments/1788729562-53009-packetbeat-otel-npcap.yaml
@@ -1,0 +1,4 @@
+kind: bug-fix
+summary: Fix npcap.never_install policy opt-out being silently ignored when packetbeat runs as an OTel receiver
+component: packetbeat
+issue: https://github.com/elastic/beats/issues/53009

--- a/packetbeat/beater/install_npcap.go
+++ b/packetbeat/beater/install_npcap.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/beats/v7/libbeat/management"
 	"github.com/elastic/beats/v7/packetbeat/npcap"
 	conf "github.com/elastic/elastic-agent-libs/config"
 	"github.com/elastic/elastic-agent-libs/logp"
@@ -119,7 +120,7 @@ func canInstallNpcap(b *beat.Beat, rawcfg *conf.C, log *logp.Logger) (bool, erro
 	}
 
 	// Agent managed case.
-	if b.Manager.Enabled() {
+	if management.UnderAgent() {
 		var cfg struct {
 			Streams []npcapInstallCfg `config:"streams"`
 		}

--- a/packetbeat/beater/packetbeat.go
+++ b/packetbeat/beater/packetbeat.go
@@ -97,7 +97,7 @@ type packetbeat struct {
 // New returns a new Packetbeat beat.Beater.
 func New(b *beat.Beat, rawConfig *conf.C) (beat.Beater, error) {
 	configurator := config.NewAgentConfig
-	if !b.Manager.Enabled() {
+	if !management.UnderAgent() {
 		configurator = initialConfig().FromStatic
 	}
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message
```
packetbeat: use management.UnderAgent() for OTel receiver config selection

Under the OTel receiver runtime, OtelManager.Enabled() always returns
false, so packetbeat.go selected FromStatic as the config loader and
install_npcap.go took the standalone branch — both looking for top-level
keys that agent never emits. Switch both sites to management.UnderAgent(),
which NewOtelManager sets true unconditionally at construction.

Fixes per-stream interface, procs and ignore_outgoing being dropped
(#53010) and npcap.never_install policy opt-out being silently ignored
(#53009) when running as an OTel receiver.
```
<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Fixes #53009
- Fixes #53010

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
