### PR TITLE
filestream: add from_id_patterns for regex-based take_over

### DIFF
--- a/changelog/fragments/1788890286-filestream-take-over-from-id-patterns.yaml
+++ b/changelog/fragments/1788890286-filestream-take-over-from-id-patterns.yaml
@@ -1,0 +1,7 @@
+kind: enhancement
+
+summary: filestream take_over now supports regex patterns via from_id_patterns
+
+component: filebeat
+
+issue: https://github.com/elastic/beats/issues/53097

--- a/docs/reference/filebeat/filebeat-input-filestream.md
+++ b/docs/reference/filebeat/filebeat-input-filestream.md
@@ -389,6 +389,20 @@ take_over:
   from_ids: ["foo", "bar"]
 ```
 
+When the source input IDs share a common pattern — for example when IDs are generated dynamically —
+use `take_over.from_id_patterns` instead of (or in addition to) `from_ids`.
+Each entry is a [Go regular expression](https://pkg.go.dev/regexp/syntax) matched against the
+input ID segment of registry keys. Invalid patterns are rejected at startup.
+
+```yaml
+take_over:
+  enabled: true
+  from_id_patterns: ["old-input-.*", "legacy-[0-9]+"]
+```
+
+`from_ids` and `from_id_patterns` can be combined; both are matched.
+When either is set, files are not taken over from `log` inputs.
+
 This take over mode was created to enable smooth migration from
 deprecated `log` inputs to the new `filestream` inputs and to allow
 changing `filestream` input IDs without data re-ingestion.

--- a/docs/reference/filebeat/filebeat-reference-yml.md
+++ b/docs/reference/filebeat/filebeat-reference-yml.md
@@ -899,10 +899,18 @@ filebeat.inputs:
   # Available options: since_first_start, since_last_start.
   #ignore_inactive: ""
 
-  # If `take_over` is set to `true`, this `filestream` will take over all files
-  # from `log` inputs if they match at least one of the `paths` set in the `filestream`.
+  # When enabled, this `filestream` input takes over states from `log` inputs
+  # or other `filestream` inputs. Only files actively matched by `paths` are migrated.
   # This functionality is still in beta.
-  #take_over: false
+  #take_over:
+  #  enabled: true
+  #  # Take over from specific filestream inputs by exact ID.
+  #  # When set, files are not taken over from `log` inputs.
+  #  #from_ids: ["foo", "bar"]
+  #  # Take over from filestream inputs whose ID matches any of these Go regexes.
+  #  # Invalid patterns are rejected at startup. Can be combined with from_ids.
+  #  # When set, files are not taken over from `log` inputs.
+  #  #from_id_patterns: ["old-input-.*", "legacy-[0-9]+"]
 
   # Defines the buffer size every harvester uses when fetching the file
   #harvester_buffer_size: 16384

--- a/docs/reference/filebeat/migrate-to-filestream.md
+++ b/docs/reference/filebeat/migrate-to-filestream.md
@@ -113,6 +113,9 @@ Every `filestream` input **must** have a unique identifier as `id`. Using meanin
 
 ::::{important}
 Never change the ID of an input, or you will end up with duplicate events.
+If you do need to rename an input ID, use [`take_over.from_ids`](/reference/filebeat/filebeat-input-filestream.md#filebeat-input-filestream-take-over)
+to migrate the existing registry state to the new ID without re-ingesting data.
+To migrate from multiple inputs whose IDs share a pattern, use `take_over.from_id_patterns` instead.
 ::::
 
 Let's start the migration process with this simple set of `filestream` inputs without any additional parameters for now:

--- a/filebeat/_meta/config/filebeat.inputs.reference.yml.tmpl
+++ b/filebeat/_meta/config/filebeat.inputs.reference.yml.tmpl
@@ -504,6 +504,12 @@ filebeat.inputs:
   #  from `filestream` inputs that were assigned these IDs.
   #  Taking over from `log` inputs is disabled when `from_ids` is set.
   #  from_ids: ["foo", "bar"]
+  #  If `from_id_patterns` is set, files are taken over from any `filestream`
+  #  input whose ID matches one of the provided Go regular expressions.
+  #  Patterns are matched only against the input ID segment of registry keys.
+  #  Invalid patterns are rejected at startup. Can be combined with `from_ids`.
+  #  Taking over from `log` inputs is disabled when `from_id_patterns` is set.
+  #  from_id_patterns: ["old-input-.*", "legacy-[0-9]+"]
 
   # Defines the buffer size every harvester uses when fetching the file
   #harvester_buffer_size: 16384

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -923,6 +923,12 @@ filebeat.inputs:
   #  from `filestream` inputs that were assigned these IDs.
   #  Taking over from `log` inputs is disabled when `from_ids` is set.
   #  from_ids: ["foo", "bar"]
+  #  If `from_id_patterns` is set, files are taken over from any `filestream`
+  #  input whose ID matches one of the provided Go regular expressions.
+  #  Patterns are matched only against the input ID segment of registry keys.
+  #  Invalid patterns are rejected at startup. Can be combined with `from_ids`.
+  #  Taking over from `log` inputs is disabled when `from_id_patterns` is set.
+  #  from_id_patterns: ["old-input-.*", "legacy-[0-9]+"]
 
   # Defines the buffer size every harvester uses when fetching the file
   #harvester_buffer_size: 16384

--- a/filebeat/input/filestream/internal/input-logfile/input.go
+++ b/filebeat/input/filestream/internal/input-logfile/input.go
@@ -37,7 +37,7 @@ type managedInput struct {
 	manager                *InputManager
 	ackCH                  *updateChan
 	sourceIdentifier       *SourceIdentifier
-	previousSrcIdentifiers []*SourceIdentifier
+	previousSrcIdentifiers []InputMatcher
 	prospector             Prospector
 	harvester              Harvester
 	cleanTimeout           time.Duration

--- a/filebeat/input/filestream/internal/input-logfile/manager.go
+++ b/filebeat/input/filestream/internal/input-logfile/manager.go
@@ -20,6 +20,7 @@ package input_logfile
 import (
 	"errors"
 	"fmt"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -260,7 +261,7 @@ func (cim *InputManager) Create(config *conf.C) (inp v2.Input, retErr error) {
 		return nil, errNoInputRunner
 	}
 
-	var previousSrcIdentifiers []*SourceIdentifier
+	var previousMatchers []InputMatcher
 	if settings.TakeOver.Enabled {
 		for _, id := range settings.TakeOver.FromIDs {
 			si, err := NewSourceIdentifier(cim.Type, id)
@@ -270,12 +271,21 @@ func (cim *InputManager) Create(config *conf.C) (inp v2.Input, retErr error) {
 						"[ID: %q] error while creating source identifier for previous ID %q: %w",
 						settings.ID, id, err)
 			}
-
-			previousSrcIdentifiers = append(previousSrcIdentifiers, si)
+			previousMatchers = append(previousMatchers, si)
+		}
+		for _, pattern := range settings.TakeOver.FromIDPatterns {
+			rm, err := newRegexInputMatcher(cim.Type, pattern)
+			if err != nil {
+				return nil,
+					fmt.Errorf(
+						"[ID: %q] error while creating regex matcher for pattern %q: %w",
+						settings.ID, pattern, err)
+			}
+			previousMatchers = append(previousMatchers, rm)
 		}
 	}
 
-	prospectorStore := newSourceStore(pStore, srcIdentifier, previousSrcIdentifiers)
+	prospectorStore := newSourceStore(pStore, srcIdentifier, previousMatchers)
 
 	// create a store with the deprecated global ID. This will be used to
 	// migrate the entries in the registry to use the new input ID.
@@ -300,7 +310,7 @@ func (cim *InputManager) Create(config *conf.C) (inp v2.Input, retErr error) {
 		backoff:                settings.Backoff,
 		stateCheckInterval:     settings.Close.OnStateChange.CheckInterval,
 		sourceIdentifier:       srcIdentifier,
-		previousSrcIdentifiers: previousSrcIdentifiers,
+		previousSrcIdentifiers: previousMatchers,
 		cleanTimeout:           settings.CleanInactive,
 		harvesterLimit:         settings.HarvesterLimit,
 	}, nil
@@ -383,13 +393,53 @@ func (i *SourceIdentifier) MatchesInput(id string) bool {
 	return strings.HasPrefix(id, i.prefix)
 }
 
+// InputMatcher reports whether a registry key belongs to a given input.
+type InputMatcher interface {
+	MatchesInput(key string) bool
+}
+
+// RegexInputMatcher matches registry keys whose input ID segment matches a compiled regexp.
+type RegexInputMatcher struct {
+	pluginPrefix string
+	pattern      *regexp.Regexp
+}
+
+func newRegexInputMatcher(pluginName, pattern string) (*RegexInputMatcher, error) {
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return nil, fmt.Errorf("invalid from_id_patterns entry %q: %w", pattern, err)
+	}
+	return &RegexInputMatcher{
+		pluginPrefix: pluginName + "::",
+		pattern:      re,
+	}, nil
+}
+
+func (r *RegexInputMatcher) MatchesInput(key string) bool {
+	if !strings.HasPrefix(key, r.pluginPrefix) {
+		return false
+	}
+	rest := key[len(r.pluginPrefix):]
+	idx := strings.Index(rest, "::")
+	var inputID string
+	if idx < 0 {
+		inputID = rest
+	} else {
+		inputID = rest[:idx]
+	}
+	return r.pattern.MatchString(inputID)
+}
+
 // TakeOverConfig is the configuration for the take over mode.
 // It allows the Filestream input to take over states from the log
 // input or other Filestream inputs
 type TakeOverConfig struct {
 	Enabled bool `config:"enabled"`
-	// Filestream IDs to take over states
+	// Filestream IDs to take over states (exact match).
 	FromIDs []string `config:"from_ids"`
+	// Go regular expressions matched against the input ID segment of registry
+	// keys. Compiled at parse time; an invalid pattern is a config error.
+	FromIDPatterns []string `config:"from_id_patterns"`
 	// Stream from the container input to take over from.
 	// Valid values: stderr, stdout or it can be empty. An empty stream means
 	// all streams.
@@ -419,20 +469,36 @@ func (t *TakeOverConfig) Unpack(value any) error {
 		}
 
 		rawFromIDs, exists := v["from_ids"]
-		if !exists {
-			return nil
+		if exists {
+			fromIDs, ok := rawFromIDs.([]any)
+			if !ok {
+				return fmt.Errorf("cannot parse '%[1]v' (type %[1]T) as []any", rawFromIDs)
+			}
+			for _, el := range fromIDs {
+				strEl, ok := el.(string)
+				if !ok {
+					return fmt.Errorf("cannot parse '%[1]v' (type %[1]T) as string", el)
+				}
+				t.FromIDs = append(t.FromIDs, strEl)
+			}
 		}
 
-		fromIDs, ok := rawFromIDs.([]any)
-		if !ok {
-			return fmt.Errorf("cannot parse '%[1]v' (type %[1]T) as []any", rawFromIDs)
-		}
-		for _, el := range fromIDs {
-			strEl, ok := el.(string)
+		rawFromIDPatterns, exists := v["from_id_patterns"]
+		if exists {
+			fromIDPatterns, ok := rawFromIDPatterns.([]any)
 			if !ok {
-				return fmt.Errorf("cannot parse '%[1]v' (type %[1]T) as string", el)
+				return fmt.Errorf("cannot parse '%[1]v' (type %[1]T) as []any", rawFromIDPatterns)
 			}
-			t.FromIDs = append(t.FromIDs, strEl)
+			for _, el := range fromIDPatterns {
+				strEl, ok := el.(string)
+				if !ok {
+					return fmt.Errorf("cannot parse '%[1]v' (type %[1]T) as string", el)
+				}
+				if _, err := regexp.Compile(strEl); err != nil {
+					return fmt.Errorf("invalid from_id_patterns entry %q: %w", strEl, err)
+				}
+				t.FromIDPatterns = append(t.FromIDPatterns, strEl)
+			}
 		}
 
 	default:
@@ -449,7 +515,7 @@ func (t *TakeOverConfig) LogWarnings(logger *logp.Logger) {
 }
 
 func (t *TakeOverConfig) FromFilestream() bool {
-	return len(t.FromIDs) != 0
+	return len(t.FromIDs) != 0 || len(t.FromIDPatterns) != 0
 }
 
 // ReadUntilEOFConfig configures the behaviour to keep reading the current

--- a/filebeat/input/filestream/internal/input-logfile/manager.go
+++ b/filebeat/input/filestream/internal/input-logfile/manager.go
@@ -420,13 +420,7 @@ func (r *RegexInputMatcher) MatchesInput(key string) bool {
 		return false
 	}
 	rest := key[len(r.pluginPrefix):]
-	idx := strings.Index(rest, "::")
-	var inputID string
-	if idx < 0 {
-		inputID = rest
-	} else {
-		inputID = rest[:idx]
-	}
+	inputID, _, _ := strings.Cut(rest, "::")
 	return r.pattern.MatchString(inputID)
 }
 

--- a/filebeat/input/filestream/internal/input-logfile/manager_test.go
+++ b/filebeat/input/filestream/internal/input-logfile/manager_test.go
@@ -716,6 +716,36 @@ take_over:
 			cfgYAML:   "take_over: 42",
 			expectErr: true,
 		},
+		"new mode with id patterns": {
+			cfgYAML: `
+take_over:
+  enabled: true
+  from_id_patterns: ["foo-.*", "bar-[0-9]+"]`,
+			expected: TakeOverConfig{
+				Enabled:        true,
+				FromIDPatterns: []string{"foo-.*", "bar-[0-9]+"},
+			},
+		},
+		"new mode with ids and id patterns": {
+			cfgYAML: `
+take_over:
+  enabled: true
+  from_ids: ["exact-id"]
+  from_id_patterns: ["prefix-.*"]`,
+			expected: TakeOverConfig{
+				Enabled:        true,
+				FromIDs:        []string{"exact-id"},
+				FromIDPatterns: []string{"prefix-.*"},
+			},
+		},
+		"invalid from_id_patterns regex": {
+			cfgYAML:   `take_over.from_id_patterns: ["[invalid"]`,
+			expectErr: true,
+		},
+		"invalid from_id_patterns element type": {
+			cfgYAML:   `take_over.from_id_patterns: ["foo", 42]`,
+			expectErr: true,
+		},
 	}
 
 	for name, tc := range testCases {
@@ -732,6 +762,60 @@ take_over:
 			}
 
 			assert.Equal(t, tc.expected, outer.TakeOver, "TakeOverConfig was not parsed correctly")
+		})
+	}
+}
+
+func TestRegexInputMatcher(t *testing.T) {
+	testCases := []struct {
+		name    string
+		pattern string
+		key     string
+		want    bool
+	}{
+		{
+			name:    "matches input ID",
+			pattern: `foo-.*`,
+			key:     "filestream::foo-bar::native::123",
+			want:    true,
+		},
+		{
+			name:    "no match on different ID",
+			pattern: `foo-.*`,
+			key:     "filestream::baz::native::123",
+			want:    false,
+		},
+		{
+			name:    "no match on different plugin",
+			pattern: `foo-.*`,
+			key:     "logfile::foo-bar::native::123",
+			want:    false,
+		},
+		{
+			name:    "pattern anchored to full ID segment",
+			pattern: `foo`,
+			key:     "filestream::foo-bar::native::123",
+			want:    true, // regexp.MatchString is a substring match
+		},
+		{
+			name:    "anchored pattern no match",
+			pattern: `^foo$`,
+			key:     "filestream::foo-bar::native::123",
+			want:    false,
+		},
+		{
+			name:    "exact match with anchors",
+			pattern: `^foo-bar$`,
+			key:     "filestream::foo-bar::native::123",
+			want:    true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			m, err := newRegexInputMatcher("filestream", tc.pattern)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, m.MatchesInput(tc.key))
 		})
 	}
 }

--- a/filebeat/input/filestream/internal/input-logfile/store.go
+++ b/filebeat/input/filestream/internal/input-logfile/store.go
@@ -44,9 +44,9 @@ var ErrKeyGone = errors.New("registry key does not exist")
 type sourceStore struct {
 	// identifier is the sourceIdentifier used to generate IDs fro this store.
 	identifier *SourceIdentifier
-	// identifiersToTakeOver are sourceIdentifier from previous input instances
-	// that this sourceStore will take states over.
-	identifiersToTakeOver []*SourceIdentifier
+	// identifiersToTakeOver are matchers for previous input instances whose
+	// states this sourceStore will take over.
+	identifiersToTakeOver []InputMatcher
 	// store is the underlying store that encapsulates
 	// the in-memory and persistent store.
 	store *store
@@ -183,7 +183,7 @@ func openStore(log *logp.Logger, statestore statestore.States, prefix string) (*
 func newSourceStore(
 	s *store,
 	identifier *SourceIdentifier,
-	identifiersToTakeOver []*SourceIdentifier,
+	identifiersToTakeOver []InputMatcher,
 ) *sourceStore {
 
 	return &sourceStore{

--- a/filebeat/input/filestream/internal/input-logfile/store_test.go
+++ b/filebeat/input/filestream/internal/input-logfile/store_test.go
@@ -431,7 +431,7 @@ func TestSourceStoreTakeOver(t *testing.T) {
 	defer s.Release()
 	store := &sourceStore{
 		identifier:            &SourceIdentifier{"filestream::current-id::"},
-		identifiersToTakeOver: []*SourceIdentifier{{"filestream::previous-id::"}},
+		identifiersToTakeOver: []InputMatcher{&SourceIdentifier{"filestream::previous-id::"}},
 		store:                 s,
 	}
 

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -2623,6 +2623,12 @@ filebeat.inputs:
   #  from `filestream` inputs that were assigned these IDs.
   #  Taking over from `log` inputs is disabled when `from_ids` is set.
   #  from_ids: ["foo", "bar"]
+  #  If `from_id_patterns` is set, files are taken over from any `filestream`
+  #  input whose ID matches one of the provided Go regular expressions.
+  #  Patterns are matched only against the input ID segment of registry keys.
+  #  Invalid patterns are rejected at startup. Can be combined with `from_ids`.
+  #  Taking over from `log` inputs is disabled when `from_id_patterns` is set.
+  #  from_id_patterns: ["old-input-.*", "legacy-[0-9]+"]
 
   # Defines the buffer size every harvester uses when fetching the file
   #harvester_buffer_size: 16384


### PR DESCRIPTION
## What does this PR do?

Adds `take_over.from_id_patterns` to the filestream input — a list of Go regular expressions matched against the input ID segment of registry keys. This lets a single filestream input take over state from many previous inputs without having to enumerate every ID.

```yaml
filestream:
  id: my-new-input
  take_over:
    enabled: true
    from_id_patterns:
      - "filestream-app-v[0-9]+-.*"
  paths: [/var/log/*.log]
```

`from_ids` (exact) and `from_id_patterns` (regex) work independently and together. Invalid patterns are rejected at config parse time.

## Why is it important?

When input IDs are generated dynamically (e.g. per-container or per-version), listing every old ID in `from_ids` is impractical. Closes #53097.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `changelog/fragments`
- [ ] I have made corresponding change to the default configuration files