### PR TITLE
libbeat/reader/etw,x-pack/filebeat/input/etw: reconnect when the realtime session is stopped

### DIFF
--- a/changelog/fragments/1788930013-etw-reconnect-after-session-restart.yaml
+++ b/changelog/fragments/1788930013-etw-reconnect-after-session-restart.yaml
@@ -1,0 +1,54 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: Reconnect the ETW input when its real-time session is stopped and restarted.
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+description: |
+  When another controller stopped the real-time ETW session, for example
+  `logman stop <session> -ets`, Windows reports the trace as finished and the
+  input exited silently, staying down until Filebeat was restarted. The input
+  now treats this as a lost session: it reports Degraded, retries creating or
+  attaching to the session with a backoff of up to 30 seconds, and reports
+  Running again once it has reconnected. Reading from an .etl file is not
+  affected. A new `reconnects_total` metric counts the reconnection attempts.
+  The changes to the shared ETW reader that make a session safe to reuse are
+  listed under libbeat.
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: filebeat
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: https://github.com/elastic/beats/issues/49984

--- a/changelog/fragments/1788930013-etw-reconnect-after-session-restart.yaml
+++ b/changelog/fragments/1788930013-etw-reconnect-after-session-restart.yaml
@@ -24,8 +24,12 @@ description: |
   input exited silently, staying down until Filebeat was restarted. The input
   now treats this as a lost session: it reports Degraded, retries creating or
   attaching to the session with a backoff of up to 30 seconds, and reports
-  Running again once it has reconnected. Reading from an .etl file is not
-  affected. A new `reconnects_total` metric counts the reconnection attempts.
+  Running again once it has reconnected. Only a session that is not running
+  is retried; an attempt that fails for a reason waiting cannot fix, such as
+  insufficient privileges, reports Failed. A session that was created but
+  could not be fully configured is now stopped rather than left running.
+  Reading from an .etl file is not affected. A new `reconnects_total` metric
+  counts the reconnection attempts.
   The changes to the shared ETW reader that make a session safe to reuse are
   listed under libbeat.
 

--- a/changelog/fragments/1788932392-etw-reader-session-reuse-and-stop.yaml
+++ b/changelog/fragments/1788932392-etw-reader-session-reuse-and-stop.yaml
@@ -27,7 +27,10 @@ description: |
     attached to again without re-registering its event callback. This is what
     lets the etw input reconnect after its session is stopped and restarted.
   - `StopSession` no longer reports an error when the session it was asked to
-    stop has already been stopped by another controller.
+    stop has already been stopped by another controller. It is a no-op when no
+    session was created or attached to, so it can be used to clean up after a
+    failed connection, and it only waits for flushed events to be processed
+    when the flush succeeded and a consumer is running.
   - A stop issued before the trace was open is no longer lost: `StartConsumer`
     closes the trace itself instead of blocking in `ProcessTrace` on a session
     that nobody will end, which could hang shutdown. The trace handle is now

--- a/changelog/fragments/1788932392-etw-reader-session-reuse-and-stop.yaml
+++ b/changelog/fragments/1788932392-etw-reader-session-reuse-and-stop.yaml
@@ -1,0 +1,60 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: Make an ETW reader session safe to reuse and stop, and fix a lost stop that could hang shutdown.
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+description: |
+  The shared ETW reader, used by the filebeat etw input and the auditbeat
+  file_integrity module, was changed so that a session can be used more than
+  once and stopped from another goroutine safely:
+  - `Session.Reset` clears the handles and rebuilds the session properties
+    left behind by a previous run, so the same session can be created or
+    attached to again without re-registering its event callback. This is what
+    lets the etw input reconnect after its session is stopped and restarted.
+  - `StopSession` no longer reports an error when the session it was asked to
+    stop has already been stopped by another controller.
+  - A stop issued before the trace was open is no longer lost: `StartConsumer`
+    closes the trace itself instead of blocking in `ProcessTrace` on a session
+    that nobody will end, which could hang shutdown. The trace handle is now
+    guarded against concurrent access between the consumer and the stopper.
+  The auditbeat file_integrity module inherits the last two fixes; its events
+  and state are unchanged.
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: libbeat
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: https://github.com/elastic/beats/issues/49984

--- a/docs/reference/filebeat/filebeat-input-etw.md
+++ b/docs/reference/filebeat/filebeat-input-etw.md
@@ -18,6 +18,16 @@ This input currently supports manifest-based, MOF (classic) and TraceLogging pro
 
 It has been tested in the Windows versions supported by Filebeat, starting from Windows 10 and Windows Server 2016. In addition, administrative privileges are required to control event tracing sessions.
 
+## Session reconnection [filebeat-input-etw-reconnection]
+
+```{applies_to}
+stack: ga 9.4.7+
+```
+
+When reading from a real-time session (`provider.name`, `provider.guid` or `session`), the input keeps running if the session is stopped by another controller, for example when an administrator restarts it with `logman`. The input reports a `DEGRADED` status while the session is unavailable, retries with a backoff that grows to 30 seconds, and reports `HEALTHY` again once it has reconnected to the session. If the input created the session itself, it creates it again; if it attached to an existing session, it waits for the session to be started again. Events produced while the session is stopped, or before the input reconnects, are not recovered.
+
+Failures during the first connection, such as a session that does not exist or insufficient privileges, still report `FAILED` and stop the input. Reading from a `file` is not affected: the input stops when it reaches the end of the file.
+
 Example configurations:
 
 Read from a provider by name:
@@ -370,6 +380,7 @@ You must assign a unique `id` to the input to expose metrics.
 | `received_events_total` | Total number of events received. |
 | `discarded_events_total` | Total number of discarded events. |
 | `errors_total` | Total number of errors. |
+| `reconnects_total` | Total number of attempts to reconnect after the ETW session stopped unexpectedly. |
 | `source_lag_time` | Histogram of the difference between timestamped event’s creation and reading. |
 | `arrival_period` | Histogram of the elapsed time between event notification callbacks. |
 | `processing_time` | Histogram of the elapsed time between event notification callback and publication to the internal queue. |

--- a/docs/reference/filebeat/filebeat-input-etw.md
+++ b/docs/reference/filebeat/filebeat-input-etw.md
@@ -24,9 +24,11 @@ It has been tested in the Windows versions supported by Filebeat, starting from 
 stack: ga 9.4.7+
 ```
 
-When reading from a real-time session (`provider.name`, `provider.guid` or `session`), the input keeps running if the session is stopped by another controller, for example when an administrator restarts it with `logman`. The input reports a `DEGRADED` status while the session is unavailable, retries with a backoff that grows to 30 seconds, and reports `HEALTHY` again once it has reconnected to the session. If the input created the session itself, it creates it again. If it attached to an existing session, it waits for the session to be started again. Events produced while the session is stopped, or before the input reconnects, are not recovered.
+When the input reads from a real-time session (`provider.name`, `provider.guid`, or `session`), it stays running if another process stops the session, for example, when an administrator restarts it with `logman`. While the session is unavailable, the input reports a `DEGRADED` status and retries with a backoff that grows to 30 seconds. After it reconnects, it reports `HEALTHY` again.
 
-Only a session that is not running is treated as a temporary condition. If a reconnection attempt fails for a reason that waiting cannot fix, such as insufficient privileges or a provider that cannot be enabled, the input reports `FAILED` and stops, as it does when the same error happens during the first connection. Reading from a `file` is not affected: the input stops when it reaches the end of the file.
+If you configured `provider.name` or `provider.guid`, the input recreates the session. If you configured `session`, the input waits for that session to start again. Events that occur while the session is stopped, or before the input reconnects, are not recovered.
+
+The input retries only when the session is not running. If a reconnection attempt fails for a reason that retrying cannot resolve, such as insufficient privileges or a provider that cannot be enabled, the input reports `FAILED` and stops. The same errors fail the input on the first connection. Reading from a `file` is unchanged: the input stops when it reaches the end of the file.
 
 Example configurations:
 
@@ -380,7 +382,7 @@ You must assign a unique `id` to the input to expose metrics.
 | `received_events_total` | Total number of events received. |
 | `discarded_events_total` | Total number of discarded events. |
 | `errors_total` | Total number of errors. |
-| `reconnects_total` | Total number of attempts to reconnect after the ETW session stopped unexpectedly. |
+| `reconnects_total` {applies_to}`stack: ga 9.4.7+` | Total number of attempts to reconnect after the ETW session stopped unexpectedly. |
 | `source_lag_time` | Histogram of the difference between timestamped event’s creation and reading. |
 | `arrival_period` | Histogram of the elapsed time between event notification callbacks. |
 | `processing_time` | Histogram of the elapsed time between event notification callback and publication to the internal queue. |

--- a/docs/reference/filebeat/filebeat-input-etw.md
+++ b/docs/reference/filebeat/filebeat-input-etw.md
@@ -24,9 +24,9 @@ It has been tested in the Windows versions supported by Filebeat, starting from 
 stack: ga 9.4.7+
 ```
 
-When reading from a real-time session (`provider.name`, `provider.guid` or `session`), the input keeps running if the session is stopped by another controller, for example when an administrator restarts it with `logman`. The input reports a `DEGRADED` status while the session is unavailable, retries with a backoff that grows to 30 seconds, and reports `HEALTHY` again once it has reconnected to the session. If the input created the session itself, it creates it again; if it attached to an existing session, it waits for the session to be started again. Events produced while the session is stopped, or before the input reconnects, are not recovered.
+When reading from a real-time session (`provider.name`, `provider.guid` or `session`), the input keeps running if the session is stopped by another controller, for example when an administrator restarts it with `logman`. The input reports a `DEGRADED` status while the session is unavailable, retries with a backoff that grows to 30 seconds, and reports `HEALTHY` again once it has reconnected to the session. If the input created the session itself, it creates it again. If it attached to an existing session, it waits for the session to be started again. Events produced while the session is stopped, or before the input reconnects, are not recovered.
 
-Failures during the first connection, such as a session that does not exist or insufficient privileges, still report `FAILED` and stop the input. Reading from a `file` is not affected: the input stops when it reaches the end of the file.
+Only a session that is not running is treated as a temporary condition. If a reconnection attempt fails for a reason that waiting cannot fix, such as insufficient privileges or a provider that cannot be enabled, the input reports `FAILED` and stops, as it does when the same error happens during the first connection. Reading from a `file` is not affected: the input stops when it reaches the end of the file.
 
 Example configurations:
 

