### PR TITLE
kubernetes/watcher: drain initial queue synchronously in Start

### DIFF
--- a/changelog/fragments/1757376000-add-kubernetes-metadata-wait-for-metadata.yaml
+++ b/changelog/fragments/1757376000-add-kubernetes-metadata-wait-for-metadata.yaml
@@ -2,10 +2,6 @@ kind: bug-fix
 
 summary: "add_kubernetes_metadata: wait_for_metadata now prevents unenriched events at startup"
 
-# description:
-# watcher.Start() now drains the initial work queue synchronously before returning,
-# so the processor's metadata cache is fully populated when wait_for_metadata is set.
-
 component: libbeat
 
 issue: https://github.com/elastic/beats/issues/53090

--- a/changelog/fragments/1757376000-add-kubernetes-metadata-wait-for-metadata.yaml
+++ b/changelog/fragments/1757376000-add-kubernetes-metadata-wait-for-metadata.yaml
@@ -1,0 +1,11 @@
+kind: bug-fix
+
+summary: "add_kubernetes_metadata: wait_for_metadata now prevents unenriched events at startup"
+
+# description:
+# watcher.Start() now drains the initial work queue synchronously before returning,
+# so the processor's metadata cache is fully populated when wait_for_metadata is set.
+
+component: libbeat
+
+issue: https://github.com/elastic/beats/issues/53090

--- a/pkg/autodiscover/kubernetes/watcher.go
+++ b/pkg/autodiscover/kubernetes/watcher.go
@@ -305,6 +305,14 @@ func (w *watcher) Start() error {
 
 	w.logger.Debugf("cache sync done")
 
+	// Drain the initial queue items synchronously so all registered event handlers
+	// have processed the initial list before Start() returns. This closes the gap
+	// where WaitForCacheSync guarantees the informer store is populated but the
+	// work queue (and therefore dependent caches) is not yet.
+	for n := w.queue.Len(); n > 0; n-- {
+		w.process(w.ctx)
+	}
+
 	// Wrap the process function with wait.Until so that if the controller crashes, it starts up again after a second.
 	go wait.Until(func() {
 		for w.process(w.ctx) {

--- a/pkg/autodiscover/kubernetes/watcher_test.go
+++ b/pkg/autodiscover/kubernetes/watcher_test.go
@@ -137,6 +137,41 @@ func TestWatcherStartRejectsInvalidLifecycleStates(t *testing.T) {
 	})
 }
 
+// TestWatcherStartDrainsInitialQueue verifies that Start() processes all
+// objects that were listed during cache sync before returning, so that
+// registered event handlers (and any caches they populate) are ready
+// immediately after Start() returns.
+func TestWatcherStartDrainsInitialQueue(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	listWatch := cachetest.NewFakeControllerSource()
+	resource := &Pod{}
+	informer := cache.NewSharedInformer(listWatch, resource, 0)
+	w, err := NewNamedWatcherWithInformer("test", client, resource, informer, logptest.NewTestingLogger(t, ""), WatchOptions{})
+	require.NoError(t, err)
+
+	pod := &Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "test-pod",
+			UID:             types.UID("poduid"),
+			Namespace:       "default",
+			ResourceVersion: "1",
+		},
+	}
+	listWatch.Add(pod)
+
+	var added bool
+	w.AddEventHandler(ResourceEventHandlerFuncs{
+		AddFunc: func(obj any) {
+			added = true
+		},
+	})
+
+	require.NoError(t, w.Start())
+	defer w.Stop()
+
+	assert.True(t, added, "event handler should have been called before Start() returned")
+}
+
 func TestWatcherHandlers(t *testing.T) {
 	client := fake.NewSimpleClientset()
 	listWatch := cachetest.NewFakeControllerSource()


### PR DESCRIPTION
## Proposed commit message

After WaitForCacheSync the initial pod Add events sit in the work queue while the drain goroutine is started asynchronously, leaving a window where handler caches (e.g. `kubernetesAnnotator.cache`) are empty. Drain the queue synchronously before launching the goroutine so that all registered handlers have processed the initial list before `Start()` returns, closing the gap that `wait_for_metadata` was meant to prevent.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

None

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

Unit test provides coverage, but I was also able to test this change with the Elastic Agent and it migrating to using a single input with a glob processor and it fixes the issue.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #53090 