### PR TITLE
libbeat/reader/auditd: capture raw audit records in coalesce mode

### DIFF
--- a/changelog/fragments/1788751959-filestream-auditd-raw-message.yaml
+++ b/changelog/fragments/1788751959-filestream-auditd-raw-message.yaml
@@ -1,0 +1,3 @@
+kind: bug-fix
+summary: Populate auditd.messages and message field in filestream auditd coalescing parser so preserve_original_event works.
+component: libbeat

--- a/libbeat/reader/auditd/coalesce.go
+++ b/libbeat/reader/auditd/coalesce.go
@@ -50,8 +50,9 @@ type coalescingParser struct {
 }
 
 type pendingEvent struct {
-	evt   *aucoalesce.Event
-	bytes int
+	evt     *aucoalesce.Event
+	bytes   int
+	rawMsgs []string // populated when cfg.IncludeRawMessage is true
 }
 
 var (
@@ -100,7 +101,15 @@ func (p *coalescingParser) ReassemblyComplete(msgs []*auparse.AuditMessage) {
 	if p.cfg.ResolveIDs {
 		aucoalesce.ResolveIDs(evt)
 	}
-	p.pending = append(p.pending, pendingEvent{evt: evt})
+	pe := pendingEvent{evt: evt}
+	if p.cfg.IncludeRawMessage {
+		rawMsgs := make([]string, 0, len(msgs))
+		for _, m := range msgs {
+			rawMsgs = append(rawMsgs, "type="+m.RecordType.String()+" msg="+m.RawData)
+		}
+		pe.rawMsgs = rawMsgs
+	}
+	p.pending = append(p.pending, pe)
 }
 
 // EventsLost implements libaudit.Stream. It is called when sequence gaps are
@@ -134,7 +143,7 @@ func (p *coalescingParser) Next() (reader.Message, error) {
 			pe := p.pending[0]
 			p.pending[0] = pendingEvent{} // allow GC
 			p.pending = p.pending[1:]
-			return p.eventToMessage(pe.evt, pe.bytes), nil
+			return p.eventToMessage(pe), nil
 		}
 
 		// Flush timed-out groups.
@@ -207,13 +216,14 @@ func (p *coalescingParser) distributeBytesRead() {
 	p.bytesRead = perGroup * inflight
 }
 
-// eventToMessage converts a coalesced aucoalesce.Event into a reader.Message
+// eventToMessage converts a coalesced pendingEvent into a reader.Message
 // with fields matching the auditd_manager integration's output namespace
 // (auditd.data.*, auditd.summary.*, etc.) plus ECS root fields.
-func (p *coalescingParser) eventToMessage(evt *aucoalesce.Event, bytes int) reader.Message {
+func (p *coalescingParser) eventToMessage(pe pendingEvent) reader.Message {
+	evt := pe.evt
 	msg := reader.Message{
 		Ts:    evt.Timestamp,
-		Bytes: bytes,
+		Bytes: pe.bytes,
 	}
 
 	auditdFields := mapstr.M{
@@ -244,6 +254,10 @@ func (p *coalescingParser) eventToMessage(evt *aucoalesce.Event, bytes int) read
 			warnings = append(warnings, w.Error())
 		}
 		auditdFields["warnings"] = warnings
+	}
+	if len(pe.rawMsgs) != 0 {
+		auditdFields["messages"] = pe.rawMsgs
+		msg.Content = []byte(strings.Join(pe.rawMsgs, "\n"))
 	}
 
 	addSummaryFields(auditdFields, evt)

--- a/libbeat/reader/auditd/coalesce_test.go
+++ b/libbeat/reader/auditd/coalesce_test.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"io"
 	"slices"
+	"strings"
 	"testing"
 	"time"
 
@@ -441,6 +442,69 @@ func TestCoalescingUserKeyMapping(t *testing.T) {
 	}
 	if _, err := msg.Fields.GetValue("auditd.user.names"); err == nil {
 		t.Error("auditd.user.names still present; want absent")
+	}
+}
+
+func TestCoalescingRawMessages(t *testing.T) {
+	lines := [][]byte{
+		[]byte(`type=SYSCALL msg=audit(1626700000.000:110): arch=c000003e syscall=59 success=yes exit=0 a0=1 a1=2 a2=3 a3=4 items=0 ppid=1 pid=110 auid=1000 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=pts0 ses=1 comm="id" exe="/usr/bin/id" key=(null)`),
+		[]byte(`type=EXECVE msg=audit(1626700000.000:110): argc=1 a0="id"`),
+		[]byte(`type=EOE msg=audit(1626700000.000:110):`),
+	}
+	cfg := coalesceConfig()
+	cfg.IncludeRawMessage = true
+	r := &testReader{messages: lines}
+	p := NewParser(r, cfg, logptest.NewTestingLogger(t, t.Name()))
+
+	msg, err := p.Next()
+	if err != nil {
+		t.Fatalf("Next() returned error: %v", err)
+	}
+
+	// auditd.messages must hold the two non-EOE records as "type=X msg=..." strings.
+	raw, err := msg.Fields.GetValue("auditd.messages")
+	if err != nil {
+		t.Fatalf("auditd.messages absent: %v", err)
+	}
+	rawSlice, ok := raw.([]string)
+	if !ok {
+		t.Fatalf("auditd.messages type = %T; want []string", raw)
+	}
+	if len(rawSlice) == 0 {
+		t.Fatal("auditd.messages is empty")
+	}
+	for _, s := range rawSlice {
+		if !strings.HasPrefix(s, "type=") {
+			t.Errorf("auditd.messages entry %q does not start with type=", s)
+		}
+	}
+
+	// msg.Content must be non-empty so the message field is set.
+	if len(msg.Content) == 0 {
+		t.Error("msg.Content is empty; want raw audit records joined with newline")
+	}
+}
+
+func TestCoalescingRawMessagesDisabled(t *testing.T) {
+	lines := [][]byte{
+		[]byte(`type=SYSCALL msg=audit(1626700000.000:111): arch=c000003e syscall=59 success=yes exit=0 a0=1 a1=2 a2=3 a3=4 items=0 ppid=1 pid=111 auid=1000 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=pts0 ses=1 comm="id" exe="/usr/bin/id" key=(null)`),
+		[]byte(`type=EOE msg=audit(1626700000.000:111):`),
+	}
+	cfg := coalesceConfig()
+	cfg.IncludeRawMessage = false
+	r := &testReader{messages: lines}
+	p := NewParser(r, cfg, logptest.NewTestingLogger(t, t.Name()))
+
+	msg, err := p.Next()
+	if err != nil {
+		t.Fatalf("Next() returned error: %v", err)
+	}
+
+	if _, err := msg.Fields.GetValue("auditd.messages"); err == nil {
+		t.Error("auditd.messages present; want absent when IncludeRawMessage=false")
+	}
+	if len(msg.Content) != 0 {
+		t.Errorf("msg.Content = %q; want empty when IncludeRawMessage=false", msg.Content)
 	}
 }
 

--- a/libbeat/reader/auditd/config.go
+++ b/libbeat/reader/auditd/config.go
@@ -56,6 +56,11 @@ type Config struct {
 	// Default is true. Set to false when reading forwarded logs from a
 	// different host, where the local name database does not apply.
 	ResolveIDs bool `config:"resolve_ids"`
+	// IncludeRawMessage, if true, captures the reassembled raw audit records as
+	// a list of "type=X msg=..." strings in auditd.messages, and sets the
+	// message field to their newline-joined form. Only meaningful in coalesce
+	// mode. Default is false, matching auditbeat's include_raw_message option.
+	IncludeRawMessage bool `config:"include_raw_message"`
 }
 
 // DefaultConfig returns a Config populated with default values. The default
@@ -64,9 +69,10 @@ type Config struct {
 // so its mere presence implies that parsing is desired.
 func DefaultConfig() Config {
 	return Config{
-		Mode:        ModeParse,
-		LogErrors:   false,
-		AddErrorKey: true,
-		ResolveIDs:  true,
+		Mode:              ModeParse,
+		LogErrors:         false,
+		AddErrorKey:       true,
+		ResolveIDs:        true,
+		IncludeRawMessage: false,
 	}
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message
```
libbeat/reader/auditd: capture raw audit records in coalesce mode

Add an include_raw_message config option (default false, matching
auditbeat's include_raw_message) that captures the reassembled raw
audit records as a list of "type=X msg=..." strings in auditd.messages
and sets msg.Content to their newline-joined form so the message field
is populated.

Without this, preserve_original_event had nothing to copy into
event.original, and the coalesced.yml ingest pipeline's join of
auditd.messages into event.original was a no-op.
```

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Fixes #53053

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
