### PR TITLE
Add Pubsub api endpoint override for filebeats

### DIFF
--- a/changelog/fragments/1778600000-gcppubsub-api-endpoint.yaml
+++ b/changelog/fragments/1778600000-gcppubsub-api-endpoint.yaml
@@ -1,0 +1,3 @@
+kind: enhancement
+summary: Add api_endpoint configuration option to gcp-pubsub input to allow overriding the default Pub/Sub API endpoint.
+component: filebeat

--- a/docs/reference/filebeat/filebeat-input-gcp-pubsub.md
+++ b/docs/reference/filebeat/filebeat-input-gcp-pubsub.md
@@ -88,6 +88,22 @@ filebeat.inputs:
 ```
 
 
+### `api_endpoint` [_api_endpoint]
+
+```{applies_to}
+stack: ga 9.6.0
+```
+
+Optional Google Cloud Pub/Sub API endpoint to connect to. When specified, Filebeat connects to this endpoint instead of the default `pubsub.googleapis.com:443`. This is useful for connecting through Private Service Connect (PSC), custom Universe Domains, or reverse proxies.
+
+```yaml
+filebeat.inputs:
+- type: gcp-pubsub
+  . . .
+  api_endpoint: custom-pubsub-endpoint.googleapis.com:443
+```
+
+
 ## Common options [filebeat-input-gcp-pubsub-common-options]
 
 The following configuration options are supported by all inputs.

--- a/x-pack/filebeat/_meta/config/filebeat.inputs.reference.xpack.yml.tmpl
+++ b/x-pack/filebeat/_meta/config/filebeat.inputs.reference.xpack.yml.tmpl
@@ -63,6 +63,9 @@
   # Path to a JSON file containing the credentials and key used to subscribe.
   credentials_file: ${path.config}/my-pubsub-subscriber-credentials.json
 
+  # Optional API endpoint to override the default Google Cloud Pub/Sub endpoint.
+  #api_endpoint: custom-pubsub-endpoint.googleapis.com:443
+
 #------------------------------ AWS S3 input --------------------------------
 # Beta: Config options for AWS S3 input
 #- type: aws-s3

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -3107,6 +3107,9 @@ filebeat.inputs:
   # Path to a JSON file containing the credentials and key used to subscribe.
   credentials_file: ${path.config}/my-pubsub-subscriber-credentials.json
 
+  # Optional API endpoint to override the default Google Cloud Pub/Sub endpoint.
+  #api_endpoint: custom-pubsub-endpoint.googleapis.com:443
+
 #------------------------------ AWS S3 input --------------------------------
 # Beta: Config options for AWS S3 input
 #- type: aws-s3

--- a/x-pack/filebeat/input/gcppubsub/config.go
+++ b/x-pack/filebeat/input/gcppubsub/config.go
@@ -42,6 +42,9 @@ type config struct {
 	// JSON blob containing authentication credentials and key.
 	CredentialsJSON common.JSONBlob `config:"credentials_json"`
 
+	// Pub/Sub API endpoint to override the default Google Cloud Pub/Sub endpoint.
+	APIEndpoint string `config:"api_endpoint"`
+
 	// Overrides the default Pub/Sub service address and disables TLS. For testing.
 	AlternativeHost string `config:"alternative_host"`
 

--- a/x-pack/filebeat/input/gcppubsub/config_test.go
+++ b/x-pack/filebeat/input/gcppubsub/config_test.go
@@ -12,6 +12,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	conf "github.com/elastic/elastic-agent-libs/config"
 )
 
 //nolint:gosec // false positive
@@ -34,4 +36,21 @@ func TestConfigValidateGoogleAppDefaultCreds(t *testing.T) {
 	os.Setenv(googleApplicationCredentialsVar, filepath.Clean("testdata/fake.json"))
 	c := defaultConfig()
 	assert.NoError(t, c.Validate())
+}
+
+func TestConfigAPIEndpoint(t *testing.T) {
+	t.Setenv(googleApplicationCredentialsVar, filepath.Clean("testdata/fake.json"))
+
+	cfg, err := conf.NewConfigFrom(map[string]any{
+		"project_id":   "test-project",
+		"topic":        "test-topic",
+		"subscription": map[string]any{"name": "test-sub"},
+		"api_endpoint": "custom-endpoint.googleapis.com:443",
+	})
+	assert.NoError(t, err, "failed to create config from map")
+
+	c := defaultConfig()
+	err = cfg.Unpack(&c)
+	assert.NoError(t, err, "failed to unpack config")
+	assert.Equal(t, "custom-endpoint.googleapis.com:443", c.APIEndpoint, "APIEndpoint does not match expected value")
 }

--- a/x-pack/filebeat/input/gcppubsub/input.go
+++ b/x-pack/filebeat/input/gcppubsub/input.go
@@ -361,6 +361,13 @@ func (in *pubsubInput) newPubsubClient(ctx context.Context) (*pubsub.Client, err
 		opts = append(opts, option.WithGRPCConn(conn), option.WithTelemetryDisabled())
 	}
 
+	if in.APIEndpoint != "" {
+		in.log.Infof("Configuring GCP Pub/Sub client with custom API endpoint: %s", in.APIEndpoint)
+		opts = append(opts, option.WithEndpoint(in.APIEndpoint))
+	} else {
+		in.log.Info("Configuring GCP Pub/Sub client with default Google Cloud API endpoint")
+	}
+
 	if in.CredentialsFile != "" {
 		opts = append(opts, option.WithCredentialsFile(in.CredentialsFile))
 	} else if len(in.CredentialsJSON) > 0 {

--- a/x-pack/filebeat/input/gcppubsub/pubsub_test.go
+++ b/x-pack/filebeat/input/gcppubsub/pubsub_test.go
@@ -314,3 +314,42 @@ func TestEndToEndACK(t *testing.T) {
 		}
 	})
 }
+
+func TestAPIEndpointOverride(t *testing.T) {
+	cfg := defaultTestConfig()
+	err := cfg.SetString("api_endpoint", -1, "invalid-custom-endpoint.example.com:443")
+	assert.NoError(t, err, "failed to set api_endpoint configuration")
+
+	runTest(t, cfg, func(client *pubsub.Client, input *pubsubInput, out *stubOutleter, t *testing.T) {
+		err := input.run()
+		assert.Error(t, err, "expected input.run() to fail when using an unreachable custom API endpoint")
+	})
+}
+
+func TestAPIEndpointOverrideSuccess(t *testing.T) {
+	host := testutil.EnsureEmulator(t)
+
+	cfg := defaultTestConfig()
+	err := cfg.SetString("api_endpoint", -1, host)
+	assert.NoError(t, err, "failed to set api_endpoint configuration")
+
+	runTest(t, cfg, func(client *pubsub.Client, input *pubsubInput, out *stubOutleter, t *testing.T) {
+		testutil.CreateTopic(t, client)
+		testutil.CreateSubscription(t, emulatorSubscription, client)
+		testutil.PublishMessages(t, client, 5)
+
+		var group errgroup.Group
+		group.Go(input.run)
+
+		time.AfterFunc(10*time.Second, func() { out.Close() })
+		events, ok := out.waitForEvents(5)
+		if !ok {
+			t.Errorf("Expected 5 events, but got %d.", len(events))
+		}
+		input.Stop()
+
+		if err := group.Wait(); err != nil {
+			t.Errorf("unexpected error from errgroup: %v", err)
+		}
+	})
+}

--- a/x-pack/filebeat/input/gcppubsub/testutil/testutil.go
+++ b/x-pack/filebeat/input/gcppubsub/testutil/testutil.go
@@ -28,23 +28,31 @@ const (
 
 var once sync.Once
 
-func TestSetup(t *testing.T) (*pubsub.Client, context.CancelFunc) {
+// EnsureEmulator ensures the Pub/Sub emulator is running and returns its host address.
+func EnsureEmulator(t *testing.T) string {
 	t.Helper()
 
-	var host string
 	if IsInDockerIntegTestEnv() {
 		// We're running inside of integration test environment so
 		// make sure that that googlepubsub container is running.
-		host = compose.EnsureUp(t, "googlepubsub").Host()
+		host := compose.EnsureUp(t, "googlepubsub").Host()
 		os.Setenv("PUBSUB_EMULATOR_HOST", host)
-	} else {
-		host = os.Getenv("PUBSUB_EMULATOR_HOST")
-		if host == "" {
-			t.Skip("PUBSUB_EMULATOR_HOST is not set in environment. You can start " +
-				"the emulator with \"docker compose up\" from the _meta directory. " +
-				"The default address is PUBSUB_EMULATOR_HOST=localhost:8432")
-		}
+		return host
 	}
+
+	host := os.Getenv("PUBSUB_EMULATOR_HOST")
+	if host == "" {
+		t.Skip("PUBSUB_EMULATOR_HOST is not set in environment. You can start " +
+			"the emulator with \"docker compose up\" from the _meta directory. " +
+			"The default address is PUBSUB_EMULATOR_HOST=localhost:8432")
+	}
+	return host
+}
+
+func TestSetup(t *testing.T) (*pubsub.Client, context.CancelFunc) {
+	t.Helper()
+
+	host := EnsureEmulator(t)
 
 	once.Do(func() {
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Enhancement
-->

## Proposed commit message
```
[gcp-pubsub] Add api_endpoint configuration option to support custom endpoints

