### PR TITLE
[AutoOps] Collect the frozen flood stage disk watermark in cluster_settings

### DIFF
--- a/changelog/fragments/1788795811-autoops-flood-stage-frozen.yaml
+++ b/changelog/fragments/1788795811-autoops-flood-stage-frozen.yaml
@@ -1,0 +1,23 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user's deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: enhancement
+
+# Change summary; a 80ish characters long description of the change.
+summary: Collect the frozen flood stage disk watermark in AutoOps cluster settings
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: metricbeat
+
+# PR URL; optional; the PR number that added the changeset.
+# pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+issue: https://github.com/elastic/beats/issues/52341

--- a/x-pack/metricbeat/module/autoops_es/cluster_settings/data.go
+++ b/x-pack/metricbeat/module/autoops_es/cluster_settings/data.go
@@ -29,9 +29,10 @@ var (
 			"allocation": c.Dict("allocation", s.Schema{
 				"disk": c.Dict("disk", s.Schema{
 					"watermark": c.Dict("watermark", s.Schema{
-						"low":         c.Str("low", s.IgnoreAllErrors),
-						"high":        c.Str("high", s.IgnoreAllErrors),
-						"flood_stage": c.Str("flood_stage", s.IgnoreAllErrors),
+						"low":                c.Str("low", s.IgnoreAllErrors),
+						"high":               c.Str("high", s.IgnoreAllErrors),
+						"flood_stage":        c.Str("flood_stage", s.IgnoreAllErrors),
+						"flood_stage_frozen": c.Str("flood_stage.frozen", s.IgnoreAllErrors),
 					}, c.DictOptional),
 				}, c.DictOptional),
 				"node_concurrent_outgoing_recoveries": c.Str("node_concurrent_outgoing_recoveries", s.IgnoreAllErrors),

--- a/x-pack/metricbeat/module/autoops_es/cluster_settings/data_test.go
+++ b/x-pack/metricbeat/module/autoops_es/cluster_settings/data_test.go
@@ -38,6 +38,10 @@ func expectValidParsedData(t *testing.T, data metricset.FetcherData[map[string]a
 	require.ElementsMatch(t, []string{"/app/data"}, auto_ops_testing.GetObjectValue(event.MetricSetFields, "path.data"))
 	require.Equal(t, "3", auto_ops_testing.GetObjectValue(event.MetricSetFields, "serverless.search.search_power_min"))
 
+	// the frozen flood stage watermark is reported alongside the regular flood stage watermark
+	require.Equal(t, "95%", auto_ops_testing.GetObjectValue(event.MetricSetFields, "cluster.routing.allocation.disk.watermark.flood_stage"))
+	require.Equal(t, "95%", auto_ops_testing.GetObjectValue(event.MetricSetFields, "cluster.routing.allocation.disk.watermark.flood_stage_frozen"))
+
 	// schema is expected to drop this field if it appears (it does in one file)
 	require.Nil(t, auto_ops_testing.GetObjectValue(event.MetricSetFields, "ignored_field"))
 }


### PR DESCRIPTION
## Proposed commit message

The `autoops_es` `cluster_settings` metricset mapped the `low`, `high`, and `flood_stage` disk watermarks, but not `cluster.routing.allocation.disk.watermark.flood_stage.frozen`, which governs the flood stage threshold for the frozen tier.

Map it as a sibling `flood_stage_frozen` field sourced from the dotted `flood_stage.frozen` key, following the existing `max_shards_per_node_frozen` precedent. A nested output key is not an option here: `flood_stage` is already a keyword, so `flood_stage.frozen` cannot also be a subfield of it.

The dotted source key resolves both shapes Elasticsearch returns — the literal `"flood_stage.frozen"` key emitted when both settings are present (because `flood_stage` is simultaneously a leaf and a prefix, ES cannot nest it), and the nested `{"flood_stage": {"frozen": ...}}` object emitted when only the frozen setting is set. `mapstr.M.GetValue` checks the literal key before falling back to dotted traversal, so a single `c.Str("flood_stage.frozen")` covers both.

The field is added to the shared cluster schema, so it is picked up for `defaults`, `persistent`, and `transient` and follows the existing flatten precedence (`transient` > `persistent` > `defaults`). The `low`, `high`, and `flood_stage` mappings are unchanged.

Closes #52341

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments`

Note on the documentation checkbox: `_meta/fields.yml` for this metricset still describes the pre-flatten `defaults`/`persistent`/`transient` nesting removed in #48454, and never received the analogous `max_shards_per_node_frozen` field either. Rather than partially updating a stale file, this PR leaves it alone.

## Disruptive User Impact

None. This is an additive field. Existing `low`, `high`, and `flood_stage` mappings are untouched, and the new field is mapped with `s.IgnoreAllErrors` so clusters that do not report the setting are unaffected.

## How to test this PR locally

```
go test ./x-pack/metricbeat/module/autoops_es/cluster_settings/...
```

The existing `cluster_settings.my-cluster.7.17.0.json` and `cluster_settings.my-cluster.8.15.3.json` fixtures already contain `flood_stage.frozen` under `defaults`, so no fixture changes were needed. `data_test.go` now asserts both `flood_stage` and `flood_stage_frozen` are `95%`. Removing the new schema line makes both subtests fail, confirming the assertion is load-bearing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)