### PR TITLE
x-pack/filebeat/input/etw: Report health status to Elastic Agent

### DIFF
--- a/changelog/fragments/1788782541-etw-input-status-reporting.yaml
+++ b/changelog/fragments/1788782541-etw-input-status-reporting.yaml
@@ -1,0 +1,51 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: enhancement
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: Report health status from the ETW input when running under Elastic Agent.
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+description: |
+  The ETW input now reports Starting, Configuring, Running, Degraded and Failed
+  states to Elastic Agent. Failure messages include the session name, the
+  configured provider and the raw Windows error code, and access-denied errors
+  spell out the privileges ETW sessions need. The input reports Degraded after
+  `failure_threshold` consecutive unreadable events (default 10) and recovers
+  after the same number of consecutive good events; set it to 0 to disable.
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: filebeat
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: https://github.com/elastic/beats/issues/44271

--- a/changelog/fragments/1788782541-etw-input-status-reporting.yaml
+++ b/changelog/fragments/1788782541-etw-input-status-reporting.yaml
@@ -23,8 +23,9 @@ description: |
   states to Elastic Agent. Failure messages include the session name, the
   configured provider and the raw Windows error code, and access-denied errors
   spell out the privileges ETW sessions need. The input reports Degraded after
-  `failure_threshold` consecutive unreadable events (default 10) and recovers
-  after the same number of consecutive good events; set it to 0 to disable.
+  `failure_threshold` consecutive unreadable events (default 3) and recovers
+  after `recovery_threshold` consecutive good events (default 1). Set
+  `failure_threshold` to 0 to disable Degraded reporting for unreadable events.
 
 # REQUIRED for breaking-change, deprecation, known-issue
 # impact:

--- a/docs/reference/filebeat/filebeat-input-etw.md
+++ b/docs/reference/filebeat/filebeat-input-etw.md
@@ -247,9 +247,7 @@ filebeat.inputs:
 stack: ga 9.4.7+
 ```
 
-Available in 9.4.7 and later, 9.5.4 and later, and 9.6.0 and later.
-
-Controls when the input reports itself as degraded to {{agent}} because of events it cannot read. After this many consecutive events fail to be read, the input reports a `DEGRADED` status. It returns to `HEALTHY` only after the same number of consecutive events are read successfully, so short bursts of bad events do not cause the status to flap. Default is `10`. Set to `0` to never report `DEGRADED` for unreadable events; failures are still counted in the input metrics and logged.
+The number of consecutive events that must fail to be read before the input reports a `DEGRADED` status to {{agent}}. Default is `3`. Set to `0` to never report `DEGRADED` for unreadable events. Failures are still counted in the input metrics and logged.
 
 Fatal errors such as a missing provider, a session that cannot be created or attached to, or insufficient privileges always report a `FAILED` status and are not affected by this setting.
 
@@ -258,7 +256,24 @@ Example:
 ```yaml
 filebeat.inputs:
 - type: etw
-  failure_threshold: 25
+  failure_threshold: 5
+```
+
+
+### `recovery_threshold` [_recovery_threshold]
+
+```{applies_to}
+stack: ga 9.4.7+
+```
+
+The number of consecutive events that must be read successfully, after the input has reported `DEGRADED`, before it reports `HEALTHY` again. Default is `1`. Must be at least `1`. Raise this value if a provider alternates between bursts of readable and unreadable events and you want the status to settle before it recovers.
+
+Example:
+
+```yaml
+filebeat.inputs:
+- type: etw
+  recovery_threshold: 5
 ```
 
 

--- a/docs/reference/filebeat/filebeat-input-etw.md
+++ b/docs/reference/filebeat/filebeat-input-etw.md
@@ -241,6 +241,27 @@ filebeat.inputs:
 ```
 
 
+### `failure_threshold` [_failure_threshold]
+
+```{applies_to}
+stack: ga 9.4.7+
+```
+
+Available in 9.4.7 and later, 9.5.4 and later, and 9.6.0 and later.
+
+Controls when the input reports itself as degraded to {{agent}} because of events it cannot read. After this many consecutive events fail to be read, the input reports a `DEGRADED` status. It returns to `HEALTHY` only after the same number of consecutive events are read successfully, so short bursts of bad events do not cause the status to flap. Default is `10`. Set to `0` to never report `DEGRADED` for unreadable events; failures are still counted in the input metrics and logged.
+
+Fatal errors such as a missing provider, a session that cannot be created or attached to, or insufficient privileges always report a `FAILED` status and are not affected by this setting.
+
+Example:
+
+```yaml
+filebeat.inputs:
+- type: etw
+  failure_threshold: 25
+```
+
+
 ## Common options [filebeat-input-etw-common-options]
 
 The following configuration options are supported by all inputs.