--- a/libbeat/reader/etw/controller.go
+++ b/libbeat/reader/etw/controller.go
@@ -142,6 +142,11 @@ func (s *Session) CreateRealtimeSession() error {
 // It is safe to call while StartConsumer is running on another goroutine; that
 // is how a blocked ProcessTrace is made to return. A stop that arrives before
 // the trace is open is honoured by StartConsumer once it is.
+//
+// StopSession is also safe to call when CreateRealtimeSession or
+// AttachToExistingSession failed, so that a session that was created but not
+// fully configured is not left running. After StopSession the session stays
+// stopped until Reset is called: StartConsumer returns without consuming.
 func (s *Session) StopSession() error {
 	if !s.Realtime {
 		return nil
@@ -154,16 +159,29 @@ func (s *Session) StopSession() error {
 	traceHandler := s.traceHandler
 	s.mu.Unlock()
 
-	// try to flush all buffer before stopping the session
-	_ = s.controlTrace(
-		s.handler,
-		nil,
-		s.properties,
-		EVENT_TRACE_CONTROL_FLUSH,
-	)
+	// handler is set by StartTrace or by the QUERY in
+	// AttachToExistingSession. Without it there is no session to flush or
+	// stop, which is the case when connecting failed before either succeeded.
+	hasSession := s.handler != 0
 
-	// give time to process any flushed events
-	time.Sleep(time.Second)
+	if hasSession {
+		// Flush so that buffered events reach the consumer before the trace
+		// is closed. Waiting for them to be processed only makes sense when
+		// the flush went through and a consumer is processing them: a
+		// session that another controller has already stopped fails the
+		// flush, and a consumer that never opened its trace has nothing to
+		// deliver to. Skipping the wait in those cases keeps a reconnect
+		// from paying a second for nothing.
+		flushErr := s.controlTrace(
+			s.handler,
+			nil,
+			s.properties,
+			EVENT_TRACE_CONTROL_FLUSH,
+		)
+		if flushErr == nil && isValidHandler(traceHandler) {
+			time.Sleep(time.Second)
+		}
+	}
 
 	if isValidHandler(traceHandler) {
 		// Attempt to close the trace and handle potential errors.
@@ -172,7 +190,7 @@ func (s *Session) StopSession() error {
 		}
 	}
 
-	if s.NewSession {
+	if s.NewSession && hasSession {
 		// If we created the session, send a control command to stop it.
 		err := s.controlTrace(
 			s.handler,

--- a/libbeat/reader/etw/controller.go
+++ b/libbeat/reader/etw/controller.go
@@ -139,10 +139,20 @@ func (s *Session) CreateRealtimeSession() error {
 }
 
 // StopSession closes the ETW session and associated handles if they were created.
+// It is safe to call while StartConsumer is running on another goroutine; that
+// is how a blocked ProcessTrace is made to return. A stop that arrives before
+// the trace is open is honoured by StartConsumer once it is.
 func (s *Session) StopSession() error {
 	if !s.Realtime {
 		return nil
 	}
+
+	// Record the stop and take the trace handle in one step; see
+	// StartConsumer for why the two must not be observed separately.
+	s.mu.Lock()
+	s.stopping = true
+	traceHandler := s.traceHandler
+	s.mu.Unlock()
 
 	// try to flush all buffer before stopping the session
 	_ = s.controlTrace(
@@ -155,21 +165,28 @@ func (s *Session) StopSession() error {
 	// give time to process any flushed events
 	time.Sleep(time.Second)
 
-	if isValidHandler(s.traceHandler) {
+	if isValidHandler(traceHandler) {
 		// Attempt to close the trace and handle potential errors.
-		if err := s.closeTrace(s.traceHandler); err != nil && !errors.Is(err, ERROR_CTX_CLOSE_PENDING) {
+		if err := s.closeTrace(traceHandler); err != nil && !errors.Is(err, ERROR_CTX_CLOSE_PENDING) {
 			return fmt.Errorf("failed to close trace: %w", err)
 		}
 	}
 
 	if s.NewSession {
 		// If we created the session, send a control command to stop it.
-		return s.controlTrace(
+		err := s.controlTrace(
 			s.handler,
 			nil,
 			s.properties,
 			EVENT_TRACE_CONTROL_STOP,
 		)
+		// Another controller may already have stopped the session; that is
+		// what brings a realtime consumer here when it reconnects, and the
+		// outcome is the one we wanted.
+		if errors.Is(err, ERROR_WMI_INSTANCE_NOT_FOUND) {
+			return nil
+		}
+		return err
 	}
 
 	return nil

--- a/libbeat/reader/etw/controller_test.go
+++ b/libbeat/reader/etw/controller_test.go
@@ -21,6 +21,7 @@ package etw
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/sys/windows"
@@ -172,6 +173,7 @@ func TestStopSession_Error(t *testing.T) {
 	session := &Session{
 		Realtime:     true,
 		NewSession:   true,
+		handler:      1,     // Session handle from StartTrace
 		traceHandler: 12345, // Example handler value
 		properties:   &EventTraceProperties{},
 		closeTrace:   closeTrace,
@@ -200,6 +202,7 @@ func TestStopSession_Success(t *testing.T) {
 	session := &Session{
 		Realtime:     true,
 		NewSession:   true,
+		handler:      1,     // Session handle from StartTrace
 		traceHandler: 12345, // Example handler value
 		properties:   &EventTraceProperties{},
 		closeTrace:   closeTrace,
@@ -228,6 +231,7 @@ func TestStopSession_AlreadyStopped(t *testing.T) {
 			session := &Session{
 				Realtime:     true,
 				NewSession:   true,
+				handler:      1,
 				traceHandler: 12345,
 				properties:   &EventTraceProperties{},
 				closeTrace: func(uint64) error {
@@ -247,4 +251,74 @@ func TestStopSession_AlreadyStopped(t *testing.T) {
 			assert.True(t, closed, "trace handle should be closed before the session is stopped")
 		})
 	}
+}
+
+func TestStopSession_NothingToStop(t *testing.T) {
+	// Connecting failed before StartTrace or the attach QUERY succeeded, so
+	// there is no session handle. StopSession is called as cleanup anyway and
+	// must not issue controls against a session that does not exist.
+	session := &Session{
+		Realtime:   true,
+		NewSession: true,
+		properties: &EventTraceProperties{},
+		closeTrace: func(uint64) error {
+			t.Error("no trace was opened, so nothing should be closed")
+			return nil
+		},
+		controlTrace: func(_ uintptr, _ *uint16, _ *EventTraceProperties, controlCode uint32) error {
+			t.Errorf("no session was created, so control %d should not be sent", controlCode)
+			return nil
+		},
+	}
+
+	start := time.Now()
+	assert.NoError(t, session.StopSession(), "stopping a session that was never created should succeed")
+	assert.Less(t, time.Since(start), time.Second/2, "there was nothing to flush, so there should be no wait for flushed events")
+}
+
+func TestStopSession_NoWaitWhenSessionGone(t *testing.T) {
+	// Another controller stopped the session, which is what brings the
+	// reconnecting consumer here. The flush fails because the session is
+	// gone, so there are no flushed events to wait for; waiting anyway would
+	// add a second to every reconnect.
+	closed := false
+	session := &Session{
+		Realtime:     true,
+		NewSession:   true,
+		handler:      1,
+		traceHandler: 12345,
+		properties:   &EventTraceProperties{},
+		closeTrace: func(uint64) error {
+			closed = true
+			return nil
+		},
+		controlTrace: func(uintptr, *uint16, *EventTraceProperties, uint32) error {
+			return ERROR_WMI_INSTANCE_NOT_FOUND
+		},
+	}
+
+	start := time.Now()
+	assert.NoError(t, session.StopSession(), "a session that is already gone is in the state we asked for")
+	assert.Less(t, time.Since(start), time.Second/2, "a failed flush has nothing to wait for")
+	assert.True(t, closed, "the trace handle should still be closed")
+}
+
+func TestStopSession_NoWaitWithoutConsumer(t *testing.T) {
+	// The session exists but no trace was ever opened on it, so a flush has
+	// nobody to deliver to and there is nothing to wait for.
+	session := &Session{
+		Realtime:   true,
+		NewSession: true,
+		handler:    1,
+		properties: &EventTraceProperties{},
+		closeTrace: func(uint64) error {
+			t.Error("no trace was opened, so nothing should be closed")
+			return nil
+		},
+		controlTrace: func(uintptr, *uint16, *EventTraceProperties, uint32) error { return nil },
+	}
+
+	start := time.Now()
+	assert.NoError(t, session.StopSession(), "stopping a session without a consumer should succeed")
+	assert.Less(t, time.Since(start), time.Second/2, "no consumer is processing, so there should be no wait for flushed events")
 }

--- a/libbeat/reader/etw/controller_test.go
+++ b/libbeat/reader/etw/controller_test.go
@@ -209,3 +209,42 @@ func TestStopSession_Success(t *testing.T) {
 	err := session.StopSession()
 	assert.NoError(t, err)
 }
+
+func TestStopSession_AlreadyStopped(t *testing.T) {
+	// When another controller has already stopped the session, the STOP
+	// control fails with ERROR_WMI_INSTANCE_NOT_FOUND. The session is in the
+	// state we asked for, so that is not an error; anything else still is.
+	tests := []struct {
+		name    string
+		stopErr error
+		wantErr error
+	}{
+		{name: "session already gone", stopErr: ERROR_WMI_INSTANCE_NOT_FOUND, wantErr: nil},
+		{name: "other stop failures are reported", stopErr: ERROR_ACCESS_DENIED, wantErr: ERROR_ACCESS_DENIED},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			closed := false
+			session := &Session{
+				Realtime:     true,
+				NewSession:   true,
+				traceHandler: 12345,
+				properties:   &EventTraceProperties{},
+				closeTrace: func(uint64) error {
+					closed = true
+					return nil
+				},
+				controlTrace: func(_ uintptr, _ *uint16, _ *EventTraceProperties, controlCode uint32) error {
+					if controlCode == EVENT_TRACE_CONTROL_STOP {
+						return test.stopErr
+					}
+					return nil
+				},
+			}
+
+			err := session.StopSession()
+			assert.ErrorIs(t, err, test.wantErr, "StopSession with STOP failing with %v", test.stopErr)
+			assert.True(t, closed, "trace handle should be closed before the session is stopped")
+		})
+	}
+}

--- a/libbeat/reader/etw/session.go
+++ b/libbeat/reader/etw/session.go
@@ -80,7 +80,9 @@ type Session struct {
 	// stopping records that StopSession has been called. StartConsumer checks
 	// it once the trace is open: a stop that arrived before then found no
 	// handle to close, and without this check ProcessTrace would block on a
-	// session that nobody is going to end.
+	// session that nobody is going to end. Only Reset clears it, so a
+	// session that has been stopped cannot be consumed again until it has
+	// been reset.
 	stopping bool
 
 	// Pointers to functions that make calls to the Windows API.
@@ -209,12 +211,14 @@ func NewSession(conf Config) (*Session, error) {
 
 // Reset prepares the session to be created or attached to again after its
 // consumer has returned, which for a realtime session happens when another
-// controller stops it. StopSession should be called first to release the
-// trace handle. The handles from the previous run and the pending stop are
-// discarded and the session properties are rebuilt, because StartTrace and
-// ControlTrace write into the properties buffer (session GUID, handle, live
-// buffer counts) and feeding the previous session's output back in as input
-// is not safe.
+// controller stops it. Callers must call StopSession first, to release the
+// trace handle, and then Reset before starting the session again: Reset is
+// the only thing that clears the stop recorded by StopSession, and until it
+// runs StartConsumer returns without consuming. The handles from the previous
+// run and the pending stop are discarded and the session properties are
+// rebuilt, because StartTrace and ControlTrace write into the properties
+// buffer (session GUID, handle, live buffer counts) and feeding the previous
+// session's output back in as input is not safe.
 //
 // Callback is kept as is on purpose: StartConsumer registers it with
 // syscall.NewCallback, which dedupes on the function value and never frees
@@ -235,7 +239,8 @@ func (s *Session) Reset() {
 // blocks until the trace ends. If StopSession was called before the trace was
 // open, StartConsumer closes the trace itself and returns nil without
 // processing events, the same outcome as a stop that arrives while
-// ProcessTrace is running.
+// ProcessTrace is running. This includes a StopSession from a previous run:
+// a stopped session must be Reset before it is started again.
 func (s *Session) StartConsumer() error {
 	var elf EventTraceLogfile
 

--- a/libbeat/reader/etw/session.go
+++ b/libbeat/reader/etw/session.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 	"syscall"
 	"unsafe"
 
@@ -68,9 +69,19 @@ type Session struct {
 	// It is obtained from StartTrace when a new trace is started.
 	// This handler is needed to enable, query or stop the trace.
 	handler uintptr
+
+	// mu guards traceHandler and stopping. StartConsumer sets them on the
+	// consumer's goroutine while StopSession reads and sets them from
+	// whichever goroutine is shutting the session down.
+	mu sync.Mutex
 	// traceHandler is the trace processing handle.
 	// It is used to control the trace that receives and processes events.
 	traceHandler uint64
+	// stopping records that StopSession has been called. StartConsumer checks
+	// it once the trace is open: a stop that arrived before then found no
+	// handle to close, and without this check ProcessTrace would block on a
+	// session that nobody is going to end.
+	stopping bool
 
 	// Pointers to functions that make calls to the Windows API.
 	// In tests, these pointers can be replaced with mock functions to simulate API behavior without making actual calls to the Windows API.
@@ -196,10 +207,37 @@ func NewSession(conf Config) (*Session, error) {
 	return session, nil
 }
 
-// StartConsumer initializes and starts the ETW event tracing session.
+// Reset prepares the session to be created or attached to again after its
+// consumer has returned, which for a realtime session happens when another
+// controller stops it. StopSession should be called first to release the
+// trace handle. The handles from the previous run and the pending stop are
+// discarded and the session properties are rebuilt, because StartTrace and
+// ControlTrace write into the properties buffer (session GUID, handle, live
+// buffer counts) and feeding the previous session's output back in as input
+// is not safe.
+//
+// Callback is kept as is on purpose: StartConsumer registers it with
+// syscall.NewCallback, which dedupes on the function value and never frees
+// registrations, so reusing the same value is what keeps reconnects from
+// leaking callback slots.
+func (s *Session) Reset() {
+	s.handler = 0
+	s.mu.Lock()
+	s.traceHandler = 0
+	s.stopping = false
+	s.mu.Unlock()
+	if s.properties != nil {
+		s.properties = newSessionProperties(s.Name, s.config)
+	}
+}
+
+// StartConsumer initializes and starts the ETW event tracing session. It
+// blocks until the trace ends. If StopSession was called before the trace was
+// open, StartConsumer closes the trace itself and returns nil without
+// processing events, the same outcome as a stop that arrives while
+// ProcessTrace is running.
 func (s *Session) StartConsumer() error {
 	var elf EventTraceLogfile
-	var err error
 
 	// Configure EventTraceLogfile based on the session type (realtime or not).
 	if !s.Realtime {
@@ -227,7 +265,7 @@ func (s *Session) StartConsumer() error {
 
 	// Open an ETW trace processing handle for consuming events
 	// from an ETW real-time trace session or an ETW log file.
-	s.traceHandler, err = s.openTrace(&elf)
+	traceHandler, err := s.openTrace(&elf)
 	switch {
 	case err == nil:
 	// Handle specific errors for trace opening.
@@ -239,8 +277,23 @@ func (s *Session) StartConsumer() error {
 		return fmt.Errorf("failed to open trace: %w", err)
 	}
 
+	// Publish the handle and check for a stop in one step, so that every
+	// ordering against StopSession is covered: a stop that ran before this
+	// point is seen here and closes the trace; one that runs after it finds
+	// the handle and closes it, which makes ProcessTrace return.
+	s.mu.Lock()
+	s.traceHandler = traceHandler
+	stopping := s.stopping
+	s.mu.Unlock()
+	if stopping {
+		if err := s.closeTrace(traceHandler); err != nil && !errors.Is(err, ERROR_CTX_CLOSE_PENDING) {
+			return fmt.Errorf("failed to close trace after stop: %w", err)
+		}
+		return nil
+	}
+
 	// Process the trace. This function blocks until processing ends.
-	if err := s.processTrace(&s.traceHandler, 1, nil, nil); err != nil {
+	if err := s.processTrace(&traceHandler, 1, nil, nil); err != nil {
 		return fmt.Errorf("failed to process trace: %w", err)
 	}
 	return nil

--- a/libbeat/reader/etw/session_test.go
+++ b/libbeat/reader/etw/session_test.go
@@ -21,6 +21,7 @@ package etw
 
 import (
 	"testing"
+	"time"
 	"unsafe"
 
 	"github.com/stretchr/testify/assert"
@@ -196,6 +197,51 @@ func TestNewSession_Logfile(t *testing.T) {
 	assert.Nil(t, session.properties)
 }
 
+func TestSession_Reset(t *testing.T) {
+	callback := func(*EventRecord) uintptr { return 0 }
+
+	t.Run("realtime session gets fresh handles and properties", func(t *testing.T) {
+		conf := Config{SessionName: "TestSession", BufferSize: 128}
+		session, err := NewSession(conf)
+		assert.NoError(t, err, "NewSession should not fail")
+		session.Callback = callback
+
+		// Simulate what StartTrace, ControlTrace, OpenTrace and StopSession
+		// leave behind.
+		session.handler = 12345
+		session.traceHandler = 67890
+		session.stopping = true
+		session.properties.Wnode.Guid = windows.GUID{Data1: 0xdeadbeef}
+		session.properties.Wnode.Union1 = 12345
+		session.properties.NumberOfBuffers = 42
+		before := session.properties
+
+		session.Reset()
+
+		assert.Equal(t, uintptr(0), session.handler, "session handle should be cleared")
+		assert.Equal(t, uint64(0), session.traceHandler, "trace handle should be cleared")
+		assert.False(t, session.stopping, "the stop from the previous run must not carry over or the next consumer would exit at once")
+		assert.NotSame(t, before, session.properties, "properties should be rebuilt, not reused")
+		assert.Equal(t, windows.GUID{}, session.properties.Wnode.Guid, "rebuilt properties should not carry the old session GUID")
+		assert.Equal(t, uint64(0), session.properties.Wnode.Union1, "rebuilt properties should not carry the old handle")
+		assert.Equal(t, uint32(0), session.properties.NumberOfBuffers, "rebuilt properties should not carry live buffer counts")
+		assert.Equal(t, uint32(128), session.properties.BufferSize, "rebuilt properties should keep the configured buffer size")
+		assert.Equal(t, before.Wnode.BufferSize, session.properties.Wnode.BufferSize, "rebuilt properties should be the same size")
+		assert.NotNil(t, session.Callback, "Reset must keep the callback so NewCallback can dedupe it")
+	})
+
+	t.Run("logfile session keeps nil properties", func(t *testing.T) {
+		session, err := NewSession(Config{Logfile: "LogFile1.etl"})
+		assert.NoError(t, err, "NewSession should not fail")
+		session.traceHandler = 67890
+
+		session.Reset()
+
+		assert.Equal(t, uint64(0), session.traceHandler, "trace handle should be cleared")
+		assert.Nil(t, session.properties, "logfile sessions have no properties to rebuild")
+	})
+}
+
 func TestStartConsumer_CallbackNull(t *testing.T) {
 	// Create a Session instance
 	session := &Session{
@@ -281,4 +327,133 @@ func TestStartConsumer_Success(t *testing.T) {
 	err := session.StartConsumer()
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(12345), session.traceHandler, "traceHandler should be set to the mock value")
+}
+
+// stoppableSession returns a realtime session whose mocks record closed trace
+// handles in *closed and run processTrace, so tests can drive the ordering of
+// StartConsumer against StopSession.
+func stoppableSession(closed *[]uint64, processTrace func(*uint64, uint32, *FileTime, *FileTime) error) *Session {
+	return &Session{
+		Name:       "TestSession",
+		Realtime:   true,
+		Callback:   func(*EventRecord) uintptr { return 1 },
+		properties: &EventTraceProperties{},
+		openTrace:  func(*EventTraceLogfile) (uint64, error) { return 12345, nil },
+		closeTrace: func(h uint64) error {
+			*closed = append(*closed, h)
+			return nil
+		},
+		controlTrace: func(uintptr, *uint16, *EventTraceProperties, uint32) error { return nil },
+		processTrace: processTrace,
+	}
+}
+
+func TestStartConsumer_StopBeforeOpen(t *testing.T) {
+	// StopSession ran before StartConsumer had a trace handle, so it had
+	// nothing to close. StartConsumer must notice the stop once the trace is
+	// open and close it itself, rather than block in ProcessTrace on a
+	// session that nobody is going to end.
+	var closed []uint64
+	session := stoppableSession(&closed, func(*uint64, uint32, *FileTime, *FileTime) error {
+		t.Error("ProcessTrace must not be called after StopSession")
+		return nil
+	})
+
+	assert.NoError(t, session.StopSession(), "stopping before the trace is open should succeed")
+	assert.Empty(t, closed, "there was no trace handle for StopSession to close yet")
+
+	assert.NoError(t, session.StartConsumer(), "a consumer stopped before it opened should finish cleanly")
+	assert.Equal(t, []uint64{12345}, closed, "StartConsumer should close the handle that StopSession could not")
+}
+
+func TestStartConsumer_AfterStopAndReset(t *testing.T) {
+	// The reconnect sequence: the previous run was stopped, the session was
+	// reset, and the consumer is started again. The old stop must not make
+	// the new consumer exit before it has processed anything.
+	var closed []uint64
+	processed := 0
+	session := stoppableSession(&closed, func(*uint64, uint32, *FileTime, *FileTime) error {
+		processed++
+		return nil
+	})
+
+	assert.NoError(t, session.StopSession(), "stopping the previous run should succeed")
+	session.Reset()
+
+	assert.NoError(t, session.StartConsumer(), "the consumer should run again after a reset")
+	assert.Equal(t, 1, processed, "ProcessTrace should run for the new consumer")
+	assert.Empty(t, closed, "nothing should have been closed while the new consumer ran")
+
+	assert.NoError(t, session.StopSession(), "stopping the new run should succeed")
+	assert.Equal(t, []uint64{12345}, closed, "StopSession should close the new consumer's handle")
+}
+
+func TestStartConsumer_StopWhileProcessing(t *testing.T) {
+	// The common shutdown: ProcessTrace is blocked and StopSession, from
+	// another goroutine, closes the trace to make it return. Under -race this
+	// also checks that the two goroutines do not touch the handle unguarded.
+	started := make(chan struct{})
+	released := make(chan struct{})
+	var closed []uint64
+	session := stoppableSession(&closed, func(*uint64, uint32, *FileTime, *FileTime) error {
+		close(started)
+		<-released // ProcessTrace returns once the trace has been closed.
+		return nil
+	})
+	closeTrace := session.closeTrace
+	session.closeTrace = func(h uint64) error {
+		err := closeTrace(h)
+		close(released)
+		return err
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- session.StartConsumer() }()
+	select {
+	case <-started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("StartConsumer never reached ProcessTrace")
+	}
+
+	assert.NoError(t, session.StopSession(), "StopSession while processing should succeed")
+	select {
+	case err := <-done:
+		assert.NoError(t, err, "StartConsumer should return once the trace is closed")
+	case <-time.After(5 * time.Second):
+		t.Fatal("StartConsumer did not return after StopSession")
+	}
+	assert.Equal(t, []uint64{12345}, closed, "StopSession should have closed the open trace handle")
+}
+
+func TestStartConsumer_ConcurrentStop(t *testing.T) {
+	// StartConsumer and StopSession run with no ordering between them, as
+	// they do when the input is cancelled just as its consumer starts. Either
+	// order must end with the trace closed exactly once and StartConsumer
+	// returning; a stop that wins the race used to leave ProcessTrace blocked
+	// for good. Under -race this also covers the handle access that the
+	// ordered test above cannot, since waiting for ProcessTrace to start
+	// serialises the two goroutines.
+	released := make(chan struct{})
+	var closed []uint64
+	session := stoppableSession(&closed, func(*uint64, uint32, *FileTime, *FileTime) error {
+		<-released // ProcessTrace returns once the trace has been closed.
+		return nil
+	})
+	closeTrace := session.closeTrace
+	session.closeTrace = func(h uint64) error {
+		err := closeTrace(h)
+		close(released)
+		return err
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- session.StartConsumer() }()
+	assert.NoError(t, session.StopSession(), "StopSession racing StartConsumer should succeed")
+	select {
+	case err := <-done:
+		assert.NoError(t, err, "StartConsumer should return whichever side closed the trace")
+	case <-time.After(5 * time.Second):
+		t.Fatal("StartConsumer did not return; the stop was lost")
+	}
+	assert.Equal(t, []uint64{12345}, closed, "the trace handle should be closed exactly once")
 }

--- a/libbeat/reader/etw/session_test.go
+++ b/libbeat/reader/etw/session_test.go
@@ -329,25 +329,6 @@ func TestStartConsumer_Success(t *testing.T) {
 	assert.Equal(t, uint64(12345), session.traceHandler, "traceHandler should be set to the mock value")
 }
 
-// stoppableSession returns a realtime session whose mocks record closed trace
-// handles in *closed and run processTrace, so tests can drive the ordering of
-// StartConsumer against StopSession.
-func stoppableSession(closed *[]uint64, processTrace func(*uint64, uint32, *FileTime, *FileTime) error) *Session {
-	return &Session{
-		Name:       "TestSession",
-		Realtime:   true,
-		Callback:   func(*EventRecord) uintptr { return 1 },
-		properties: &EventTraceProperties{},
-		openTrace:  func(*EventTraceLogfile) (uint64, error) { return 12345, nil },
-		closeTrace: func(h uint64) error {
-			*closed = append(*closed, h)
-			return nil
-		},
-		controlTrace: func(uintptr, *uint16, *EventTraceProperties, uint32) error { return nil },
-		processTrace: processTrace,
-	}
-}
-
 func TestStartConsumer_StopBeforeOpen(t *testing.T) {
 	// StopSession ran before StartConsumer had a trace handle, so it had
 	// nothing to close. StartConsumer must notice the stop once the trace is
@@ -456,4 +437,24 @@ func TestStartConsumer_ConcurrentStop(t *testing.T) {
 		t.Fatal("StartConsumer did not return; the stop was lost")
 	}
 	assert.Equal(t, []uint64{12345}, closed, "the trace handle should be closed exactly once")
+}
+
+// stoppableSession is the fixture for the tests above that drive the ordering
+// of StartConsumer against StopSession. It returns a realtime session whose
+// mocks open trace handle 12345, record every handle passed to closeTrace in
+// *closed, and run processTrace in place of ProcessTrace.
+func stoppableSession(closed *[]uint64, processTrace func(*uint64, uint32, *FileTime, *FileTime) error) *Session {
+	return &Session{
+		Name:       "TestSession",
+		Realtime:   true,
+		Callback:   func(*EventRecord) uintptr { return 1 },
+		properties: &EventTraceProperties{},
+		openTrace:  func(*EventTraceLogfile) (uint64, error) { return 12345, nil },
+		closeTrace: func(h uint64) error {
+			*closed = append(*closed, h)
+			return nil
+		},
+		controlTrace: func(uintptr, *uint16, *EventTraceProperties, uint32) error { return nil },
+		processTrace: processTrace,
+	}
 }

--- a/x-pack/filebeat/input/etw/input.go
+++ b/x-pack/filebeat/input/etw/input.go
@@ -7,6 +7,7 @@
 package etw
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strconv"
@@ -16,6 +17,7 @@ import (
 	input "github.com/elastic/beats/v7/filebeat/input/v2"
 	stateless "github.com/elastic/beats/v7/filebeat/input/v2/input-stateless"
 	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/beats/v7/libbeat/common/backoff"
 	"github.com/elastic/beats/v7/libbeat/feature"
 	"github.com/elastic/beats/v7/libbeat/management/status"
 	"github.com/elastic/beats/v7/libbeat/reader/etw"
@@ -24,14 +26,21 @@ import (
 	"github.com/elastic/elastic-agent-libs/mapstr"
 	"github.com/elastic/elastic-agent-libs/monitoring"
 	"github.com/elastic/elastic-agent-libs/monitoring/adapter"
+	"github.com/elastic/go-concert/ctxtool"
 
 	"github.com/rcrowley/go-metrics"
-	"golang.org/x/sync/errgroup"
 	"golang.org/x/sys/windows"
 )
 
 const (
 	inputName = "etw"
+
+	// Reconnect backoff bounds. A realtime session that is restarted by its
+	// owner usually comes back within seconds, and events produced while no
+	// consumer is attached are lost, so the first retries are quick. The cap
+	// keeps a session that never returns from being polled too eagerly.
+	reconnectInitialBackoff = time.Second
+	reconnectMaxBackoff     = 30 * time.Second
 )
 
 // It abstracts the underlying operations needed to work with ETW, allowing for easier
@@ -42,6 +51,7 @@ type sessionOperator interface {
 	createRealtimeSession(session *etw.Session) error
 	startConsumer(session *etw.Session) error
 	stopSession(session *etw.Session) error
+	resetSession(session *etw.Session)
 }
 
 type realSessionOperator struct{}
@@ -66,6 +76,10 @@ func (op *realSessionOperator) stopSession(session *etw.Session) error {
 	return session.StopSession()
 }
 
+func (op *realSessionOperator) resetSession(session *etw.Session) {
+	session.Reset()
+}
+
 // etwInput struct holds the configuration and state for the ETW input
 type etwInput struct {
 	log        *logp.Logger
@@ -75,6 +89,9 @@ type etwInput struct {
 	publisher  stateless.Publisher
 	operator   sessionOperator
 	health     *eventHealth
+	// backoff paces reconnection attempts. Nil means use the package
+	// defaults; tests set a short one.
+	backoff backoff.Backoff
 }
 
 func Plugin() input.Plugin {
@@ -105,6 +122,14 @@ func (e *etwInput) Test(_ input.TestContext) error {
 }
 
 // Run starts the ETW session and processes incoming events.
+//
+// For realtime sessions Run does not return when the session ends. Windows
+// makes ProcessTrace return ERROR_SUCCESS when another controller stops the
+// session (for example `logman stop <session> -ets`), which used to look like
+// a clean exit and left the input stopped until Filebeat was restarted. Run
+// now treats that as a lost session: it reports Degraded and keeps trying to
+// create or attach to the session again, with backoff, until it is consuming
+// events or the input is cancelled.
 func (e *etwInput) Run(ctx input.Context, publisher stateless.Publisher) error {
 	var err error
 
@@ -124,6 +149,10 @@ func (e *etwInput) Run(ctx input.Context, publisher stateless.Publisher) error {
 		ctx.UpdateStatus(status.Failed, "failed to initialize ETW session: "+errDetail(err))
 		return fmt.Errorf("error initializing ETW session: %w", err)
 	}
+	// The same session object, and so the same Callback value, is reused for
+	// every reconnect. StartConsumer hands Callback to syscall.NewCallback,
+	// which dedupes on the function value but never frees registrations and
+	// caps them process-wide, so a fresh closure per attempt would leak.
 	e.etwSession.Callback = e.consumeEvent
 	e.publisher = publisher
 	e.metrics = newInputMetrics(e.etwSession.Name, ctx.MetricsRegistry, ctx.Logger)
@@ -133,65 +162,156 @@ func (e *etwInput) Run(ctx input.Context, publisher stateless.Publisher) error {
 	e.log.Info("Starting " + inputName + " input")
 	defer e.log.Info(inputName + " input stopped")
 
-	// Handle realtime session creation or attachment
+	b := e.backoff
+	if b == nil {
+		b = backoff.NewEqualJitterBackoff(reconnectInitialBackoff, reconnectMaxBackoff)
+	}
+	cancelCtx := ctxtool.FromCanceller(ctx.Cancelation)
+
+	// The first pass fails fast so that a bad configuration or missing
+	// privileges surface as Failed with the runner's error log. Once the
+	// session has worked, losing it is treated as transient: it is most
+	// likely being restarted by whoever owns it, so we stay Degraded and
+	// keep trying to get it back for as long as the input runs.
+	for attempt := 0; ; attempt++ {
+		err = e.runSession(ctx, cancelCtx, attempt == 0)
+		switch {
+		case cancelCtx.Err() != nil:
+			// Shutting down. The consumer was stopped by us, so whatever it
+			// returned is not a failure.
+			return nil
+		case !e.etwSession.Realtime:
+			// Reading an .etl file: ProcessTrace returning means the file
+			// has been read to the end. There is nothing to reconnect to.
+			if err != nil {
+				ctx.UpdateStatus(status.Failed, statusMessage(err))
+			}
+			return err
+		case attempt == 0 && err != nil:
+			ctx.UpdateStatus(status.Failed, statusMessage(err))
+			return err
+		}
+
+		if err != nil {
+			e.log.Warnw("reconnecting to ETW session failed, will retry", "attempt", attempt, "error", err)
+			ctx.UpdateStatus(status.Degraded, fmt.Sprintf("%s; reconnecting (attempt %d)", statusMessage(err), attempt+1))
+		} else {
+			// The session was consuming and then ended without us asking:
+			// another controller stopped it. Start the backoff over, since
+			// the previous schedule was for a different outage.
+			e.log.Warn("ETW session stopped by another controller, reconnecting")
+			ctx.UpdateStatus(status.Degraded, fmt.Sprintf("ETW session %q stopped; reconnecting (attempt %d)",
+				e.etwSession.Name, attempt+1))
+			b.Reset()
+		}
+		if !b.Wait(cancelCtx) {
+			return nil
+		}
+		// Counted after the wait so that it only covers attempts that are
+		// made, not one that shutdown interrupted.
+		e.metrics.reconnects.Inc()
+		e.operator.resetSession(e.etwSession)
+	}
+}
+
+// runSession connects to the session and consumes it until ProcessTrace
+// returns, then stops the session so its handles are released before any
+// reconnect. cancelCtx is ctx.Cancelation as a context.Context. first selects
+// the lifecycle statuses: only the first pass reports Configuring, so a
+// reconnect stays Degraded until it is consuming again.
+func (e *etwInput) runSession(ctx input.Context, cancelCtx context.Context, first bool) error {
 	if e.etwSession.Realtime {
-		ctx.UpdateStatus(status.Configuring, "")
-		switch e.etwSession.NewSession {
-		case true:
-			// Create a new realtime session
-			// If it fails with ERROR_ALREADY_EXISTS we try to attach to it
-			createErr := e.operator.createRealtimeSession(e.etwSession)
-			if createErr == nil {
-				e.log.Debug("created new session")
-				break
-			}
-			if !errors.Is(createErr, etw.ERROR_ALREADY_EXISTS) {
-				ctx.UpdateStatus(status.Failed, fmt.Sprintf("failed to create realtime session %q for provider %s: %s",
-					e.etwSession.Name, e.config.provider(), errDetail(createErr)))
-				return fmt.Errorf("realtime session could not be created: %w", createErr)
-			}
-			e.log.Debug("session already exists, trying to attach to it")
-			fallthrough
-		case false:
-			// Attach to an existing session
-			if err := e.operator.attachToExistingSession(e.etwSession); err != nil {
-				ctx.UpdateStatus(status.Failed, fmt.Sprintf("failed to attach to session %q: %s",
-					e.etwSession.Name, errDetail(err)))
-				return fmt.Errorf("unable to retrieve handler: %w", err)
-			}
-			e.log.Debug("attached to existing session")
+		if first {
+			ctx.UpdateStatus(status.Configuring, "")
+		}
+		if err := e.connect(); err != nil {
+			return err
 		}
 	}
 
-	stopConsumer := sync.OnceFunc(e.Close)
-	defer stopConsumer()
-
-	// Stop the consumer upon input cancellation (shutdown).
-	go func() {
-		<-ctx.Cancelation.Done()
-		stopConsumer()
+	// Stop the session on cancellation so that ProcessTrace returns. The
+	// same stop runs when the consumer returns for any other reason, to
+	// close the trace handle; OnceFunc makes the two paths safe together.
+	stop := sync.OnceFunc(e.Close)
+	unregister := context.AfterFunc(cancelCtx, stop)
+	defer func() {
+		unregister()
+		stop()
 	}()
 
-	// Start a goroutine to consume ETW events
-	g := new(errgroup.Group)
-	g.Go(func() error {
-		e.log.Debug("starting ETW consumer")
-		defer e.log.Debug("stopped ETW consumer")
-		// startConsumer opens the trace and then blocks inside ProcessTrace
-		// for the life of the session, so there is no point after it returns
-		// where we could report Running. Report it up front; if opening the
-		// trace fails we immediately move to Failed below.
-		ctx.UpdateStatus(status.Running, "")
-		if err = e.operator.startConsumer(e.etwSession); err != nil {
-			e.metrics.errors.Inc()
-			ctx.UpdateStatus(status.Failed, fmt.Sprintf("ETW consumer for session %q failed: %s",
-				e.etwSession.Name, errDetail(err)))
-			return fmt.Errorf("failed running ETW consumer: %w", err)
+	e.log.Debug("starting ETW consumer")
+	defer e.log.Debug("stopped ETW consumer")
+	// startConsumer opens the trace and then blocks inside ProcessTrace for
+	// the life of the session, so there is no point after it returns where
+	// we could report Running. Report it up front; if opening the trace
+	// fails the caller moves to Failed or Degraded right after.
+	ctx.UpdateStatus(status.Running, "")
+	// A Degraded that eventHealth reported for the previous session has just
+	// been overwritten by Running; its counters must agree or it would never
+	// report Degraded again.
+	e.health.reset()
+	if err := e.operator.startConsumer(e.etwSession); err != nil {
+		e.metrics.errors.Inc()
+		return &sessionError{
+			status: fmt.Sprintf("ETW consumer for session %q failed: %s", e.etwSession.Name, errDetail(err)),
+			err:    fmt.Errorf("failed running ETW consumer: %w", err),
 		}
-		return nil
-	})
+	}
+	return nil
+}
 
-	return g.Wait()
+// connect creates the realtime session or attaches to an existing one. When
+// creating fails with ERROR_ALREADY_EXISTS the input attaches instead, which
+// is also how it picks a session back up after a reconnect races the owner.
+func (e *etwInput) connect() error {
+	switch e.etwSession.NewSession {
+	case true:
+		createErr := e.operator.createRealtimeSession(e.etwSession)
+		if createErr == nil {
+			e.log.Debug("created new session")
+			return nil
+		}
+		if !errors.Is(createErr, etw.ERROR_ALREADY_EXISTS) {
+			return &sessionError{
+				status: fmt.Sprintf("failed to create realtime session %q for provider %s: %s",
+					e.etwSession.Name, e.config.provider(), errDetail(createErr)),
+				err: fmt.Errorf("realtime session could not be created: %w", createErr),
+			}
+		}
+		e.log.Debug("session already exists, trying to attach to it")
+		fallthrough
+	case false:
+		if err := e.operator.attachToExistingSession(e.etwSession); err != nil {
+			return &sessionError{
+				status: fmt.Sprintf("failed to attach to session %q: %s", e.etwSession.Name, errDetail(err)),
+				err:    fmt.Errorf("unable to retrieve handler: %w", err),
+			}
+		}
+		e.log.Debug("attached to existing session")
+	}
+	return nil
+}
+
+// sessionError is returned by runSession. It carries the message for the
+// status reporter separately from the error returned to the runner: the status
+// message names the session and provider and spells out Windows error codes,
+// while the returned error keeps the shorter form that ends up in the runner's
+// log line. Run decides whether it means Failed or Degraded.
+type sessionError struct {
+	status string
+	err    error
+}
+
+func (e *sessionError) Error() string { return e.err.Error() }
+func (e *sessionError) Unwrap() error { return e.err }
+
+// statusMessage returns the text to report for err.
+func statusMessage(err error) string {
+	var se *sessionError
+	if errors.As(err, &se) {
+		return se.status
+	}
+	return errDetail(err)
 }
 
 // eventHealth turns the per-event success/failure stream from consumeEvent
@@ -248,6 +368,15 @@ func (h *eventHealth) success() {
 	}
 	h.degraded = false
 	h.reporter.UpdateStatus(status.Running, "")
+}
+
+// reset forgets the run counts and any Degraded that was reported. It is for
+// when the input has reported a lifecycle status itself, such as Running
+// after a reconnect, so that the two views of the input's health agree.
+func (h *eventHealth) reset() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.bad, h.good, h.degraded = 0, 0, false
 }
 
 var (
@@ -453,14 +582,16 @@ func errDetail(err error) string {
 	return msg
 }
 
-// Close stops the ETW session and logs the outcome.
+// Close stops the ETW session and logs the outcome. It runs both at shutdown
+// and after a session ends on its own, to release the trace handle before the
+// session is reused.
 func (e *etwInput) Close() {
 	if err := e.operator.stopSession(e.etwSession); err != nil {
-		e.log.Error("failed to shutdown ETW session")
+		e.log.Errorw("failed to stop ETW session", "error", err)
 		e.metrics.errors.Inc()
 		return
 	}
-	e.log.Info("successfully shutdown")
+	e.log.Info("ETW session stopped")
 }
 
 // inputMetrics handles event log metric reporting.
@@ -471,6 +602,7 @@ type inputMetrics struct {
 	events         *monitoring.Uint   // total number of events received
 	dropped        *monitoring.Uint   // total number of discarded events
 	errors         *monitoring.Uint   // total number of errors
+	reconnects     *monitoring.Uint   // total number of attempts to reconnect after the session ended
 	sourceLag      metrics.Sample     // histogram of the difference between timestamped event's creation and reading
 	arrivalPeriod  metrics.Sample     // histogram of the elapsed time between callbacks.
 	processingTime metrics.Sample     // histogram of the elapsed time between event callback receipt and publication.
@@ -484,6 +616,7 @@ func newInputMetrics(session string, reg *monitoring.Registry, logger *logp.Logg
 		events:         monitoring.NewUint(reg, "received_events_total"),
 		dropped:        monitoring.NewUint(reg, "discarded_events_total"),
 		errors:         monitoring.NewUint(reg, "errors_total"),
+		reconnects:     monitoring.NewUint(reg, "reconnects_total"),
 		sourceLag:      metrics.NewUniformSample(1024),
 		arrivalPeriod:  metrics.NewUniformSample(1024),
 		processingTime: metrics.NewUniformSample(1024),

--- a/x-pack/filebeat/input/etw/input.go
+++ b/x-pack/filebeat/input/etw/input.go
@@ -129,7 +129,8 @@ func (e *etwInput) Test(_ input.TestContext) error {
 // a clean exit and left the input stopped until Filebeat was restarted. Run
 // now treats that as a lost session: it reports Degraded and keeps trying to
 // create or attach to the session again, with backoff, until it is consuming
-// events or the input is cancelled.
+// events, the input is cancelled, or an attempt fails with an error that
+// waiting will not fix, which reports Failed.
 func (e *etwInput) Run(ctx input.Context, publisher stateless.Publisher) error {
 	var err error
 
@@ -172,7 +173,8 @@ func (e *etwInput) Run(ctx input.Context, publisher stateless.Publisher) error {
 	// privileges surface as Failed with the runner's error log. Once the
 	// session has worked, losing it is treated as transient: it is most
 	// likely being restarted by whoever owns it, so we stay Degraded and
-	// keep trying to get it back for as long as the input runs.
+	// keep trying to get it back for as long as the input runs. Only
+	// failures that waiting can fix are retried, though; see isTransient.
 	for attempt := 0; ; attempt++ {
 		err = e.runSession(ctx, cancelCtx, attempt == 0)
 		switch {
@@ -187,7 +189,7 @@ func (e *etwInput) Run(ctx input.Context, publisher stateless.Publisher) error {
 				ctx.UpdateStatus(status.Failed, statusMessage(err))
 			}
 			return err
-		case attempt == 0 && err != nil:
+		case err != nil && (attempt == 0 || !isTransient(err)):
 			ctx.UpdateStatus(status.Failed, statusMessage(err))
 			return err
 		}
@@ -214,6 +216,17 @@ func (e *etwInput) Run(ctx input.Context, publisher stateless.Publisher) error {
 	}
 }
 
+// isTransient reports whether a reconnect failure is one that waiting can
+// fix. Only "session is not running" qualifies: the owner has stopped the
+// session and has not started it again yet, which is exactly what the
+// reconnect loop exists to wait out. Anything else, such as access denied or
+// a provider that cannot be enabled, is the same class of error that fails
+// the first pass and does not clear by retrying, so the input reports Failed
+// rather than sitting Degraded forever.
+func isTransient(err error) bool {
+	return errors.Is(err, etw.ERROR_WMI_INSTANCE_NOT_FOUND)
+}
+
 // runSession connects to the session and consumes it until ProcessTrace
 // returns, then stops the session so its handles are released before any
 // reconnect. cancelCtx is ctx.Cancelation as a context.Context. first selects
@@ -225,6 +238,12 @@ func (e *etwInput) runSession(ctx input.Context, cancelCtx context.Context, firs
 			ctx.UpdateStatus(status.Configuring, "")
 		}
 		if err := e.connect(); err != nil {
+			// connect can fail part way: StartTrace succeeds and enabling a
+			// provider does not. That leaves a session running with no
+			// providers, and the next attempt would hit ERROR_ALREADY_EXISTS,
+			// attach to it and collect nothing. Tear down whatever connect
+			// built; StopSession is a no-op if it built nothing.
+			e.Close()
 			return err
 		}
 	}
@@ -375,8 +394,8 @@ func (h *eventHealth) success() {
 // after a reconnect, so that the two views of the input's health agree.
 func (h *eventHealth) reset() {
 	h.mu.Lock()
-	defer h.mu.Unlock()
 	h.bad, h.good, h.degraded = 0, 0, false
+	h.mu.Unlock()
 }
 
 var (

--- a/x-pack/filebeat/input/etw/input_test.go
+++ b/x-pack/filebeat/input/etw/input_test.go
@@ -532,6 +532,129 @@ func Test_RunEtwInput_RecreateOwnSessionAfterItStops(t *testing.T) {
 	assert.Equal(t, int32(1), mockOperator.resets.Load(), "the session should be reset once per reconnect")
 }
 
+func Test_RunEtwInput_ReconnectPermanentErrorFails(t *testing.T) {
+	// The session was lost and the reconnect attempt fails with an error that
+	// waiting will not fix. Staying Degraded forever would hide a problem that
+	// needs a person, so the input reports Failed and returns, exactly as it
+	// would had the same error happened on the first pass.
+	mockOperator := &mockSessionOperator{}
+	mockOperator.newSessionFunc = func(config) (*etw.Session, error) {
+		return &etw.Session{Name: "MySession", Realtime: true, NewSession: false}, nil
+	}
+	var attaches atomic.Int32
+	mockOperator.attachToExistingSessionFunc = func(*etw.Session) error {
+		if attaches.Add(1) == 1 {
+			return nil
+		}
+		return fmt.Errorf("failed to get handler: %w", etw.ERROR_ACCESS_DENIED)
+	}
+	mockOperator.startConsumerFunc = func(*etw.Session) error { return nil } // Session lost at once.
+
+	reporter := &recordingReporter{}
+	inputCtx := input.Context{
+		Cancelation:     t.Context(),
+		Logger:          logptest.NewTestingLogger(t, ""),
+		MetricsRegistry: monitoring.NewRegistry(),
+	}.WithStatusReporter(reporter)
+
+	etwInput := &etwInput{
+		config:   config{Session: "MySession"},
+		operator: mockOperator,
+		backoff:  testBackoff(),
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- etwInput.Run(inputCtx, nil) }()
+	select {
+	case err := <-done:
+		assert.ErrorContains(t, err, "unable to retrieve handler", "the permanent error should be returned to the runner")
+		assert.ErrorIs(t, err, etw.ERROR_ACCESS_DENIED, "the underlying Windows error should be preserved")
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run kept retrying a permanent error instead of failing")
+	}
+	assert.Equal(t, []status.Status{status.Starting, status.Configuring, status.Running, status.Degraded, status.Failed}, reporter.statuses(),
+		"a permanent reconnect failure should end in Failed, not stay Degraded")
+	assert.Contains(t, reporter.lastMsg(), "Performance Log Users",
+		"the Failed message should carry the same detail a first-pass failure would")
+	assert.Equal(t, int32(2), attaches.Load(), "there should be exactly one reconnect attempt")
+}
+
+func Test_RunEtwInput_ConnectFailureStopsSession(t *testing.T) {
+	// Creating a session can fail after StartTrace has succeeded, for example
+	// when a provider cannot be enabled. Without a stop, that half-configured
+	// session stays running; the next attempt would then get
+	// ERROR_ALREADY_EXISTS, attach to it, and never see an event.
+	tests := []struct {
+		name string
+		// failOnCreate is the create call that fails: 1 is the first pass,
+		// 2 is the first reconnect attempt.
+		failOnCreate int32
+		wantStatus   []status.Status
+		wantStops    int32
+	}{
+		{
+			name:         "first pass",
+			failOnCreate: 1,
+			wantStatus:   []status.Status{status.Starting, status.Configuring, status.Failed},
+			wantStops:    1, // Teardown after the failed create.
+		},
+		{
+			name:         "reconnect",
+			failOnCreate: 2,
+			wantStatus:   []status.Status{status.Starting, status.Configuring, status.Running, status.Degraded, status.Failed},
+			wantStops:    2, // Cleanup after the loss, then teardown after the failed create.
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			mockOperator := &mockSessionOperator{}
+			mockOperator.newSessionFunc = func(config) (*etw.Session, error) {
+				return &etw.Session{Name: "MySession", Realtime: true, NewSession: true}, nil
+			}
+			var creates, stops atomic.Int32
+			mockOperator.createRealtimeSessionFunc = func(*etw.Session) error {
+				if creates.Add(1) == test.failOnCreate {
+					return fmt.Errorf("failed to enable trace: %w", etw.ERROR_INVALID_PARAMETER)
+				}
+				return nil
+			}
+			mockOperator.attachToExistingSessionFunc = func(*etw.Session) error {
+				t.Error("a create failure other than ERROR_ALREADY_EXISTS must not fall back to attach")
+				return nil
+			}
+			mockOperator.startConsumerFunc = func(*etw.Session) error { return nil } // Session lost at once.
+			mockOperator.stopSessionFunc = func(*etw.Session) error {
+				stops.Add(1)
+				return nil
+			}
+
+			reporter := &recordingReporter{}
+			inputCtx := input.Context{
+				Cancelation:     t.Context(),
+				Logger:          logptest.NewTestingLogger(t, ""),
+				MetricsRegistry: monitoring.NewRegistry(),
+			}.WithStatusReporter(reporter)
+
+			etwInput := &etwInput{
+				config:   config{ProviderName: "Microsoft-Windows-Provider", SessionName: "MySession"},
+				operator: mockOperator,
+				backoff:  testBackoff(),
+			}
+
+			done := make(chan error, 1)
+			go func() { done <- etwInput.Run(inputCtx, nil) }()
+			select {
+			case err := <-done:
+				assert.ErrorContains(t, err, "realtime session could not be created", "the create error should be returned")
+			case <-time.After(5 * time.Second):
+				t.Fatal("Run did not return after the create failure")
+			}
+			assert.Equal(t, test.wantStatus, reporter.statuses(), "create failure should end in Failed")
+			assert.Equal(t, test.wantStops, stops.Load(), "the session must be stopped after a failed create so nothing is left running")
+		})
+	}
+}
+
 func Test_RunEtwInput_LogfileDoesNotReconnect(t *testing.T) {
 	// For an .etl file ProcessTrace returning means end of file. That is
 	// the input finishing its job, not a lost session.

--- a/x-pack/filebeat/input/etw/input_test.go
+++ b/x-pack/filebeat/input/etw/input_test.go
@@ -13,6 +13,7 @@ import (
 	"slices"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -20,6 +21,7 @@ import (
 	"golang.org/x/sys/windows"
 
 	input "github.com/elastic/beats/v7/filebeat/input/v2"
+	"github.com/elastic/beats/v7/libbeat/common/backoff"
 	"github.com/elastic/beats/v7/libbeat/management/status"
 	"github.com/elastic/beats/v7/libbeat/reader/etw"
 	"github.com/elastic/elastic-agent-libs/logp/logptest"
@@ -34,6 +36,13 @@ type mockSessionOperator struct {
 	createRealtimeSessionFunc   func(session *etw.Session) error
 	startConsumerFunc           func(session *etw.Session) error
 	stopSessionFunc             func(session *etw.Session) error
+
+	// resets counts resetSession calls, one per reconnect attempt.
+	resets atomic.Int32
+}
+
+func (m *mockSessionOperator) resetSession(*etw.Session) {
+	m.resets.Add(1)
 }
 
 func (m *mockSessionOperator) newSession(config config) (*etw.Session, error) {
@@ -122,7 +131,7 @@ func Test_RunEtwInput_NewSessionError(t *testing.T) {
 	// Setup input
 	reporter := &recordingReporter{}
 	inputCtx := input.Context{
-		Cancelation:     nil,
+		Cancelation:     t.Context(),
 		Logger:          logptest.NewTestingLogger(t, ""),
 		MetricsRegistry: monitoring.NewRegistry(),
 	}.WithStatusReporter(reporter)
@@ -171,7 +180,7 @@ func Test_RunEtwInput_AttachToExistingSessionError(t *testing.T) {
 	// Setup input
 	reporter := &recordingReporter{}
 	inputCtx := input.Context{
-		Cancelation:     nil,
+		Cancelation:     t.Context(),
 		Logger:          logptest.NewTestingLogger(t, ""),
 		MetricsRegistry: monitoring.NewRegistry(),
 	}.WithStatusReporter(reporter)
@@ -223,7 +232,7 @@ func Test_RunEtwInput_CreateRealtimeSessionError(t *testing.T) {
 	// Setup input
 	reporter := &recordingReporter{}
 	inputCtx := input.Context{
-		Cancelation:     nil,
+		Cancelation:     t.Context(),
 		Logger:          logptest.NewTestingLogger(t, ""),
 		MetricsRegistry: monitoring.NewRegistry(),
 	}.WithStatusReporter(reporter)
@@ -412,6 +421,273 @@ func Test_RunEtwInput_Success(t *testing.T) {
 		"a healthy start should report Starting, Configuring, Running exactly once each")
 }
 
+func Test_RunEtwInput_ReconnectAfterAttachedSessionStops(t *testing.T) {
+	// The input is attached to a session owned by someone else, who stops it
+	// and restarts it a little later. ProcessTrace returns success when the
+	// session stops, so the first startConsumer returns nil unprompted.
+	// Attaching then fails until the owner has restarted the session.
+	mockOperator := &mockSessionOperator{}
+	mockOperator.newSessionFunc = func(config) (*etw.Session, error) {
+		return &etw.Session{Name: "MySession", Realtime: true, NewSession: false}, nil
+	}
+	var attaches atomic.Int32
+	mockOperator.attachToExistingSessionFunc = func(*etw.Session) error {
+		// 1: initial attach. 2, 3: session still gone. 4: it is back.
+		switch attaches.Add(1) {
+		case 2, 3:
+			return fmt.Errorf("session is not running: %w", etw.ERROR_WMI_INSTANCE_NOT_FOUND)
+		}
+		return nil
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	consumes := lostSessionConsumer(mockOperator, ctx)
+	reporter := &recordingReporter{}
+	inputCtx := input.Context{
+		Cancelation:     ctx,
+		Logger:          logptest.NewTestingLogger(t, ""),
+		MetricsRegistry: monitoring.NewRegistry(),
+	}.WithStatusReporter(reporter)
+
+	etwInput := &etwInput{
+		config:   config{Session: "MySession"},
+		operator: mockOperator,
+		backoff:  testBackoff(),
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- etwInput.Run(inputCtx, nil) }()
+
+	want := []status.Status{
+		status.Starting, status.Configuring, status.Running, // First connection.
+		status.Degraded, // Session stopped by its owner.
+		status.Degraded, // Reconnect attempt 2 could not attach.
+		status.Degraded, // Reconnect attempt 3 could not attach.
+		status.Running,  // Reattached.
+	}
+	waitForUpdateCount(t, reporter, len(want))
+	cancel()
+	assert.NoError(t, <-done, "Run should exit cleanly on cancellation after reconnecting")
+
+	assert.Equal(t, want, reporter.statuses(), "input should stay Degraded while the session is gone and recover to Running")
+	updates := reporter.updates
+	assert.Equal(t, `ETW session "MySession" stopped; reconnecting (attempt 1)`, updates[3].msg,
+		"losing the session should say so and count the attempt")
+	assert.Equal(t, fmt.Sprintf(`failed to attach to session "MySession": session is not running: %v (windows error %d); reconnecting (attempt 2)`,
+		etw.ERROR_WMI_INSTANCE_NOT_FOUND, uint32(etw.ERROR_WMI_INSTANCE_NOT_FOUND)), updates[4].msg,
+		"a failed reconnect should carry the attach error and the next attempt number")
+	assert.Equal(t, int32(4), attaches.Load(), "one initial attach plus one per reconnect attempt")
+	assert.Equal(t, int32(2), consumes.Load(), "the consumer should only start once the session is back")
+	assert.Equal(t, int32(3), mockOperator.resets.Load(), "the session should be reset before every reconnect attempt")
+	assert.Equal(t, uint64(3), etwInput.metrics.reconnects.Get(), "reconnects_total should count every attempt")
+}
+
+func Test_RunEtwInput_RecreateOwnSessionAfterItStops(t *testing.T) {
+	// The input created the session itself and someone stops it from
+	// outside. Recreating it does not depend on anyone else, so the first
+	// reconnect attempt succeeds.
+	mockOperator := &mockSessionOperator{}
+	mockOperator.newSessionFunc = func(config) (*etw.Session, error) {
+		return &etw.Session{Name: "MySession", Realtime: true, NewSession: true}, nil
+	}
+	var creates, attaches atomic.Int32
+	mockOperator.createRealtimeSessionFunc = func(*etw.Session) error {
+		creates.Add(1)
+		return nil
+	}
+	mockOperator.attachToExistingSessionFunc = func(*etw.Session) error {
+		attaches.Add(1)
+		return nil
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	consumes := lostSessionConsumer(mockOperator, ctx)
+	reporter := &recordingReporter{}
+	inputCtx := input.Context{
+		Cancelation:     ctx,
+		Logger:          logptest.NewTestingLogger(t, ""),
+		MetricsRegistry: monitoring.NewRegistry(),
+	}.WithStatusReporter(reporter)
+
+	etwInput := &etwInput{
+		config:   config{ProviderName: "Microsoft-Windows-Provider", SessionName: "MySession"},
+		operator: mockOperator,
+		backoff:  testBackoff(),
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- etwInput.Run(inputCtx, nil) }()
+
+	want := []status.Status{status.Starting, status.Configuring, status.Running, status.Degraded, status.Running}
+	waitForUpdateCount(t, reporter, len(want))
+	cancel()
+	assert.NoError(t, <-done, "Run should exit cleanly on cancellation after reconnecting")
+
+	assert.Equal(t, want, reporter.statuses(), "a recreated session should go Degraded then straight back to Running")
+	assert.Equal(t, int32(2), creates.Load(), "the session should be created again after it was stopped")
+	assert.Equal(t, int32(0), attaches.Load(), "creating succeeded, so there should be no attach fallback")
+	assert.Equal(t, int32(2), consumes.Load(), "the consumer should be started for each session")
+	assert.Equal(t, int32(1), mockOperator.resets.Load(), "the session should be reset once per reconnect")
+}
+
+func Test_RunEtwInput_LogfileDoesNotReconnect(t *testing.T) {
+	// For an .etl file ProcessTrace returning means end of file. That is
+	// the input finishing its job, not a lost session.
+	tests := []struct {
+		name        string
+		consumerErr error
+		wantErr     string
+		wantStatus  []status.Status
+	}{
+		{
+			name:       "end of file",
+			wantStatus: []status.Status{status.Starting, status.Running},
+		},
+		{
+			name:        "unreadable file",
+			consumerErr: fmt.Errorf("invalid log source when opening trace: %w", etw.ERROR_BAD_PATHNAME),
+			wantErr:     "failed running ETW consumer: invalid log source when opening trace",
+			wantStatus:  []status.Status{status.Starting, status.Running, status.Failed},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			mockOperator := &mockSessionOperator{}
+			mockOperator.newSessionFunc = func(config) (*etw.Session, error) {
+				return &etw.Session{Name: `C:\logs\trace.etl`, Realtime: false}, nil
+			}
+			var connects atomic.Int32
+			mockOperator.createRealtimeSessionFunc = func(*etw.Session) error {
+				connects.Add(1)
+				return nil
+			}
+			mockOperator.attachToExistingSessionFunc = func(*etw.Session) error {
+				connects.Add(1)
+				return nil
+			}
+			mockOperator.startConsumerFunc = func(*etw.Session) error { return test.consumerErr }
+
+			reporter := &recordingReporter{}
+			inputCtx := input.Context{
+				Cancelation:     t.Context(),
+				Logger:          logptest.NewTestingLogger(t, ""),
+				MetricsRegistry: monitoring.NewRegistry(),
+			}.WithStatusReporter(reporter)
+
+			etwInput := &etwInput{
+				config:   config{Logfile: `C:\logs\trace.etl`},
+				operator: mockOperator,
+				backoff:  testBackoff(),
+			}
+
+			done := make(chan error, 1)
+			go func() { done <- etwInput.Run(inputCtx, nil) }()
+			select {
+			case err := <-done:
+				if test.wantErr == "" {
+					assert.NoError(t, err, "reaching the end of the file is a clean exit")
+				} else {
+					assert.ErrorContains(t, err, test.wantErr, "a consumer error on a file is fatal")
+				}
+			case <-time.After(5 * time.Second):
+				t.Fatal("Run did not return after the file was consumed; it must not try to reconnect")
+			}
+			assert.Equal(t, test.wantStatus, reporter.statuses(), "file input should not report Configuring or Degraded")
+			assert.Equal(t, int32(0), connects.Load(), "file input should neither create nor attach to a session")
+			assert.Equal(t, int32(0), mockOperator.resets.Load(), "file input should never reset the session")
+			assert.Equal(t, uint64(0), etwInput.metrics.reconnects.Get(), "file input should never count a reconnect")
+		})
+	}
+}
+
+func Test_RunEtwInput_CancelWhileWaitingToReconnect(t *testing.T) {
+	// Shutdown during the backoff between reconnect attempts must return
+	// promptly and cleanly, not report Failed and not wait out the backoff.
+	mockOperator := &mockSessionOperator{}
+	mockOperator.newSessionFunc = func(config) (*etw.Session, error) {
+		return &etw.Session{Name: "MySession", Realtime: true, NewSession: false}, nil
+	}
+	mockOperator.startConsumerFunc = func(*etw.Session) error { return nil } // Session lost at once.
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	reporter := &recordingReporter{}
+	inputCtx := input.Context{
+		Cancelation:     ctx,
+		Logger:          logptest.NewTestingLogger(t, ""),
+		MetricsRegistry: monitoring.NewRegistry(),
+	}.WithStatusReporter(reporter)
+
+	etwInput := &etwInput{
+		config:   config{Session: "MySession"},
+		operator: mockOperator,
+		// Long enough that the test can only pass if cancellation
+		// interrupts the wait.
+		backoff: backoff.NewEqualJitterBackoff(time.Hour, time.Hour),
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- etwInput.Run(inputCtx, nil) }()
+	waitForStatus(t, reporter, status.Degraded)
+	cancel()
+	select {
+	case err := <-done:
+		assert.NoError(t, err, "cancellation while waiting to reconnect is a clean exit")
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run did not return after cancellation while waiting to reconnect")
+	}
+	assert.Equal(t, []status.Status{status.Starting, status.Configuring, status.Running, status.Degraded}, reporter.statuses(),
+		"shutdown while Degraded must not report Failed")
+	assert.Equal(t, int32(0), mockOperator.resets.Load(), "cancelled before the reconnect attempt, so no reset")
+	assert.Equal(t, uint64(0), etwInput.metrics.reconnects.Get(), "an attempt that shutdown interrupted must not be counted")
+}
+
+// lostSessionConsumer configures op so that startConsumer returns nil at once
+// on its first call, as ProcessTrace does when another controller stops the
+// session, and on later calls blocks until the input is cancelled and stops
+// the session. It returns the count of startConsumer calls.
+//
+// The release is keyed on cancellation rather than on which stopSession call
+// this is: the input's own cleanup stop after the loss must not release the
+// consumer, and cancellation may land before or after the second
+// startConsumer call, since Running is reported just ahead of it.
+func lostSessionConsumer(op *mockSessionOperator, ctx context.Context) *atomic.Int32 {
+	consumes := new(atomic.Int32)
+	stopped := make(chan struct{})
+	var closeStopped sync.Once
+	op.startConsumerFunc = func(*etw.Session) error {
+		if consumes.Add(1) == 1 {
+			return nil
+		}
+		<-stopped
+		return nil
+	}
+	op.stopSessionFunc = func(*etw.Session) error {
+		if ctx.Err() != nil {
+			closeStopped.Do(func() { close(stopped) })
+		}
+		return nil
+	}
+	return consumes
+}
+
+// testBackoff returns a backoff short enough that reconnect tests run in
+// milliseconds rather than the seconds production waits.
+func testBackoff() backoff.Backoff {
+	return backoff.NewEqualJitterBackoff(time.Millisecond, 5*time.Millisecond)
+}
+
+// waitForUpdateCount blocks until reporter has recorded at least n status
+// updates, failing the test if they do not show up in time.
+func waitForUpdateCount(t *testing.T, reporter *recordingReporter, n int) {
+	t.Helper()
+	assert.Eventually(t, func() bool {
+		return len(reporter.statuses()) >= n
+	}, 5*time.Second, 10*time.Millisecond, "input never reported %d status updates, got %v", n, reporter.statuses())
+}
+
 // blockConsumerUntilStopped makes the mock consumer behave like the real
 // one: startConsumer blocks until stopSession is called, so tests can
 // exercise the cancellation path rather than having Run return at once.
@@ -438,8 +714,8 @@ func waitForStatus(t *testing.T, reporter *recordingReporter, want status.Status
 
 func Test_eventHealth(t *testing.T) {
 	// Each test feeds a string of events to eventHealth: 'b' is a failure,
-	// 'g' is a success. Spaces are ignored and are only there to make the
-	// runs readable.
+	// 'g' is a success and 'r' is a reset, as done on reconnect. Spaces are
+	// ignored and are only there to make the runs readable.
 	degraded := func(n int) statusUpdate {
 		return statusUpdate{status.Degraded, fmt.Sprintf("%d consecutive events could not be read; last error: bad", n)}
 	}
@@ -508,6 +784,29 @@ func Test_eventHealth(t *testing.T) {
 			events:   "bbbbbbbbbb gggg",
 			want:     nil,
 		},
+		{
+			// Run reports Running itself after a reconnect. Without the
+			// reset the stale degraded flag would swallow the second run.
+			name:     "reset after Degraded lets the next failure run report again",
+			failure:  3,
+			recovery: 1,
+			events:   "bbb r bbb",
+			want:     []statusUpdate{degraded(3), degraded(3)},
+		},
+		{
+			name:     "reset clears a partial failure run",
+			failure:  3,
+			recovery: 1,
+			events:   "bb r bb",
+			want:     nil,
+		},
+		{
+			name:     "reset while healthy reports nothing",
+			failure:  3,
+			recovery: 1,
+			events:   "gg r gg",
+			want:     nil,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -523,6 +822,8 @@ func Test_eventHealth(t *testing.T) {
 					h.failure(errors.New("bad"))
 				case 'g':
 					h.success()
+				case 'r':
+					h.reset()
 				}
 			}
 			assert.Equal(t, test.want, reporter.updates,
@@ -559,6 +860,40 @@ func Test_errDetail(t *testing.T) {
 			assert.Equal(t, test.want, errDetail(test.err), "errDetail(%v)", test.err)
 		})
 	}
+}
+
+func Test_statusMessage(t *testing.T) {
+	se := &sessionError{
+		status: `failed to attach to session "MySession": boom (windows error 5)`,
+		err:    errors.New("unable to retrieve handler: boom"),
+	}
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{
+			name: "session error reports its status text",
+			err:  se,
+			want: se.status,
+		},
+		{
+			name: "wrapped session error is still found",
+			err:  fmt.Errorf("outer: %w", se),
+			want: se.status,
+		},
+		{
+			name: "other errors fall back to errDetail",
+			err:  fmt.Errorf("stopped: %w", etw.ERROR_WMI_INSTANCE_NOT_FOUND),
+			want: errDetail(fmt.Errorf("stopped: %w", etw.ERROR_WMI_INSTANCE_NOT_FOUND)),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.want, statusMessage(test.err), "statusMessage(%v)", test.err)
+		})
+	}
+	assert.EqualError(t, se, "unable to retrieve handler: boom", "the runner should see the short error, not the status text")
 }
 
 func Test_buildEvent(t *testing.T) {


### PR DESCRIPTION
## Type of change
- Bug

## Proposed commit message
```
llibbeat/reader/etw,x-pack/filebeat/input/etw: reconnect when the realtime session is stopped

When an external controller stops a realtime ETW session (e.g. logman
stop <session> -ets), ProcessTrace returns ERROR_SUCCESS. The input
returned nil on that result, which the stateless input manager treats as
a clean finish, so the ETW input stopped without restarting.

The fix adds reconnection logic to the input and the supporting changes
to the reader needed to make a session safe to reuse. The input now
treats an external stop as transient: it reports Degraded, waits with
backoff, and re-establishes the session. Two race conditions in the
reader (one that could hang shutdown, one flagged by the race detector)
are fixed as a side effect of making the reader handle repeated start/
stop cycles.

x-pack/filebeat/input/etw:

  - Run now loops over the session lifecycle so it can reconnect after
    an external stop. The first iteration retains fail-fast behaviour:
    bad configuration or missing privileges still report Failed.
  - After a session has been established, losing it reports Degraded.
    The input waits with equal-jitter backoff capped at 30s, resets
    the session, then creates or attaches to it again. It reports
    Running once consumption resumes. Reading from an .etl file is
    unchanged: end of file ends the input.
  - One Session and Callback are reused across reconnects so that
    syscall.NewCallback deduplicates the registration rather than
    leaking a slot per attempt.
  - eventHealth is reset before each Running report so a stale Degraded
    from the previous session does not suppress the new one.
  - Cancellation uses context.AfterFunc scoped to each session instead
    of a goroutine that outlived Run; the single-task errgroup is
    removed.
  - Add a reconnects_total metric and a doc section on reconnection.

libbeat/reader/etw:

  - Add Session.Reset to clear stale handles and rebuild the properties
    buffer that StartTrace and ControlTrace write into. Callback is
    preserved across resets: syscall.NewCallback deduplicates on the
    function value and never frees registrations, so re-registering a
    new closure per reconnect would leak callback slots.
  - StopSession now treats ERROR_WMI_INSTANCE_NOT_FOUND as success;
    the session being already gone is the expected state on reconnect.
  - If Stop was called before OpenTrace returned, the stop was lost and
    ProcessTrace blocked indefinitely, hanging shutdown. The fix records
    the stop in a flag and checks it once the trace handle is available,
    holding both the flag and traceHandler under one mutex so every
    ordering produces exactly one CloseTrace call. This also removes the
    unsynchronised access to traceHandler between the consumer and
    stopper goroutines that the race detector flagged.

The auditbeat file_integrity module uses the same reader and inherits
the last two fixes; its behaviour is otherwise unchanged.

Fixes #49984

Assisted-By: Cursor
```
<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

- Closes https://github.com/elastic/beats/issues/49984


## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