Add an optional api_endpoint configuration setting to the Google Cloud
Pub/Sub input to allow users to override the default service endpoint.

By default, the input connects to pubsub.googleapis.com:443 over the
public internet. In enterprise and high-security environments, direct
public internet egress is often prohibited, and workloads must route
Pub/Sub traffic through Google Cloud Private Service Connect (PSC),
private VPC endpoints, reverse proxies, or custom Universe Domains.
Without the ability to configure a custom endpoint, Filebeat cannot
connect to Pub/Sub in these restricted network topologies. Specifying
api_endpoint configures the Pub/Sub client to target the supplied
endpoint instead of the default.
```

WHAT:
- Added an optional `api_endpoint` configuration field to the GCP Pub/Sub input (`x-pack/filebeat/input/gcppubsub/config.go`).
- Configured the Google Cloud Pub/Sub client constructor (`x-pack/filebeat/input/gcppubsub/input.go`) to apply `option.WithEndpoint(in.APIEndpoint)` when `api_endpoint` is specified.
- Added info log statements indicating whether a custom or default API endpoint is in use.
- Updated documentation and reference configurations in `x-pack/filebeat/filebeat.reference.yml` and `x-pack/filebeat/_meta/config/filebeat.inputs.reference.xpack.yml.tmpl`.
- Added unit test `TestConfigAPIEndpoint` and integration tests `TestAPIEndpointOverride` / `TestAPIEndpointOverrideSuccess` in `x-pack/filebeat/input/gcppubsub/`.
- Created changelog fragment `changelog/fragments/1778600000-gcppubsub-api-endpoint.yaml`.

WHY:
Enables users to override the default Google Cloud Pub/Sub endpoint (`pubsub.googleapis.com:443`). This is required for connecting through custom enterprise endpoints, Google Cloud Private Service Connect (PSC), custom Universe Domains (such as isolated cloud regions or testing environments), or reverse proxies where direct public internet egress to default endpoints is prohibited.


<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->
None. The api_endpoint setting is optional and defaults to empty. When omitted, Filebeat preserves existing behavior by utilizing the default Google Cloud Pub/Sub API endpoint.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

1. Run Unit Tests
Run the configuration validation tests:
`go test -v -run TestConfigAPIEndpoint ./x-pack/filebeat/input/gcppubsub/...`

2. Run Integration Tests (Emulator)
Start the Pub/Sub emulator and run the integration test suite:
`cd x-pack/filebeat/input/gcppubsub/_meta
docker compose up -d
export PUBSUB_EMULATOR_HOST=localhost:8432
go test -v -run 'TestAPIEndpointOverride.*' ./x-pack/filebeat/input/gcppubsub/...
docker compose down
`

3. Manual Verification with Filebeat
Add the option to your filebeat.yml:
`filebeat.inputs:
- type: gcp-pubsub
  project_id: "my-project"
  topic: "my-topic"
  subscription.name: "my-subscription"
  api_endpoint: "custom-pubsub-endpoint.googleapis.com:443"
  credentials_file: "${path.config}/credentials.json"
`

Launch Filebeat and verify the log output:
`Configuring GCP Pub/Sub client with custom API endpoint: custom-pubsub-endpoint.googleapis.com:443
`

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #48923 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

1. Private Service Connect (PSC) / VPC Service Controls: Organizations that route Google Cloud Pub/Sub traffic over dedicated internal IP endpoints or private endpoints rather than over public internet gateways.
2. Custom Universe Domains / Government Clouds: Deployments in custom Google Cloud Universe domains or isolated regions that expose service endpoints outside standard .googleapis.com.
3. Enterprise Proxies & Gateways: Environments routing outbound telemetry traffic through local API gateways or reverse proxies.

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->
<img width="1110" height="124" alt="Screenshot 2026-09-03 at 10 50 16 AM" src="https://github.com/user-attachments/assets/55e8341f-8ab2-4c3e-9009-1652273a3284" />

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
{"log.level":"info","@timestamp":"2026-09-03T...","log.logger":"gcp.pubsub","log.origin":{"file.name":"gcppubsub/input.go","file.line":365},"message":"Configuring GCP Pub/Sub client with custom API endpoint: custom-pubsub-endpoint.googleapis.com:443",...}