--- a/docs/reference/filebeat/filebeat-input-etw.md
+++ b/docs/reference/filebeat/filebeat-input-etw.md
@@ -266,7 +266,7 @@ filebeat.inputs:
 stack: ga 9.4.7+
 ```
 
-The number of consecutive events that must be read successfully, after the input has reported `DEGRADED`, before it reports `HEALTHY` again. Default is `1`. Must be at least `1`. Raise this value if a provider alternates between bursts of readable and unreadable events and you want the status to settle before it recovers.
+The number of consecutive events that must be read successfully, after the input has reported `DEGRADED`, before it reports `HEALTHY` again. Default is `1`. Must be at least `1` unless `failure_threshold` is `0`. Raise this value if a provider alternates between bursts of readable and unreadable events and you want the status to settle before it recovers.
 
 Example:
 

--- a/x-pack/filebeat/input/etw/config.go
+++ b/x-pack/filebeat/input/etw/config.go
@@ -57,6 +57,11 @@ type config struct {
 	BufferSize     uint32      `config:"buffer_size"`
 	MinimumBuffers uint32      `config:"minimum_buffers"`
 	MaximumBuffers uint32      `config:"maximum_buffers"`
+	// FailureThreshold is the number of consecutive events that must fail to
+	// render before the input reports Degraded, and the number of consecutive
+	// good events needed afterwards to report Running again. 0 disables
+	// Degraded reporting for render failures.
+	FailureThreshold uint `config:"failure_threshold"`
 }
 
 type EventFilter struct {
@@ -90,13 +95,28 @@ func convertConfig(cfg config) etw.Config {
 	}
 }
 
+// provider returns whichever provider identifier the user configured, for
+// use in log and status messages. Validate guarantees at most one is set.
+func (c *config) provider() string {
+	if c.ProviderName != "" {
+		return c.ProviderName
+	}
+	return c.ProviderGUID
+}
+
 func defaultConfig() config {
 	return config{
-		TraceLevel:      "verbose",
-		MatchAnyKeyword: 0xffffffffffffffff,
-		BufferSize:      64,
+		TraceLevel:       "verbose",
+		MatchAnyKeyword:  0xffffffffffffffff,
+		BufferSize:       64,
+		FailureThreshold: defaultFailureThreshold,
 	}
 }
+
+// defaultFailureThreshold is deliberately higher than the 3 used by other
+// inputs: ETW providers can emit thousands of events a second, so a short
+// burst of unreadable events should not flip the input to Degraded.
+const defaultFailureThreshold = 10
 
 func (c *config) Validate() error {
 	if c.ProviderName == "" && c.ProviderGUID == "" && c.Logfile == "" && c.Session == "" {

--- a/x-pack/filebeat/input/etw/config.go
+++ b/x-pack/filebeat/input/etw/config.go
@@ -58,10 +58,13 @@ type config struct {
 	MinimumBuffers uint32      `config:"minimum_buffers"`
 	MaximumBuffers uint32      `config:"maximum_buffers"`
 	// FailureThreshold is the number of consecutive events that must fail to
-	// render before the input reports Degraded, and the number of consecutive
-	// good events needed afterwards to report Running again. 0 disables
-	// Degraded reporting for render failures.
+	// render before the input reports Degraded. 0 disables Degraded reporting
+	// for render failures.
 	FailureThreshold uint `config:"failure_threshold"`
+	// RecoveryThreshold is the number of consecutive events that must render
+	// successfully, after the input has reported Degraded, before it reports
+	// Running again. Must be at least 1.
+	RecoveryThreshold uint `config:"recovery_threshold"`
 }
 
 type EventFilter struct {
@@ -106,17 +109,20 @@ func (c *config) provider() string {
 
 func defaultConfig() config {
 	return config{
-		TraceLevel:       "verbose",
-		MatchAnyKeyword:  0xffffffffffffffff,
-		BufferSize:       64,
-		FailureThreshold: defaultFailureThreshold,
+		TraceLevel:        "verbose",
+		MatchAnyKeyword:   0xffffffffffffffff,
+		BufferSize:        64,
+		FailureThreshold:  defaultFailureThreshold,
+		RecoveryThreshold: defaultRecoveryThreshold,
 	}
 }
 
-// defaultFailureThreshold is deliberately higher than the 3 used by other
-// inputs: ETW providers can emit thousands of events a second, so a short
-// burst of unreadable events should not flip the input to Degraded.
-const defaultFailureThreshold = 10
+// The health thresholds follow the Kubernetes probe defaults (three failures
+// to go unhealthy, one success to recover), which the awss3 input also uses.
+const (
+	defaultFailureThreshold  = 3
+	defaultRecoveryThreshold = 1
+)
 
 func (c *config) Validate() error {
 	if c.ProviderName == "" && c.ProviderGUID == "" && c.Logfile == "" && c.Session == "" {
@@ -152,6 +158,10 @@ func (c *config) Validate() error {
 		if c.Session != "" {
 			return fmt.Errorf("configuration constraint error: file and existing session cannot be defined together")
 		}
+	}
+
+	if c.RecoveryThreshold == 0 {
+		return fmt.Errorf("recovery_threshold must be at least 1")
 	}
 
 	return nil

--- a/x-pack/filebeat/input/etw/config.go
+++ b/x-pack/filebeat/input/etw/config.go
@@ -63,7 +63,7 @@ type config struct {
 	FailureThreshold uint `config:"failure_threshold"`
 	// RecoveryThreshold is the number of consecutive events that must render
 	// successfully, after the input has reported Degraded, before it reports
-	// Running again. Must be at least 1.
+	// Running again. Must be at least 1 when FailureThreshold is non-zero.
 	RecoveryThreshold uint `config:"recovery_threshold"`
 }
 
@@ -160,8 +160,8 @@ func (c *config) Validate() error {
 		}
 	}
 
-	if c.RecoveryThreshold == 0 {
-		return fmt.Errorf("recovery_threshold must be at least 1")
+	if c.FailureThreshold > 0 && c.RecoveryThreshold == 0 {
+		return fmt.Errorf("recovery_threshold must be at least 1 if failure_threshold is set")
 	}
 
 	return nil

--- a/x-pack/filebeat/input/etw/config_test.go
+++ b/x-pack/filebeat/input/etw/config_test.go
@@ -23,20 +23,33 @@ func Test_validateConfig(t *testing.T) {
 		{
 			name: "valid config",
 			config: config{
-				ProviderName:    "Microsoft-Windows-DNSServer",
-				SessionName:     "MySession-DNSServer",
-				TraceLevel:      "verbose",
-				MatchAnyKeyword: 0xffffffffffffffff,
-				MatchAllKeyword: 0,
+				ProviderName:      "Microsoft-Windows-DNSServer",
+				SessionName:       "MySession-DNSServer",
+				TraceLevel:        "verbose",
+				MatchAnyKeyword:   0xffffffffffffffff,
+				MatchAllKeyword:   0,
+				RecoveryThreshold: 1,
 			},
 		},
 		{
 			name: "minimal config",
 			config: config{
+				ProviderName:      "Microsoft-Windows-DNSServer",
+				TraceLevel:        "verbose",
+				MatchAnyKeyword:   0xffffffffffffffff,
+				RecoveryThreshold: 1,
+			},
+		},
+		{
+			// A zero-valued struct field is serialised by ucfg and overrides
+			// the default, so this exercises the recovery_threshold check.
+			name: "zero recovery threshold",
+			config: config{
 				ProviderName:    "Microsoft-Windows-DNSServer",
 				TraceLevel:      "verbose",
 				MatchAnyKeyword: 0xffffffffffffffff,
 			},
+			wantError: "recovery_threshold must be at least 1",
 		},
 		{
 			name: "missing source config",
@@ -139,44 +152,59 @@ func Test_validateConfig(t *testing.T) {
 	}
 }
 
-func Test_failureThreshold(t *testing.T) {
+func Test_healthThresholds(t *testing.T) {
 	tests := []struct {
-		name      string
-		raw       map[string]any
-		want      uint
-		wantError bool
+		name         string
+		raw          map[string]any
+		wantFailure  uint
+		wantRecovery uint
+		wantError    string
 	}{
 		{
-			name: "default",
-			raw:  map[string]any{"provider.name": "P"},
-			want: defaultFailureThreshold,
+			name:         "defaults",
+			raw:          map[string]any{"provider.name": "P"},
+			wantFailure:  defaultFailureThreshold,
+			wantRecovery: defaultRecoveryThreshold,
 		},
 		{
-			name: "custom",
-			raw:  map[string]any{"provider.name": "P", "failure_threshold": 25},
-			want: 25,
+			name:         "custom",
+			raw:          map[string]any{"provider.name": "P", "failure_threshold": 25, "recovery_threshold": 5},
+			wantFailure:  25,
+			wantRecovery: 5,
 		},
 		{
-			name: "zero disables",
-			raw:  map[string]any{"provider.name": "P", "failure_threshold": 0},
-			want: 0,
+			name:         "zero failure threshold disables",
+			raw:          map[string]any{"provider.name": "P", "failure_threshold": 0},
+			wantFailure:  0,
+			wantRecovery: defaultRecoveryThreshold,
 		},
 		{
-			name:      "negative rejected",
+			name:      "zero recovery threshold rejected",
+			raw:       map[string]any{"provider.name": "P", "recovery_threshold": 0},
+			wantError: "recovery_threshold must be at least 1",
+		},
+		{
+			name:      "negative failure threshold rejected",
 			raw:       map[string]any{"provider.name": "P", "failure_threshold": -1},
-			wantError: true,
+			wantError: "can not convert 'int' into 'uint' accessing 'failure_threshold'",
+		},
+		{
+			name:      "negative recovery threshold rejected",
+			raw:       map[string]any{"provider.name": "P", "recovery_threshold": -1},
+			wantError: "can not convert 'int' into 'uint' accessing 'recovery_threshold'",
 		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
 			cfg := defaultConfig()
-			err := confpkg.MustNewConfigFrom(tt.raw).Unpack(&cfg)
-			if tt.wantError {
-				assert.Error(t, err, "unpack should reject %v", tt.raw["failure_threshold"])
+			err := confpkg.MustNewConfigFrom(test.raw).Unpack(&cfg)
+			if test.wantError != "" {
+				assert.ErrorContains(t, err, test.wantError, "unpack of %v", test.raw)
 				return
 			}
-			assert.NoError(t, err, "unpack should accept %v", tt.raw)
-			assert.Equal(t, tt.want, cfg.FailureThreshold, "failure_threshold value")
+			assert.NoError(t, err, "unpack of %v", test.raw)
+			assert.Equal(t, test.wantFailure, cfg.FailureThreshold, "failure_threshold")
+			assert.Equal(t, test.wantRecovery, cfg.RecoveryThreshold, "recovery_threshold")
 		})
 	}
 }

--- a/x-pack/filebeat/input/etw/config_test.go
+++ b/x-pack/filebeat/input/etw/config_test.go
@@ -138,3 +138,45 @@ func Test_validateConfig(t *testing.T) {
 		})
 	}
 }
+
+func Test_failureThreshold(t *testing.T) {
+	tests := []struct {
+		name      string
+		raw       map[string]any
+		want      uint
+		wantError bool
+	}{
+		{
+			name: "default",
+			raw:  map[string]any{"provider.name": "P"},
+			want: defaultFailureThreshold,
+		},
+		{
+			name: "custom",
+			raw:  map[string]any{"provider.name": "P", "failure_threshold": 25},
+			want: 25,
+		},
+		{
+			name: "zero disables",
+			raw:  map[string]any{"provider.name": "P", "failure_threshold": 0},
+			want: 0,
+		},
+		{
+			name:      "negative rejected",
+			raw:       map[string]any{"provider.name": "P", "failure_threshold": -1},
+			wantError: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := defaultConfig()
+			err := confpkg.MustNewConfigFrom(tt.raw).Unpack(&cfg)
+			if tt.wantError {
+				assert.Error(t, err, "unpack should reject %v", tt.raw["failure_threshold"])
+				return
+			}
+			assert.NoError(t, err, "unpack should accept %v", tt.raw)
+			assert.Equal(t, tt.want, cfg.FailureThreshold, "failure_threshold value")
+		})
+	}
+}

--- a/x-pack/filebeat/input/etw/config_test.go
+++ b/x-pack/filebeat/input/etw/config_test.go
@@ -43,13 +43,22 @@ func Test_validateConfig(t *testing.T) {
 		{
 			// A zero-valued struct field is serialised by ucfg and overrides
 			// the default, so this exercises the recovery_threshold check.
-			name: "zero recovery threshold",
+			name: "zero recovery threshold with thresholding enabled",
+			config: config{
+				ProviderName:     "Microsoft-Windows-DNSServer",
+				TraceLevel:       "verbose",
+				MatchAnyKeyword:  0xffffffffffffffff,
+				FailureThreshold: 3,
+			},
+			wantError: "recovery_threshold must be at least 1 if failure_threshold is set",
+		},
+		{
+			name: "zero recovery threshold with thresholding disabled",
 			config: config{
 				ProviderName:    "Microsoft-Windows-DNSServer",
 				TraceLevel:      "verbose",
 				MatchAnyKeyword: 0xffffffffffffffff,
 			},
-			wantError: "recovery_threshold must be at least 1",
 		},
 		{
 			name: "missing source config",
@@ -179,9 +188,15 @@ func Test_healthThresholds(t *testing.T) {
 			wantRecovery: defaultRecoveryThreshold,
 		},
 		{
-			name:      "zero recovery threshold rejected",
+			name:      "zero recovery threshold rejected when thresholding enabled",
 			raw:       map[string]any{"provider.name": "P", "recovery_threshold": 0},
-			wantError: "recovery_threshold must be at least 1",
+			wantError: "recovery_threshold must be at least 1 if failure_threshold is set",
+		},
+		{
+			name:         "zero recovery threshold allowed when thresholding disabled",
+			raw:          map[string]any{"provider.name": "P", "failure_threshold": 0, "recovery_threshold": 0},
+			wantFailure:  0,
+			wantRecovery: 0,
 		},
 		{
 			name:      "negative failure threshold rejected",

--- a/x-pack/filebeat/input/etw/input.go
+++ b/x-pack/filebeat/input/etw/input.go
@@ -112,7 +112,11 @@ func (e *etwInput) Run(ctx input.Context, publisher stateless.Publisher) error {
 	// drops repeats of the state it already has. Per-event health goes
 	// through e.health, which is the hot path and needs the counting logic.
 	ctx.UpdateStatus(status.Starting, "")
-	e.health = &eventHealth{reporter: ctx, threshold: e.config.FailureThreshold}
+	e.health = &eventHealth{
+		reporter:          ctx,
+		failureThreshold:  e.config.FailureThreshold,
+		recoveryThreshold: e.config.RecoveryThreshold,
+	}
 
 	// Initialize a new ETW session with the provided configuration
 	e.etwSession, err = e.operator.newSession(e.config)
@@ -191,14 +195,15 @@ func (e *etwInput) Run(ctx input.Context, publisher stateless.Publisher) error {
 }
 
 // eventHealth turns the per-event success/failure stream from consumeEvent
-// into Degraded/Running reports. It follows the awss3 input: N consecutive
-// failures mark the input Degraded. Unlike awss3 it also needs N consecutive
-// successes to recover, because a provider that alternates bursts of good and
-// unreadable events would otherwise flap on every burst. A single threshold
-// is used for both directions; there is no known reason to tune them apart.
+// into Degraded/Running reports using the consecutive-count model of
+// Kubernetes probes and the awss3 input: failureThreshold failures in a row
+// mark the input Degraded, recoveryThreshold successes in a row clear it.
+// The two are separate knobs because there is no reason to expect the run
+// lengths of good and bad events to match in a failing provider.
 type eventHealth struct {
-	reporter  status.StatusReporter
-	threshold uint // 0 means never report Degraded.
+	reporter          status.StatusReporter
+	failureThreshold  uint // 0 means never report Degraded.
+	recoveryThreshold uint // Validated to be at least 1.
 
 	// ETW delivers callbacks on a single thread today, so mu is rarely
 	// contended; it is cheap insurance against that changing.
@@ -211,14 +216,14 @@ type eventHealth struct {
 // failure records an event that could not be read. err is only formatted
 // when the threshold is reached, since most calls never report anything.
 func (h *eventHealth) failure(err error) {
-	if h.threshold == 0 {
+	if h.failureThreshold == 0 {
 		return
 	}
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	h.good = 0
 	h.bad++
-	if h.degraded || h.bad < h.threshold {
+	if h.degraded || h.bad < h.failureThreshold {
 		return
 	}
 	h.degraded = true
@@ -228,7 +233,7 @@ func (h *eventHealth) failure(err error) {
 
 // success records an event that was read and published.
 func (h *eventHealth) success() {
-	if h.threshold == 0 {
+	if h.failureThreshold == 0 {
 		return
 	}
 	h.mu.Lock()
@@ -238,7 +243,7 @@ func (h *eventHealth) success() {
 		return
 	}
 	h.good++
-	if h.good < h.threshold {
+	if h.good < h.recoveryThreshold {
 		return
 	}
 	h.degraded = false

--- a/x-pack/filebeat/input/etw/input.go
+++ b/x-pack/filebeat/input/etw/input.go
@@ -17,6 +17,7 @@ import (
 	stateless "github.com/elastic/beats/v7/filebeat/input/v2/input-stateless"
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/feature"
+	"github.com/elastic/beats/v7/libbeat/management/status"
 	"github.com/elastic/beats/v7/libbeat/reader/etw"
 	conf "github.com/elastic/elastic-agent-libs/config"
 	"github.com/elastic/elastic-agent-libs/logp"
@@ -73,6 +74,7 @@ type etwInput struct {
 	etwSession *etw.Session
 	publisher  stateless.Publisher
 	operator   sessionOperator
+	health     *eventHealth
 }
 
 func Plugin() input.Plugin {
@@ -106,9 +108,16 @@ func (e *etwInput) Test(_ input.TestContext) error {
 func (e *etwInput) Run(ctx input.Context, publisher stateless.Publisher) error {
 	var err error
 
+	// Lifecycle states are reported straight to the context; the agent
+	// drops repeats of the state it already has. Per-event health goes
+	// through e.health, which is the hot path and needs the counting logic.
+	ctx.UpdateStatus(status.Starting, "")
+	e.health = &eventHealth{reporter: ctx, threshold: e.config.FailureThreshold}
+
 	// Initialize a new ETW session with the provided configuration
 	e.etwSession, err = e.operator.newSession(e.config)
 	if err != nil {
+		ctx.UpdateStatus(status.Failed, "failed to initialize ETW session: "+errDetail(err))
 		return fmt.Errorf("error initializing ETW session: %w", err)
 	}
 	e.etwSession.Callback = e.consumeEvent
@@ -122,6 +131,7 @@ func (e *etwInput) Run(ctx input.Context, publisher stateless.Publisher) error {
 
 	// Handle realtime session creation or attachment
 	if e.etwSession.Realtime {
+		ctx.UpdateStatus(status.Configuring, "")
 		switch e.etwSession.NewSession {
 		case true:
 			// Create a new realtime session
@@ -132,6 +142,8 @@ func (e *etwInput) Run(ctx input.Context, publisher stateless.Publisher) error {
 				break
 			}
 			if !errors.Is(createErr, etw.ERROR_ALREADY_EXISTS) {
+				ctx.UpdateStatus(status.Failed, fmt.Sprintf("failed to create realtime session %q for provider %s: %s",
+					e.etwSession.Name, e.config.provider(), errDetail(createErr)))
 				return fmt.Errorf("realtime session could not be created: %w", createErr)
 			}
 			e.log.Debug("session already exists, trying to attach to it")
@@ -139,6 +151,8 @@ func (e *etwInput) Run(ctx input.Context, publisher stateless.Publisher) error {
 		case false:
 			// Attach to an existing session
 			if err := e.operator.attachToExistingSession(e.etwSession); err != nil {
+				ctx.UpdateStatus(status.Failed, fmt.Sprintf("failed to attach to session %q: %s",
+					e.etwSession.Name, errDetail(err)))
 				return fmt.Errorf("unable to retrieve handler: %w", err)
 			}
 			e.log.Debug("attached to existing session")
@@ -159,14 +173,76 @@ func (e *etwInput) Run(ctx input.Context, publisher stateless.Publisher) error {
 	g.Go(func() error {
 		e.log.Debug("starting ETW consumer")
 		defer e.log.Debug("stopped ETW consumer")
+		// startConsumer opens the trace and then blocks inside ProcessTrace
+		// for the life of the session, so there is no point after it returns
+		// where we could report Running. Report it up front; if opening the
+		// trace fails we immediately move to Failed below.
+		ctx.UpdateStatus(status.Running, "")
 		if err = e.operator.startConsumer(e.etwSession); err != nil {
 			e.metrics.errors.Inc()
+			ctx.UpdateStatus(status.Failed, fmt.Sprintf("ETW consumer for session %q failed: %s",
+				e.etwSession.Name, errDetail(err)))
 			return fmt.Errorf("failed running ETW consumer: %w", err)
 		}
 		return nil
 	})
 
 	return g.Wait()
+}
+
+// eventHealth turns the per-event success/failure stream from consumeEvent
+// into Degraded/Running reports. It follows the awss3 input: N consecutive
+// failures mark the input Degraded. Unlike awss3 it also needs N consecutive
+// successes to recover, because a provider that alternates bursts of good and
+// unreadable events would otherwise flap on every burst. A single threshold
+// is used for both directions; there is no known reason to tune them apart.
+type eventHealth struct {
+	reporter  status.StatusReporter
+	threshold uint // 0 means never report Degraded.
+
+	// ETW delivers callbacks on a single thread today, so mu is rarely
+	// contended; it is cheap insurance against that changing.
+	mu       sync.Mutex
+	bad      uint // Consecutive failures, reset by a success.
+	good     uint // Consecutive successes, reset by a failure.
+	degraded bool
+}
+
+// failure records an event that could not be read. err is only formatted
+// when the threshold is reached, since most calls never report anything.
+func (h *eventHealth) failure(err error) {
+	if h.threshold == 0 {
+		return
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.good = 0
+	h.bad++
+	if h.degraded || h.bad < h.threshold {
+		return
+	}
+	h.degraded = true
+	h.reporter.UpdateStatus(status.Degraded,
+		fmt.Sprintf("%d consecutive events could not be read; last error: %s", h.bad, errDetail(err)))
+}
+
+// success records an event that was read and published.
+func (h *eventHealth) success() {
+	if h.threshold == 0 {
+		return
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.bad = 0
+	if !h.degraded {
+		return
+	}
+	h.good++
+	if h.good < h.threshold {
+		return
+	}
+	h.degraded = false
+	h.reporter.UpdateStatus(status.Running, "")
 }
 
 var (
@@ -312,10 +388,14 @@ func buildEvent(etwEvent etw.RenderedEtwEvent, h etw.EventHeader, session *etw.S
 	}
 }
 
+// errNullRecord is reported to eventHealth when ETW hands us a nil record.
+var errNullRecord = errors.New("received null event record from ETW session")
+
 func (e *etwInput) consumeEvent(record *etw.EventRecord) uintptr {
 	if record == nil {
 		e.log.Error("received null event record")
 		e.metrics.errors.Inc()
+		e.health.failure(errNullRecord)
 		return 1
 	}
 
@@ -327,10 +407,13 @@ func (e *etwInput) consumeEvent(record *etw.EventRecord) uintptr {
 
 	etwEvent, err := e.etwSession.RenderEvent(record)
 	if err != nil {
+		// Unprocessable events are expected noise from some providers and
+		// are dropped quietly; anything else means we are losing data.
 		if !errors.Is(err, etw.ErrUnprocessableEvent) {
 			e.log.Errorw("failed to read event properties", "error", err)
 			e.metrics.errors.Inc()
 			e.metrics.dropped.Inc()
+			e.health.failure(err)
 		}
 		return 1
 	}
@@ -338,6 +421,7 @@ func (e *etwInput) consumeEvent(record *etw.EventRecord) uintptr {
 	evt := buildEvent(etwEvent, record.EventHeader, e.etwSession, e.config)
 	e.publisher.Publish(evt)
 
+	e.health.success()
 	e.metrics.events.Inc()
 	e.metrics.sourceLag.Update(start.Sub(evt.Timestamp).Nanoseconds())
 	if !e.metrics.lastCallback.IsZero() {
@@ -346,6 +430,22 @@ func (e *etwInput) consumeEvent(record *etw.EventRecord) uintptr {
 	e.metrics.lastCallback = start
 
 	return 0
+}
+
+// errDetail formats err for a status message. When a Windows error is wrapped
+// it appends the raw code, since the text alone ("Access is denied.") is often
+// not enough to search for, and for access denied it spells out what
+// privileges ETW needs.
+func errDetail(err error) string {
+	var errno windows.Errno
+	if !errors.As(err, &errno) {
+		return err.Error()
+	}
+	msg := fmt.Sprintf("%v (windows error %d)", err, uint32(errno))
+	if errno == etw.ERROR_ACCESS_DENIED {
+		msg += "; ETW sessions require running as Administrator or membership in the Performance Log Users group"
+	}
+	return msg
 }
 
 // Close stops the ETW session and logs the outcome.

--- a/x-pack/filebeat/input/etw/input.go
+++ b/x-pack/filebeat/input/etw/input.go
@@ -203,7 +203,7 @@ func (e *etwInput) Run(ctx input.Context, publisher stateless.Publisher) error {
 type eventHealth struct {
 	reporter          status.StatusReporter
 	failureThreshold  uint // 0 means never report Degraded.
-	recoveryThreshold uint // Validated to be at least 1.
+	recoveryThreshold uint // Validated to be at least 1 if thresholding is being used.
 
 	// ETW delivers callbacks on a single thread today, so mu is rarely
 	// contended; it is cheap insurance against that changing.

--- a/x-pack/filebeat/input/etw/input_test.go
+++ b/x-pack/filebeat/input/etw/input_test.go
@@ -86,17 +86,17 @@ type recordingReporter struct {
 
 func (r *recordingReporter) UpdateStatus(s status.Status, msg string) {
 	r.mu.Lock()
-	defer r.mu.Unlock()
 	r.updates = append(r.updates, statusUpdate{status: s, msg: msg})
+	r.mu.Unlock()
 }
 
 func (r *recordingReporter) statuses() []status.Status {
 	r.mu.Lock()
-	defer r.mu.Unlock()
 	out := make([]status.Status, len(r.updates))
 	for i, u := range r.updates {
 		out[i] = u.status
 	}
+	r.mu.Unlock()
 	return out
 }
 
@@ -265,7 +265,7 @@ func Test_RunEtwInput_CreateRealtimeSessionAlreadyExists(t *testing.T) {
 	}
 	blockConsumerUntilStopped(mockOperator)
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 	reporter := &recordingReporter{}
 	inputCtx := input.Context{
@@ -378,7 +378,7 @@ func Test_RunEtwInput_Success(t *testing.T) {
 	blockConsumerUntilStopped(mockOperator)
 
 	// Setup cancellation
-	ctx, cancelFunc := context.WithCancel(context.Background())
+	ctx, cancelFunc := context.WithCancel(t.Context())
 	defer cancelFunc()
 
 	// Setup input
@@ -440,71 +440,84 @@ func Test_eventHealth(t *testing.T) {
 	// Each test feeds a string of events to eventHealth: 'b' is a failure,
 	// 'g' is a success. Spaces are ignored and are only there to make the
 	// runs readable.
+	degraded := func(n int) statusUpdate {
+		return statusUpdate{status.Degraded, fmt.Sprintf("%d consecutive events could not be read; last error: bad", n)}
+	}
+	running := statusUpdate{status.Running, ""}
+
 	tests := []struct {
-		name      string
-		threshold uint
-		events    string
-		want      []statusUpdate
+		name     string
+		failure  uint
+		recovery uint
+		events   string
+		want     []statusUpdate
 	}{
 		{
-			name:      "below threshold never degrades",
-			threshold: 3,
-			events:    "bb g bb g bb",
-			want:      nil,
+			name:     "defaults: below failure threshold never degrades",
+			failure:  3,
+			recovery: 1,
+			events:   "bb g bb g bb",
+			want:     nil,
 		},
 		{
-			name:      "degrades at threshold, once",
-			threshold: 3,
-			events:    "bbb bbbbb",
-			want: []statusUpdate{
-				{status.Degraded, "3 consecutive events could not be read; last error: bad"},
-			},
+			name:     "defaults: degrades at threshold, once",
+			failure:  3,
+			recovery: 1,
+			events:   "bbb bbbbb",
+			want:     []statusUpdate{degraded(3)},
 		},
 		{
-			name:      "one good event is not enough to recover",
-			threshold: 3,
-			events:    "bbb g bbb g",
-			want: []statusUpdate{
-				{status.Degraded, "3 consecutive events could not be read; last error: bad"},
-			},
+			name:     "defaults: one good event recovers",
+			failure:  3,
+			recovery: 1,
+			events:   "bbb g",
+			want:     []statusUpdate{degraded(3), running},
 		},
 		{
-			name:      "recovers after threshold good events",
-			threshold: 3,
-			events:    "bbb gg b ggg",
-			want: []statusUpdate{
-				{status.Degraded, "3 consecutive events could not be read; last error: bad"},
-				{status.Running, ""},
-			},
+			name:     "defaults: alternating runs flap",
+			failure:  3,
+			recovery: 1,
+			events:   "bbb g bbb g",
+			want:     []statusUpdate{degraded(3), running, degraded(3), running},
 		},
 		{
-			name:      "can degrade again after recovering",
-			threshold: 2,
-			events:    "bb gg bb",
-			want: []statusUpdate{
-				{status.Degraded, "2 consecutive events could not be read; last error: bad"},
-				{status.Running, ""},
-				{status.Degraded, "2 consecutive events could not be read; last error: bad"},
-			},
+			name:     "higher recovery threshold: one good event is not enough",
+			failure:  3,
+			recovery: 3,
+			events:   "bbb g bbb g",
+			want:     []statusUpdate{degraded(3)},
 		},
 		{
-			name:      "good events while healthy report nothing",
-			threshold: 2,
-			events:    "gggggg",
-			want:      nil,
+			name:     "higher recovery threshold: a failure resets the good run",
+			failure:  3,
+			recovery: 3,
+			events:   "bbb gg b ggg",
+			want:     []statusUpdate{degraded(3), running},
 		},
 		{
-			name:      "zero threshold disables reporting",
-			threshold: 0,
-			events:    "bbbbbbbbbb gggg",
-			want:      nil,
+			name:     "good events while healthy report nothing",
+			failure:  2,
+			recovery: 1,
+			events:   "gggggg",
+			want:     nil,
+		},
+		{
+			name:     "zero failure threshold disables reporting",
+			failure:  0,
+			recovery: 1,
+			events:   "bbbbbbbbbb gggg",
+			want:     nil,
 		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
 			reporter := &recordingReporter{}
-			h := &eventHealth{reporter: reporter, threshold: tt.threshold}
-			for _, ev := range tt.events {
+			h := &eventHealth{
+				reporter:          reporter,
+				failureThreshold:  test.failure,
+				recoveryThreshold: test.recovery,
+			}
+			for _, ev := range test.events {
 				switch ev {
 				case 'b':
 					h.failure(errors.New("bad"))
@@ -512,7 +525,8 @@ func Test_eventHealth(t *testing.T) {
 					h.success()
 				}
 			}
-			assert.Equal(t, tt.want, reporter.updates, "events %q with threshold %d", tt.events, tt.threshold)
+			assert.Equal(t, test.want, reporter.updates,
+				"events %q with failure=%d recovery=%d", test.events, test.failure, test.recovery)
 		})
 	}
 }
@@ -540,9 +554,9 @@ func Test_errDetail(t *testing.T) {
 				etw.ERROR_ACCESS_DENIED),
 		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, errDetail(tt.err), "errDetail(%v)", tt.err)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.want, errDetail(test.err), "errDetail(%v)", test.err)
 		})
 	}
 }

--- a/x-pack/filebeat/input/etw/input_test.go
+++ b/x-pack/filebeat/input/etw/input_test.go
@@ -8,8 +8,11 @@ package etw
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"slices"
 	"strconv"
+	"sync"
 	"testing"
 	"time"
 
@@ -17,8 +20,8 @@ import (
 	"golang.org/x/sys/windows"
 
 	input "github.com/elastic/beats/v7/filebeat/input/v2"
+	"github.com/elastic/beats/v7/libbeat/management/status"
 	"github.com/elastic/beats/v7/libbeat/reader/etw"
-	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 	"github.com/elastic/elastic-agent-libs/monitoring"
@@ -68,6 +71,45 @@ func (m *mockSessionOperator) stopSession(session *etw.Session) error {
 	return nil
 }
 
+// statusUpdate is one UpdateStatus call as seen by recordingReporter.
+type statusUpdate struct {
+	status status.Status
+	msg    string
+}
+
+// recordingReporter captures every status update so tests can check the
+// exact sequence the input reported.
+type recordingReporter struct {
+	mu      sync.Mutex
+	updates []statusUpdate
+}
+
+func (r *recordingReporter) UpdateStatus(s status.Status, msg string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.updates = append(r.updates, statusUpdate{status: s, msg: msg})
+}
+
+func (r *recordingReporter) statuses() []status.Status {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]status.Status, len(r.updates))
+	for i, u := range r.updates {
+		out[i] = u.status
+	}
+	return out
+}
+
+// lastMsg returns the message of the most recent update, or "" if none.
+func (r *recordingReporter) lastMsg() string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if len(r.updates) == 0 {
+		return ""
+	}
+	return r.updates[len(r.updates)-1].msg
+}
+
 func Test_RunEtwInput_NewSessionError(t *testing.T) {
 	// Mocks
 	mockOperator := &mockSessionOperator{}
@@ -78,11 +120,12 @@ func Test_RunEtwInput_NewSessionError(t *testing.T) {
 	}
 
 	// Setup input
+	reporter := &recordingReporter{}
 	inputCtx := input.Context{
 		Cancelation:     nil,
-		Logger:          logp.NewLogger("test"),
+		Logger:          logptest.NewTestingLogger(t, ""),
 		MetricsRegistry: monitoring.NewRegistry(),
-	}
+	}.WithStatusReporter(reporter)
 
 	etwInput := &etwInput{
 		config: config{
@@ -100,6 +143,10 @@ func Test_RunEtwInput_NewSessionError(t *testing.T) {
 	// Run test
 	err := etwInput.Run(inputCtx, nil)
 	assert.EqualError(t, err, "error initializing ETW session: failed creating session 'MySession'")
+	assert.Equal(t, []status.Status{status.Starting, status.Failed}, reporter.statuses(),
+		"input should report Starting then Failed when the session cannot be initialized")
+	assert.Equal(t, "failed to initialize ETW session: failed creating session 'MySession'", reporter.lastMsg(),
+		"Failed message should carry the underlying error")
 }
 
 func Test_RunEtwInput_AttachToExistingSessionError(t *testing.T) {
@@ -115,17 +162,19 @@ func Test_RunEtwInput_AttachToExistingSessionError(t *testing.T) {
 		}
 		return mockSession, nil
 	}
-	// Setup the mock behavior for AttachToExistingSession
+	// Setup the mock behavior for AttachToExistingSession. Wrap a real
+	// Windows error so we can check the code is surfaced in the status.
 	mockOperator.attachToExistingSessionFunc = func(session *etw.Session) error {
-		return fmt.Errorf("mock error")
+		return fmt.Errorf("session is not running: %w", etw.ERROR_WMI_INSTANCE_NOT_FOUND)
 	}
 
 	// Setup input
+	reporter := &recordingReporter{}
 	inputCtx := input.Context{
 		Cancelation:     nil,
-		Logger:          logp.NewLogger("test"),
+		Logger:          logptest.NewTestingLogger(t, ""),
 		MetricsRegistry: monitoring.NewRegistry(),
-	}
+	}.WithStatusReporter(reporter)
 
 	etwInput := &etwInput{
 		config: config{
@@ -140,7 +189,13 @@ func Test_RunEtwInput_AttachToExistingSessionError(t *testing.T) {
 
 	// Run test
 	err := etwInput.Run(inputCtx, nil)
-	assert.EqualError(t, err, "unable to retrieve handler: mock error")
+	assert.ErrorContains(t, err, "unable to retrieve handler: session is not running")
+	assert.Equal(t, []status.Status{status.Starting, status.Configuring, status.Failed}, reporter.statuses(),
+		"input should fail while configuring when attach fails")
+	assert.Contains(t, reporter.lastMsg(), `failed to attach to session "MySession"`,
+		"Failed message should name the session")
+	assert.Contains(t, reporter.lastMsg(), fmt.Sprintf("(windows error %d)", uint32(etw.ERROR_WMI_INSTANCE_NOT_FOUND)),
+		"Failed message should include the Windows error code")
 }
 
 func Test_RunEtwInput_CreateRealtimeSessionError(t *testing.T) {
@@ -166,11 +221,12 @@ func Test_RunEtwInput_CreateRealtimeSessionError(t *testing.T) {
 	}
 
 	// Setup input
+	reporter := &recordingReporter{}
 	inputCtx := input.Context{
 		Cancelation:     nil,
-		Logger:          logp.NewLogger("test"),
+		Logger:          logptest.NewTestingLogger(t, ""),
 		MetricsRegistry: monitoring.NewRegistry(),
-	}
+	}.WithStatusReporter(reporter)
 
 	etwInput := &etwInput{
 		config: config{
@@ -186,6 +242,51 @@ func Test_RunEtwInput_CreateRealtimeSessionError(t *testing.T) {
 	// Run test
 	err := etwInput.Run(inputCtx, nil)
 	assert.EqualError(t, err, "realtime session could not be created: mock error")
+	assert.Equal(t, []status.Status{status.Starting, status.Configuring, status.Failed}, reporter.statuses(),
+		"input should fail while configuring when session creation fails")
+	assert.Equal(t, `failed to create realtime session "MySession" for provider Microsoft-Windows-Provider: mock error`,
+		reporter.lastMsg(), "Failed message should name the session and provider")
+}
+
+func Test_RunEtwInput_CreateRealtimeSessionAlreadyExists(t *testing.T) {
+	// When the session already exists we fall back to attaching. That is a
+	// normal path and must not show up as Degraded or Failed.
+	mockOperator := &mockSessionOperator{}
+	mockOperator.newSessionFunc = func(config config) (*etw.Session, error) {
+		return &etw.Session{Name: "MySession", Realtime: true, NewSession: true}, nil
+	}
+	mockOperator.createRealtimeSessionFunc = func(session *etw.Session) error {
+		return fmt.Errorf("session already exists: %w", etw.ERROR_ALREADY_EXISTS)
+	}
+	attached := false
+	mockOperator.attachToExistingSessionFunc = func(session *etw.Session) error {
+		attached = true
+		return nil
+	}
+	blockConsumerUntilStopped(mockOperator)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	reporter := &recordingReporter{}
+	inputCtx := input.Context{
+		Cancelation:     ctx,
+		Logger:          logptest.NewTestingLogger(t, ""),
+		MetricsRegistry: monitoring.NewRegistry(),
+	}.WithStatusReporter(reporter)
+
+	etwInput := &etwInput{
+		config:   config{ProviderName: "Microsoft-Windows-Provider", SessionName: "MySession"},
+		operator: mockOperator,
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- etwInput.Run(inputCtx, nil) }()
+	waitForStatus(t, reporter, status.Running)
+	cancel()
+	assert.NoError(t, <-done, "Run should exit cleanly on cancellation")
+	assert.True(t, attached, "input should attach when the session already exists")
+	assert.Equal(t, []status.Status{status.Starting, status.Configuring, status.Running}, reporter.statuses(),
+		"falling back to attach should still end up Running")
 }
 
 func Test_RunEtwInput_StartConsumerError(t *testing.T) {
@@ -209,9 +310,10 @@ func Test_RunEtwInput_StartConsumerError(t *testing.T) {
 	mockOperator.createRealtimeSessionFunc = func(session *etw.Session) error {
 		return nil
 	}
-	// Setup the mock behavior for StartConsumer
+	// Setup the mock behavior for StartConsumer. Access denied is the most
+	// common real failure here, so use it to check the privilege hint.
 	mockOperator.startConsumerFunc = func(session *etw.Session) error {
-		return fmt.Errorf("mock error")
+		return fmt.Errorf("access denied when opening trace: %w", etw.ERROR_ACCESS_DENIED)
 	}
 	// Setup the mock behavior for StopSession
 	mockOperator.stopSessionFunc = func(session *etw.Session) error {
@@ -222,11 +324,12 @@ func Test_RunEtwInput_StartConsumerError(t *testing.T) {
 	ctx := t.Context()
 
 	// Setup input
+	reporter := &recordingReporter{}
 	inputCtx := input.Context{
 		Cancelation:     ctx,
-		Logger:          logp.NewLogger("test"),
+		Logger:          logptest.NewTestingLogger(t, ""),
 		MetricsRegistry: monitoring.NewRegistry(),
-	}
+	}.WithStatusReporter(reporter)
 
 	etwInput := &etwInput{
 		config: config{
@@ -241,7 +344,13 @@ func Test_RunEtwInput_StartConsumerError(t *testing.T) {
 
 	// Run test
 	err := etwInput.Run(inputCtx, nil)
-	assert.EqualError(t, err, "failed running ETW consumer: mock error")
+	assert.ErrorContains(t, err, "failed running ETW consumer: access denied when opening trace")
+	assert.Equal(t, []status.Status{status.Starting, status.Configuring, status.Running, status.Failed}, reporter.statuses(),
+		"consumer failure should move from Running to Failed")
+	assert.Contains(t, reporter.lastMsg(), `ETW consumer for session "MySession" failed`,
+		"Failed message should name the session")
+	assert.Contains(t, reporter.lastMsg(), "Performance Log Users",
+		"access denied should explain which privileges ETW needs")
 }
 
 func Test_RunEtwInput_Success(t *testing.T) {
@@ -265,25 +374,20 @@ func Test_RunEtwInput_Success(t *testing.T) {
 	mockOperator.createRealtimeSessionFunc = func(session *etw.Session) error {
 		return nil
 	}
-	// Setup the mock behavior for StartConsumer
-	mockOperator.startConsumerFunc = func(session *etw.Session) error {
-		return nil
-	}
-	// Setup the mock behavior for StopSession
-	mockOperator.stopSessionFunc = func(session *etw.Session) error {
-		return nil
-	}
+	// Setup the mock behavior for StartConsumer and StopSession
+	blockConsumerUntilStopped(mockOperator)
 
 	// Setup cancellation
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
 
 	// Setup input
+	reporter := &recordingReporter{}
 	inputCtx := input.Context{
 		Cancelation:     ctx,
-		Logger:          logp.NewLogger("test"),
+		Logger:          logptest.NewTestingLogger(t, ""),
 		MetricsRegistry: monitoring.NewRegistry(),
-	}
+	}.WithStatusReporter(reporter)
 
 	etwInput := &etwInput{
 		config: config{
@@ -297,16 +401,150 @@ func Test_RunEtwInput_Success(t *testing.T) {
 	}
 
 	// Run test
-	go func() {
-		err := etwInput.Run(inputCtx, nil)
-		if err != nil {
-			t.Errorf("Run() error = %v, wantErr %v", err, false)
-		}
-	}()
+	done := make(chan error, 1)
+	go func() { done <- etwInput.Run(inputCtx, nil) }()
 
-	// Simulate waiting for a condition
-	time.Sleep(time.Millisecond * 100)
-	cancelFunc() // Trigger cancellation to test cleanup and goroutine exit
+	// Wait until the consumer is up, then cancel to test cleanup and exit.
+	waitForStatus(t, reporter, status.Running)
+	cancelFunc()
+	assert.NoError(t, <-done, "Run should exit cleanly on cancellation")
+	assert.Equal(t, []status.Status{status.Starting, status.Configuring, status.Running}, reporter.statuses(),
+		"a healthy start should report Starting, Configuring, Running exactly once each")
+}
+
+// blockConsumerUntilStopped makes the mock consumer behave like the real
+// one: startConsumer blocks until stopSession is called, so tests can
+// exercise the cancellation path rather than having Run return at once.
+func blockConsumerUntilStopped(op *mockSessionOperator) {
+	stopped := make(chan struct{})
+	op.startConsumerFunc = func(*etw.Session) error {
+		<-stopped
+		return nil
+	}
+	op.stopSessionFunc = func(*etw.Session) error {
+		close(stopped)
+		return nil
+	}
+}
+
+// waitForStatus blocks until reporter has seen want, failing the test if it
+// does not show up in time.
+func waitForStatus(t *testing.T, reporter *recordingReporter, want status.Status) {
+	t.Helper()
+	assert.Eventually(t, func() bool {
+		return slices.Contains(reporter.statuses(), want)
+	}, 5*time.Second, 10*time.Millisecond, "input never reported %s", want)
+}
+
+func Test_eventHealth(t *testing.T) {
+	// Each test feeds a string of events to eventHealth: 'b' is a failure,
+	// 'g' is a success. Spaces are ignored and are only there to make the
+	// runs readable.
+	tests := []struct {
+		name      string
+		threshold uint
+		events    string
+		want      []statusUpdate
+	}{
+		{
+			name:      "below threshold never degrades",
+			threshold: 3,
+			events:    "bb g bb g bb",
+			want:      nil,
+		},
+		{
+			name:      "degrades at threshold, once",
+			threshold: 3,
+			events:    "bbb bbbbb",
+			want: []statusUpdate{
+				{status.Degraded, "3 consecutive events could not be read; last error: bad"},
+			},
+		},
+		{
+			name:      "one good event is not enough to recover",
+			threshold: 3,
+			events:    "bbb g bbb g",
+			want: []statusUpdate{
+				{status.Degraded, "3 consecutive events could not be read; last error: bad"},
+			},
+		},
+		{
+			name:      "recovers after threshold good events",
+			threshold: 3,
+			events:    "bbb gg b ggg",
+			want: []statusUpdate{
+				{status.Degraded, "3 consecutive events could not be read; last error: bad"},
+				{status.Running, ""},
+			},
+		},
+		{
+			name:      "can degrade again after recovering",
+			threshold: 2,
+			events:    "bb gg bb",
+			want: []statusUpdate{
+				{status.Degraded, "2 consecutive events could not be read; last error: bad"},
+				{status.Running, ""},
+				{status.Degraded, "2 consecutive events could not be read; last error: bad"},
+			},
+		},
+		{
+			name:      "good events while healthy report nothing",
+			threshold: 2,
+			events:    "gggggg",
+			want:      nil,
+		},
+		{
+			name:      "zero threshold disables reporting",
+			threshold: 0,
+			events:    "bbbbbbbbbb gggg",
+			want:      nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reporter := &recordingReporter{}
+			h := &eventHealth{reporter: reporter, threshold: tt.threshold}
+			for _, ev := range tt.events {
+				switch ev {
+				case 'b':
+					h.failure(errors.New("bad"))
+				case 'g':
+					h.success()
+				}
+			}
+			assert.Equal(t, tt.want, reporter.updates, "events %q with threshold %d", tt.events, tt.threshold)
+		})
+	}
+}
+
+func Test_errDetail(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{
+			name: "plain error",
+			err:  errors.New("boom"),
+			want: "boom",
+		},
+		{
+			name: "wrapped windows error gets its code",
+			err:  fmt.Errorf("session is not running: %w", etw.ERROR_WMI_INSTANCE_NOT_FOUND),
+			want: fmt.Sprintf("session is not running: %v (windows error 4201)", etw.ERROR_WMI_INSTANCE_NOT_FOUND),
+		},
+		{
+			name: "access denied explains required privileges",
+			err:  fmt.Errorf("access denied when opening trace: %w", etw.ERROR_ACCESS_DENIED),
+			want: fmt.Sprintf("access denied when opening trace: %v (windows error 5); ETW sessions require running as Administrator or membership in the Performance Log Users group",
+				etw.ERROR_ACCESS_DENIED),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, errDetail(tt.err), "errDetail(%v)", tt.err)
+		})
+	}
 }
 
 func Test_buildEvent(t *testing.T) {


### PR DESCRIPTION
## Type of change
- Enhancement

## Proposed commit message
```
x-pack/filebeat/input/etw: report health status to Elastic Agent

