### PR TITLE
[Heartbeat] Apply Fleet job limits from output unit config

### DIFF
--- a/changelog/fragments/1788861796-codex-heartbeat-fleet-job-limits.yaml
+++ b/changelog/fragments/1788861796-codex-heartbeat-fleet-job-limits.yaml
@@ -1,0 +1,45 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: enhancement
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: Allow Fleet to update Heartbeat per-type scheduler job limits
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# description:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: heartbeat
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: https://github.com/elastic/beats/issues/53085

--- a/heartbeat/beater/heartbeat.go
+++ b/heartbeat/beater/heartbeat.go
@@ -143,6 +143,9 @@ func New(b *beat.Beat, rawConfig *conf.C) (beat.Beater, error) {
 		trace:  trace,
 		logger: logger,
 	}
+	if manager, ok := b.Manager.(management.OutputConfigHandlerRegistrar); ok {
+		manager.SetOutputConfigHandler(bt.applyOutputJobLimits)
+	}
 	runFromID := "<unknown location>"
 	if parsedConfig.RunFrom != nil {
 		runFromID = parsedConfig.RunFrom.ID

--- a/heartbeat/beater/output_job_limits.go
+++ b/heartbeat/beater/output_job_limits.go
@@ -1,0 +1,53 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package beater
+
+import (
+	"github.com/elastic/beats/v7/heartbeat/config"
+	conf "github.com/elastic/elastic-agent-libs/config"
+)
+
+// applyOutputJobLimits applies the Heartbeat-specific control-plane fields
+// carried by the Elastic Agent output unit. Input units only carry monitors,
+// so per-type limits must be read here rather than from every stream.
+func (bt *Heartbeat) applyOutputJobLimits(outputConfig *conf.C) {
+	if outputConfig == nil {
+		bt.logger.Warn("received empty output expected config; retaining current job limits")
+		return
+	}
+
+	heartbeatConfig, err := outputConfig.Child("heartbeat", -1)
+	if err != nil {
+		bt.logger.Debug("output expected config has no heartbeat.jobs; retaining current job limits")
+		return
+	}
+	jobsConfig, err := heartbeatConfig.Child("jobs", -1)
+	if err != nil {
+		bt.logger.Warn("output expected config has malformed heartbeat.jobs; retaining current job limits")
+		return
+	}
+
+	limits := make(map[string]*config.JobLimit)
+	if err := jobsConfig.Unpack(&limits); err != nil {
+		bt.logger.Warnf("could not unpack output expected heartbeat.jobs: %v; retaining current job limits", err)
+		return
+	}
+	if err := bt.scheduler.ApplyJobLimits(limits); err != nil {
+		bt.logger.Warnf("could not apply output expected heartbeat.jobs: %v; retaining current job limits", err)
+	}
+}

--- a/heartbeat/beater/output_job_limits_test.go
+++ b/heartbeat/beater/output_job_limits_test.go
@@ -1,0 +1,158 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package beater
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	hbconfig "github.com/elastic/beats/v7/heartbeat/config"
+	"github.com/elastic/beats/v7/heartbeat/scheduler"
+	conf "github.com/elastic/elastic-agent-libs/config"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
+	"github.com/elastic/elastic-agent-libs/monitoring"
+)
+
+func TestOutputExpectedConfigJobLimitsOverrideStartupFallbacks(t *testing.T) {
+	t.Setenv("SYNTHETICS_LIMIT_BROWSER", "3")
+	t.Setenv("SYNTHETICS_LIMIT_API", "5")
+
+	fallbacks := hbconfig.DefaultConfig(logptest.NewTestingLogger(t, ""))
+	heartbeatConfig, err := conf.NewConfigFrom(map[string]any{
+		"jobs": map[string]any{
+			"browser": map[string]any{"limit": 2},
+			"api":     map[string]any{"limit": 6},
+		},
+	})
+	require.NoError(t, err, "heartbeat.yml fallback config should parse")
+	require.NoError(t, heartbeatConfig.Unpack(fallbacks), "heartbeat.yml should override environment limits")
+
+	s := scheduler.Create(10, monitoring.NewRegistry(), time.Local, fallbacks.Jobs, false, logptest.NewTestingLogger(t, ""))
+	defer s.Stop()
+	bt := &Heartbeat{scheduler: s, logger: logptest.NewTestingLogger(t, "")}
+
+	outputConfig, err := conf.NewConfigFrom(map[string]any{
+		"heartbeat": map[string]any{
+			"jobs": map[string]any{
+				"browser": map[string]any{"limit": 1},
+			},
+		},
+	})
+	require.NoError(t, err, "output expected config should parse")
+	bt.applyOutputJobLimits(outputConfig)
+
+	firstStarted, firstRelease, firstDone := startBlockingMonitor(t, s, "browser", "first")
+	requireClosed(t, firstStarted, "first browser monitor should start")
+	secondStarted, secondRelease, secondDone := startBlockingMonitor(t, s, "browser", "second")
+	assertNotClosed(t, secondStarted, "Fleet browser limit should override heartbeat.yml and environment limits")
+
+	apiOnlyConfig, err := conf.NewConfigFrom(map[string]any{
+		"heartbeat": map[string]any{
+			"jobs": map[string]any{
+				"api": map[string]any{"limit": 7},
+			},
+		},
+	})
+	require.NoError(t, err, "partial output expected config should parse")
+	bt.applyOutputJobLimits(apiOnlyConfig)
+	requireClosed(t, secondStarted, "an omitted Fleet type should return to its heartbeat.yml fallback")
+
+	close(firstRelease)
+	close(secondRelease)
+	requireClosed(t, firstDone, "first browser monitor should finish")
+	requireClosed(t, secondDone, "second browser monitor should finish")
+}
+
+func TestOutputExpectedConfigInvalidJobsKeepLastGoodLimits(t *testing.T) {
+	s := scheduler.Create(10, monitoring.NewRegistry(), time.Local, map[string]*hbconfig.JobLimit{
+		"browser": {Limit: 2},
+	}, false, logptest.NewTestingLogger(t, ""))
+	defer s.Stop()
+	bt := &Heartbeat{scheduler: s, logger: logptest.NewTestingLogger(t, "")}
+
+	valid, err := conf.NewConfigFrom(map[string]any{
+		"heartbeat": map[string]any{"jobs": map[string]any{"browser": map[string]any{"limit": 1}}},
+	})
+	require.NoError(t, err, "valid output expected config should parse")
+	bt.applyOutputJobLimits(valid)
+
+	firstStarted, firstRelease, firstDone := startBlockingMonitor(t, s, "browser", "first")
+	requireClosed(t, firstStarted, "first browser monitor should start")
+	secondStarted, secondRelease, secondDone := startBlockingMonitor(t, s, "browser", "second")
+	assertNotClosed(t, secondStarted, "valid Fleet limit should constrain browser monitors")
+
+	malformed, err := conf.NewConfigFrom(map[string]any{
+		"heartbeat": map[string]any{"jobs": "not-a-map"},
+	})
+	require.NoError(t, err, "malformed field container should still parse")
+	bt.applyOutputJobLimits(malformed)
+	assertNotClosed(t, secondStarted, "malformed output config must retain the last good limit")
+
+	missing, err := conf.NewConfigFrom(map[string]any{"hosts": []string{"https://example.invalid"}})
+	require.NoError(t, err, "ordinary output config should parse")
+	bt.applyOutputJobLimits(missing)
+	assertNotClosed(t, secondStarted, "missing heartbeat.jobs must retain the last good limit")
+
+	close(firstRelease)
+	requireClosed(t, firstDone, "first browser monitor should finish")
+	requireClosed(t, secondStarted, "waiting monitor should run when its slot is released")
+	close(secondRelease)
+	requireClosed(t, secondDone, "second browser monitor should finish")
+}
+
+type immediateSchedule struct{}
+
+func (immediateSchedule) Next(now time.Time) time.Time { return now.Add(time.Hour) }
+func (immediateSchedule) RunOnInit() bool              { return true }
+
+func startBlockingMonitor(t *testing.T, s *scheduler.Scheduler, jobType, id string) (started, release, done chan struct{}) {
+	t.Helper()
+	started = make(chan struct{})
+	release = make(chan struct{})
+	done = make(chan struct{})
+	_, err := s.Add(immediateSchedule{}, nil, id, func(context.Context) []scheduler.TaskFunc {
+		close(started)
+		<-release
+		close(done)
+		return nil
+	}, jobType)
+	require.NoError(t, err, "blocking monitor should register with the scheduler")
+	return started, release, done
+}
+
+func assertNotClosed(t *testing.T, ch <-chan struct{}, message string) {
+	t.Helper()
+	select {
+	case <-ch:
+		assert.Fail(t, message)
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+func requireClosed(t *testing.T, ch <-chan struct{}, message string) {
+	t.Helper()
+	select {
+	case <-ch:
+	case <-time.After(5 * time.Second):
+		require.FailNow(t, message)
+	}
+}

--- a/heartbeat/config/config.go
+++ b/heartbeat/config/config.go
@@ -55,6 +55,29 @@ type JobLimit struct {
 	Limit int64 `config:"limit" validate:"min=0"`
 }
 
+// supportedJobTypes is the canonical list of monitor types Heartbeat schedules.
+// It is hard coded to avoid a cycle with the current plugin system.
+// TODO: refactor plugin system to DRY this up
+var supportedJobTypes = [...]string{"http", "tcp", "icmp", "browser", "api"}
+
+// SupportedJobTypes returns the monitor types Heartbeat can schedule. The
+// returned slice is a copy, so callers cannot alter the list.
+func SupportedJobTypes() []string {
+	return append([]string(nil), supportedJobTypes[:]...)
+}
+
+// IsSupportedJobType reports whether jobType is one of the monitor types
+// returned by SupportedJobTypes.
+func IsSupportedJobType(jobType string) bool {
+	for _, supported := range supportedJobTypes {
+		if supported == jobType {
+			return true
+		}
+	}
+
+	return false
+}
+
 // Scheduler defines the syntax of a heartbeat.yml scheduler block.
 type Scheduler struct {
 	Limit    int64  `config:"limit"  validate:"min=0"`
@@ -71,10 +94,8 @@ func DefaultConfig(logger *logp.Logger) *Config {
 		"api": {Limit: 4},
 	}
 
-	// Read the env key SYNTHETICS_LIMIT_{TYPE} for each type of monitor to set scaling limits
-	// hard coded list of types to avoid cycles in current plugin system.
-	// TODO: refactor plugin system to DRY this up
-	for _, t := range []string{"http", "tcp", "icmp", "browser", "api"} {
+	// Read the env key SYNTHETICS_LIMIT_{TYPE} for each type of monitor to set scaling limits.
+	for _, t := range SupportedJobTypes() {
 		envKey := fmt.Sprintf("SYNTHETICS_LIMIT_%s", strings.ToUpper(t))
 		if limitStr := os.Getenv(envKey); limitStr != "" {
 			tLimitVal, err := strconv.ParseInt(limitStr, 10, 64)

--- a/heartbeat/scheduler/job_limit_semaphore.go
+++ b/heartbeat/scheduler/job_limit_semaphore.go
@@ -1,0 +1,111 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package scheduler
+
+import (
+	"context"
+	"sync"
+)
+
+// jobLimitSemaphore is a resizable, per-type job limiter. semaphore.Weighted
+// is suitable for the immutable global scheduler limit, but cannot shrink
+// safely while jobs are holding slots. This limiter drains an over-subscribed
+// type to its new cap without interrupting in-flight jobs.
+type jobLimitSemaphore struct {
+	mu      sync.Mutex
+	limit   int64
+	running int64
+	waiters []chan struct{}
+}
+
+func newJobLimitSemaphore(limit int64) *jobLimitSemaphore {
+	return &jobLimitSemaphore{limit: limit}
+}
+
+func (s *jobLimitSemaphore) acquire(ctx context.Context) error {
+	s.mu.Lock()
+	if len(s.waiters) == 0 && s.canAcquire() {
+		s.running++
+		s.mu.Unlock()
+		return nil
+	}
+
+	waiter := make(chan struct{})
+	s.waiters = append(s.waiters, waiter)
+	s.mu.Unlock()
+
+	select {
+	case <-waiter:
+		return nil
+	case <-ctx.Done():
+		s.mu.Lock()
+		if s.removeWaiter(waiter) {
+			s.mu.Unlock()
+			return ctx.Err()
+		}
+
+		// A slot was assigned concurrently with cancellation. Return that
+		// slot before honoring cancellation so a later waiter cannot deadlock.
+		s.running--
+		s.grantWaiters()
+		s.mu.Unlock()
+		return ctx.Err()
+	}
+}
+
+func (s *jobLimitSemaphore) release() {
+	s.mu.Lock()
+	s.running--
+	s.grantWaiters()
+	s.mu.Unlock()
+}
+
+func (s *jobLimitSemaphore) setLimit(limit int64) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.limit == limit {
+		return false
+	}
+	s.limit = limit
+	s.grantWaiters()
+	return true
+}
+
+func (s *jobLimitSemaphore) canAcquire() bool {
+	return s.limit == 0 || s.running < s.limit
+}
+
+func (s *jobLimitSemaphore) grantWaiters() {
+	for len(s.waiters) > 0 && s.canAcquire() {
+		waiter := s.waiters[0]
+		s.waiters = s.waiters[1:]
+		s.running++
+		close(waiter)
+	}
+}
+
+func (s *jobLimitSemaphore) removeWaiter(waiter chan struct{}) bool {
+	for i, queued := range s.waiters {
+		if queued == waiter {
+			s.waiters = append(s.waiters[:i], s.waiters[i+1:]...)
+			return true
+		}
+	}
+	return false
+}

--- a/heartbeat/scheduler/job_limits_test.go
+++ b/heartbeat/scheduler/job_limits_test.go
@@ -1,0 +1,153 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package scheduler
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/beats/v7/heartbeat/config"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
+	"github.com/elastic/elastic-agent-libs/monitoring"
+)
+
+func TestApplyJobLimitsTransitionsBetweenLimitedAndUnlimited(t *testing.T) {
+	const jobType = "http"
+	s := Create(10, monitoring.NewRegistry(), tarawaTime(), map[string]*config.JobLimit{
+		jobType: {Limit: 0},
+	}, false, logptest.NewTestingLogger(t, ""))
+	defer s.Stop()
+
+	require.NoError(t, s.ApplyJobLimits(map[string]*config.JobLimit{
+		jobType: {Limit: 1},
+	}), "Fleet should be able to add a limit to an unlimited type")
+
+	firstStarted, firstRelease, firstDone := startBlockingJob(t, s, jobType, "first")
+	requireClosed(t, firstStarted, "first limited job should start")
+	secondStarted, secondRelease, secondDone := startBlockingJob(t, s, jobType, "second")
+	assertNotClosed(t, secondStarted, "second job should wait for the Fleet limit")
+
+	require.NoError(t, s.ApplyJobLimits(map[string]*config.JobLimit{
+		jobType: {Limit: 0},
+	}), "Fleet should be able to remove a type limit")
+	requireClosed(t, secondStarted, "removing the limit should release the waiting job")
+
+	close(firstRelease)
+	close(secondRelease)
+	requireClosed(t, firstDone, "first job should finish")
+	requireClosed(t, secondDone, "second job should finish")
+}
+
+func TestApplyJobLimitsDrainsWhenReducingConcurrency(t *testing.T) {
+	const jobType = "browser"
+	s := Create(10, monitoring.NewRegistry(), tarawaTime(), map[string]*config.JobLimit{
+		jobType: {Limit: 3},
+	}, false, logptest.NewTestingLogger(t, ""))
+	defer s.Stop()
+
+	started := make([]chan struct{}, 3)
+	release := make([]chan struct{}, 3)
+	done := make([]chan struct{}, 3)
+	for i := range started {
+		started[i], release[i], done[i] = startBlockingJob(t, s, jobType, "initial")
+		requireClosed(t, started[i], "initial jobs should all start before the cap is reduced")
+	}
+
+	require.NoError(t, s.ApplyJobLimits(map[string]*config.JobLimit{
+		jobType: {Limit: 1},
+	}), "Fleet should be able to reduce the cap")
+
+	fourthStarted, fourthRelease, fourthDone := startBlockingJob(t, s, jobType, "fourth")
+	assertNotClosed(t, fourthStarted, "new work should wait while the old cap drains")
+
+	for i := 0; i < 2; i++ {
+		close(release[i])
+		requireClosed(t, done[i], "released in-flight job should finish")
+		assertNotClosed(t, fourthStarted, "new work must not start above the reduced cap")
+	}
+
+	close(release[2])
+	requireClosed(t, done[2], "last over-subscribed job should finish")
+	requireClosed(t, fourthStarted, "new work should start after the scheduler drains to the cap")
+	close(fourthRelease)
+	requireClosed(t, fourthDone, "waiting job should finish without deadlocking")
+}
+
+func TestApplyJobLimitsRestoresStartupFallbacksForOmittedTypes(t *testing.T) {
+	s := Create(10, monitoring.NewRegistry(), tarawaTime(), map[string]*config.JobLimit{
+		"browser": {Limit: 2},
+		"api":     {Limit: 4},
+	}, false, logptest.NewTestingLogger(t, ""))
+	defer s.Stop()
+
+	require.NoError(t, s.ApplyJobLimits(map[string]*config.JobLimit{
+		"browser": {Limit: 1},
+	}), "Fleet browser limit should apply")
+	assert.Equal(t, int64(1), jobLimit(t, s, "browser"), "Fleet limit should take precedence over the startup fallback")
+
+	require.NoError(t, s.ApplyJobLimits(map[string]*config.JobLimit{
+		"api": {Limit: 5},
+	}), "Fleet API limit should apply")
+	assert.Equal(t, int64(2), jobLimit(t, s, "browser"), "an omitted Fleet type should return to its startup fallback")
+	assert.Equal(t, int64(5), jobLimit(t, s, "api"), "the provided Fleet type should use its new limit")
+}
+
+func startBlockingJob(t *testing.T, s *Scheduler, jobType, id string) (started, release, done chan struct{}) {
+	started = make(chan struct{})
+	release = make(chan struct{})
+	done = make(chan struct{})
+	go func() {
+		_ = newSchedJob(context.Background(), s, id, jobType, func(context.Context) []TaskFunc {
+			close(started)
+			<-release
+			return nil
+		}, logptest.NewTestingLogger(t, "")).run()
+		close(done)
+	}()
+	return started, release, done
+}
+
+func jobLimit(t *testing.T, s *Scheduler, jobType string) int64 {
+	t.Helper()
+	sem := s.getJobLimitSem(jobType)
+	sem.mu.Lock()
+	defer sem.mu.Unlock()
+	return sem.limit
+}
+
+func assertNotClosed(t *testing.T, ch <-chan struct{}, message string) {
+	t.Helper()
+	select {
+	case <-ch:
+		assert.Fail(t, message)
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+func requireClosed(t *testing.T, ch <-chan struct{}, message string) {
+	t.Helper()
+	select {
+	case <-ch:
+	case <-time.After(5 * time.Second):
+		require.FailNow(t, message)
+	}
+}

--- a/heartbeat/scheduler/schedjob.go
+++ b/heartbeat/scheduler/schedjob.go
@@ -23,8 +23,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"golang.org/x/sync/semaphore"
-
 	"github.com/elastic/elastic-agent-libs/logp"
 )
 
@@ -34,7 +32,7 @@ type schedJob struct {
 	scheduler   *Scheduler
 	wg          *sync.WaitGroup
 	entrypoint  TaskFunc
-	jobLimitSem *semaphore.Weighted
+	jobLimitSem *jobLimitSemaphore
 	activeTasks atomic.Int64
 	logger      *logp.Logger
 }
@@ -47,7 +45,7 @@ func newSchedJob(ctx context.Context, s *Scheduler, id string, jobType string, t
 		id:          id,
 		ctx:         ctx,
 		scheduler:   s,
-		jobLimitSem: s.jobLimitSem[jobType],
+		jobLimitSem: s.getJobLimitSem(jobType),
 		entrypoint:  task,
 		wg:          &sync.WaitGroup{},
 		logger:      logger,
@@ -59,17 +57,14 @@ func newSchedJob(ctx context.Context, s *Scheduler, id string, jobType string, t
 // recursively.
 // The wait group passed into this function expects to already have its count incremented by one.
 func (sj *schedJob) run() (startedAt time.Time) {
+	err := sj.jobLimitSem.acquire(sj.ctx)
+	if err != nil {
+		sj.logger.Errorf("could not acquire job limit: %v", err)
+		return time.Now()
+	}
+	defer sj.jobLimitSem.release()
 	sj.wg.Add(1)
 	sj.activeTasks.Add(1)
-	if sj.jobLimitSem != nil {
-		err := sj.jobLimitSem.Acquire(sj.ctx, 1)
-		// Defer release only if acquired
-		if err == nil {
-			defer sj.jobLimitSem.Release(1)
-		} else {
-			sj.logger.Errorf("could not acquire semaphore: %v", err)
-		}
-	}
 
 	startedAt = sj.runTask(sj.entrypoint)
 

--- a/heartbeat/scheduler/scheduler.go
+++ b/heartbeat/scheduler/scheduler.go
@@ -41,17 +41,19 @@ var ErrInvalidTransition = fmt.Errorf("invalid state transition")
 
 // Scheduler represents our async timer based scheduler.
 type Scheduler struct {
-	limit       int64
-	limitSem    *semaphore.Weighted
-	location    *time.Location
-	timerQueue  *timerqueue.TimerQueue
-	ctx         context.Context
-	cancelCtx   context.CancelFunc
-	stats       schedulerStats
-	jobLimitSem map[string]*semaphore.Weighted
-	runOnce     bool
-	runOnceWg   *sync.WaitGroup
-	logger      *logp.Logger
+	limit             int64
+	limitSem          *semaphore.Weighted
+	location          *time.Location
+	timerQueue        *timerqueue.TimerQueue
+	ctx               context.Context
+	cancelCtx         context.CancelFunc
+	stats             schedulerStats
+	jobLimitMu        sync.Mutex
+	jobLimitSem       map[string]*jobLimitSemaphore
+	fallbackJobLimits map[string]*config.JobLimit
+	runOnce           bool
+	runOnceWg         *sync.WaitGroup
+	logger            *logp.Logger
 }
 
 type schedulerStats struct {
@@ -74,17 +76,6 @@ type Schedule interface {
 	RunOnInit() bool
 }
 
-func getJobLimitSem(jobLimitByType map[string]*config.JobLimit, logger *logp.Logger) map[string]*semaphore.Weighted {
-	jobLimitSem := map[string]*semaphore.Weighted{}
-	for jobType, jobLimit := range jobLimitByType {
-		if jobLimit.Limit > 0 {
-			logger.Infof("limiting to %d concurrent jobs for '%s' type", jobLimit.Limit, jobType)
-			jobLimitSem[jobType] = semaphore.NewWeighted(jobLimit.Limit)
-		}
-	}
-	return jobLimitSem
-}
-
 // NewWithLocation creates a new Scheduler using the given runAt zone.
 func Create(
 	limit int64,
@@ -104,17 +95,19 @@ func Create(
 	activeJobsGauge := monitoring.NewUint(registry, "jobs.active")
 	activeTasksGauge := monitoring.NewUint(registry, "tasks.active")
 	waitingTasksGauge := monitoring.NewUint(registry, "tasks.waiting")
+	fallbackJobLimits := cloneJobLimits(jobLimitByType)
 
 	sched := &Scheduler{
-		limit:       limit,
-		location:    location,
-		ctx:         ctx,
-		cancelCtx:   cancelCtx,
-		limitSem:    semaphore.NewWeighted(limit),
-		jobLimitSem: getJobLimitSem(jobLimitByType, logger),
-		timerQueue:  timerqueue.NewTimerQueue(ctx),
-		runOnce:     runOnce,
-		runOnceWg:   &sync.WaitGroup{},
+		limit:             limit,
+		location:          location,
+		ctx:               ctx,
+		cancelCtx:         cancelCtx,
+		limitSem:          semaphore.NewWeighted(limit),
+		jobLimitSem:       newJobLimitSem(fallbackJobLimits, logger),
+		fallbackJobLimits: fallbackJobLimits,
+		timerQueue:        timerqueue.NewTimerQueue(ctx),
+		runOnce:           runOnce,
+		runOnceWg:         &sync.WaitGroup{},
 
 		stats: schedulerStats{
 			activeJobs:         activeJobsGauge,
@@ -129,6 +122,89 @@ func Create(
 	go sched.missedDeadlineReporter()
 
 	return sched
+}
+
+// ApplyJobLimits overlays Fleet output-unit limits on the limits supplied by
+// heartbeat.yml and SYNTHETICS_LIMIT_* at startup. Omitted types return to
+// their original fallback instead of retaining an older Fleet value.
+func (s *Scheduler) ApplyJobLimits(overrides map[string]*config.JobLimit) error {
+	effective := cloneJobLimits(s.fallbackJobLimits)
+	for jobType, jobLimit := range overrides {
+		if !config.IsSupportedJobType(jobType) {
+			continue
+		}
+		if jobLimit == nil {
+			return fmt.Errorf("job limit for %q is nil", jobType)
+		}
+		if jobLimit.Limit < 0 {
+			return fmt.Errorf("job limit for %q must not be negative", jobType)
+		}
+		effective[jobType] = &config.JobLimit{Limit: jobLimit.Limit}
+	}
+
+	s.jobLimitMu.Lock()
+	defer s.jobLimitMu.Unlock()
+
+	for _, jobType := range config.SupportedJobTypes() {
+		limit := jobLimitValue(effective[jobType])
+		jobLimitSem, exists := s.jobLimitSem[jobType]
+		if !exists {
+			jobLimitSem = newJobLimitSemaphore(limit)
+			s.jobLimitSem[jobType] = jobLimitSem
+			continue
+		}
+		if !jobLimitSem.setLimit(limit) {
+			continue
+		}
+		if limit == 0 {
+			s.logger.Infof("removing concurrent job limit for '%s' type", jobType)
+		} else {
+			s.logger.Infof("limiting to %d concurrent jobs for '%s' type", limit, jobType)
+		}
+	}
+
+	return nil
+}
+
+func (s *Scheduler) getJobLimitSem(jobType string) *jobLimitSemaphore {
+	s.jobLimitMu.Lock()
+	defer s.jobLimitMu.Unlock()
+
+	jobLimitSem, exists := s.jobLimitSem[jobType]
+	if !exists {
+		jobLimitSem = newJobLimitSemaphore(jobLimitValue(s.fallbackJobLimits[jobType]))
+		s.jobLimitSem[jobType] = jobLimitSem
+	}
+	return jobLimitSem
+}
+
+func newJobLimitSem(jobLimits map[string]*config.JobLimit, logger interface{ Infof(string, ...any) }) map[string]*jobLimitSemaphore {
+	jobLimitSem := make(map[string]*jobLimitSemaphore, len(jobLimits))
+	for jobType, jobLimit := range jobLimits {
+		limit := jobLimitValue(jobLimit)
+		jobLimitSem[jobType] = newJobLimitSemaphore(limit)
+		if limit > 0 {
+			logger.Infof("limiting to %d concurrent jobs for '%s' type", limit, jobType)
+		}
+	}
+	return jobLimitSem
+}
+
+func cloneJobLimits(jobLimits map[string]*config.JobLimit) map[string]*config.JobLimit {
+	cloned := make(map[string]*config.JobLimit, len(jobLimits))
+	for jobType, jobLimit := range jobLimits {
+		if jobLimit != nil {
+			cloned[jobType] = &config.JobLimit{Limit: jobLimit.Limit}
+		}
+	}
+	return cloned
+}
+
+func jobLimitValue(jobLimit *config.JobLimit) int64 {
+	if jobLimit == nil || jobLimit.Limit < 1 {
+		return 0
+	}
+	return jobLimit.Limit
 }
 
 func (s *Scheduler) missedDeadlineReporter() {

--- a/libbeat/management/management.go
+++ b/libbeat/management/management.go
@@ -29,6 +29,16 @@ import (
 // DebugK used as key for all things central management
 var DebugK = "centralmgmt"
 
+// OutputConfigHandler receives the raw expected configuration for an Elastic
+// Agent output unit after the output has reloaded successfully.
+type OutputConfigHandler func(*config.C)
+
+// OutputConfigHandlerRegistrar is implemented by managers that can deliver
+// raw Elastic Agent output-unit configuration changes to a Beat.
+type OutputConfigHandlerRegistrar interface {
+	SetOutputConfigHandler(OutputConfigHandler)
+}
+
 // Manager interacts with the beat to provide status updates and to receive
 // configurations.
 type Manager interface {

--- a/x-pack/libbeat/management/managerV2.go
+++ b/x-pack/libbeat/management/managerV2.go
@@ -74,6 +74,10 @@ type BeatV2Manager struct {
 	status  status.Status
 	message string
 	payload map[string]any
+	// outputConfigHandler receives raw expected output-unit config after a
+	// successful output reload. It is used for Beat-specific settings that do
+	// not belong on monitor input streams.
+	outputConfigHandler lbmanagement.OutputConfigHandler
 
 	// stop callback must be registered by libbeat, as with the V1 callback
 	stopFunc    func()
@@ -254,6 +258,22 @@ func (cm *BeatV2Manager) AgentInfo() lbmanagement.AgentInfo {
 		ManagedMode:  lbmanagement.AgentManagedMode(info.ManagedMode),
 		Unprivileged: info.Unprivileged,
 	}
+}
+
+// SetOutputConfigHandler registers a handler for successful Elastic Agent
+// output-unit configuration changes.
+func (cm *BeatV2Manager) SetOutputConfigHandler(handler lbmanagement.OutputConfigHandler) {
+	cm.mx.Lock()
+	defer cm.mx.Unlock()
+
+	cm.outputConfigHandler = handler
+}
+
+func (cm *BeatV2Manager) outputConfigHandlerSnapshot() lbmanagement.OutputConfigHandler {
+	cm.mx.Lock()
+	defer cm.mx.Unlock()
+
+	return cm.outputConfigHandler
 }
 
 // RegisterDiagnosticHook will register a diagnostic callback function when elastic-agent asks for a diagnostics dump
@@ -874,6 +894,19 @@ func (cm *BeatV2Manager) reloadOutput(unit *agentUnit) (bool, error) {
 	err = output.Reload(reloadConfig)
 	if err != nil {
 		return false, fmt.Errorf("failed to reload output: %w", err)
+	}
+	if handler := cm.outputConfigHandlerSnapshot(); handler != nil {
+		source := expected.Config.GetSource()
+		if source == nil {
+			cm.logger.Warn("output expected config has no source for registered handler")
+			return false, nil
+		}
+		outputConfig, err := conf.NewConfigFrom(source.AsMap())
+		if err != nil {
+			cm.logger.Errorf("could not create output config for handler: %v", err)
+			return false, nil
+		}
+		handler(outputConfig)
 	}
 	return false, nil
 }

--- a/x-pack/libbeat/management/managerV2_test.go
+++ b/x-pack/libbeat/management/managerV2_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/elastic/elastic-agent-client/v7/pkg/client"
 	"github.com/elastic/elastic-agent-client/v7/pkg/client/mock"
 	"github.com/elastic/elastic-agent-client/v7/pkg/proto"
+	conf "github.com/elastic/elastic-agent-libs/config"
 	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/logp/logptest"
 
@@ -834,6 +835,59 @@ func TestReloadNilOutputUnit(t *testing.T) {
 	require.NotPanics(t, func() {
 		mm.reload(map[unitKey]*agentUnit{})
 	}, "reload must not panic when there is no output unit")
+}
+
+func TestReloadOutputCallsConfigHandlerWithRawExpectedConfig(t *testing.T) {
+	r := reload.NewRegistry()
+	output := &reloadable{}
+	r.MustRegisterOutput(output)
+
+	m, err := NewV2AgentManagerWithClient(
+		&Config{Enabled: false},
+		r,
+		nil,
+		logptest.NewTestingLogger(t, ""),
+	)
+	require.NoError(t, err, "could not instantiate ManagerV2")
+
+	cm, ok := m.(*BeatV2Manager)
+	require.True(t, ok, "unexpected type for BeatV2Manager: %T", m)
+
+	var received *conf.C
+	cm.SetOutputConfigHandler(func(cfg *conf.C) {
+		assert.NotNil(t, output.Config(), "output should reload before the handler is called")
+		received = cfg
+	})
+
+	unit := newAgentUnit(&mockClientUnit{expected: client.Expected{
+		Config: &proto.UnitExpectedConfig{
+			Id:   "default",
+			Type: "elasticsearch",
+			Source: requireNewStruct(t, map[string]any{
+				"hosts": []any{"https://example.invalid:9200"},
+				"heartbeat": map[string]any{
+					"jobs": map[string]any{
+						"browser": map[string]any{"limit": 3},
+					},
+				},
+			}),
+		},
+	}}, logptest.NewTestingLogger(t, ""))
+
+	_, err = cm.reloadOutput(unit)
+	require.NoError(t, err, "output reload should succeed")
+	require.NotNil(t, received, "output config handler should receive the raw expected config")
+
+	var config struct {
+		Heartbeat struct {
+			Jobs map[string]struct {
+				Limit int64 `config:"limit"`
+			} `config:"jobs"`
+		} `config:"heartbeat"`
+	}
+	require.NoError(t, received.Unpack(&config), "handler config should unpack")
+	assert.Equal(t, int64(3), config.Heartbeat.Jobs["browser"].Limit,
+		"handler should receive Heartbeat control-plane fields from the output unit")
 }
 
 type reloadable struct {


### PR DESCRIPTION
## Proposed commit message

[Heartbeat] Apply Fleet job limits from output unit config

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have made corresponding changes to the default configuration.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added a changelog fragment.

## Disruptive User Impact

None. Fleet can update managed Heartbeat job limits without restarting the Beat; work already in flight is allowed to drain.

## How to test this PR locally

- `go test -race ./heartbeat/scheduler ./heartbeat/beater`
- `go test ./x-pack/libbeat/management ./x-pack/otel/otelmanager`
- `go test -run '^$' ./x-pack/osquerybeat/beater`
- `go test -race -count=20 -run '^TestApplyJobLimits' ./heartbeat/scheduler`

`mage check` reached Go formatting and header checks, but the local Python 3.14 environment failed while building the autopep8 dependency (`AttributeError: 'Constant' object has no attribute 's'`). Direct license-header checks passed.

## Related issues

Closes #53085

Relates #53074

## Use cases

Fleet-managed private locations can adjust the browser, API, HTTP, TCP, and ICMP concurrency limits dynamically, without restarting Heartbeat.