The ETW input made no UpdateStatus calls, so under Elastic Agent it
showed only the generic Failed or Stopped state that the stateless
runner reports after Run returns. Users had no way to see that a
session was being set up, that it was consuming events, or why it had
stopped.

Lifecycle status:

- Report Starting before the session is created, Configuring while a
  realtime session is created or attached to, Running just before the
  consumer starts, and Failed at each fatal exit.
- Failure messages carry the session name, the configured provider and
  the raw Windows error code. Access denied errors spell out that ETW
  needs Administrator or Performance Log Users membership.

Per-event health:

- Events that cannot be read are tracked with the consecutive-count
  model used by Kubernetes probes and the awss3 input.
- failure_threshold (default 3) consecutive unreadable events report
  Degraded. Set to 0 to disable Degraded reporting for unreadable
  events; they are still logged and counted in the input metrics.
- recovery_threshold (default 1) consecutive readable events report
  Running again. Must be at least 1. The two thresholds are separate
  knobs because there is no reason to expect runs of good and bad
  events to have matching lengths in a failing provider.
- Both options are documented in the ETW input reference.

Fixes #44271

Assisted-By: Cursor
Co-authored-by: Cursor <cursoragent@cursor.com>
```
<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

- Closes https://github.com/elastic/beats/issues/44271

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
