### PR TITLE
fix: register Kafka input Sarama metrics on the per-input registry

### DIFF
--- a/changelog/fragments/1788943710-filebeat-kafka-input-local-metrics-registry.yaml
+++ b/changelog/fragments/1788943710-filebeat-kafka-input-local-metrics-registry.yaml
@@ -11,18 +11,11 @@
 kind: bug-fix
 
 # Change summary; a 80ish characters long description of the change.
-summary: Register Filebeat Kafka input Sarama metrics on the per-input registry
+summary: Fix race condition in Kafka input when multiple inputs are configured.
 
 # Long description; in case the summary is not enough to describe the change
 # this field accommodate a description without length limits.
 description: >
-  The Kafka input registered Sarama go-metrics on the process-global
-  monitoring.Default under filebeat.inputs.kafka. Multiple inputs (or
-  per-stream filebeatreceivers) opening brokers at once raced on
-  Registry.Add("bytes_read") and panicked with "name bytes_read already used".
-  Metrics now attach at Run on the input's MetricsRegistry, matching other
-  Filebeat inputs. bytes_read and bytes_write are reported per input under
-  the dataset namespace instead of as process-global stats.
 
 component: filebeat
 

--- a/changelog/fragments/1788943710-filebeat-kafka-input-local-metrics-registry.yaml
+++ b/changelog/fragments/1788943710-filebeat-kafka-input-local-metrics-registry.yaml
@@ -1,0 +1,30 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user's deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# Change summary; a 80ish characters long description of the change.
+summary: Register Filebeat Kafka input Sarama metrics on the per-input registry
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+description: >
+  The Kafka input registered Sarama go-metrics on the process-global
+  monitoring.Default under filebeat.inputs.kafka. Multiple inputs (or
+  per-stream filebeatreceivers) opening brokers at once raced on
+  Registry.Add("bytes_read") and panicked with "name bytes_read already used".
+  Metrics now attach at Run on the input's MetricsRegistry, matching other
+  Filebeat inputs. bytes_read and bytes_write are reported per input under
+  the dataset namespace instead of as process-global stats.
+
+component: filebeat
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+issue: https://github.com/elastic/beats/issues/34919

--- a/filebeat/input/kafka/config.go
+++ b/filebeat/input/kafka/config.go
@@ -238,12 +238,6 @@ func newSaramaConfig(config kafkaInputConfig, logger *logp.Logger) (*sarama.Conf
 	return k, nil
 }
 
-// attachSaramaMetrics registers Sarama's go-metrics on parent instead of
-// monitoring.Default. parent should be the input's MetricsRegistry so each
-// Kafka input (and each filebeatreceiver) has its own tree. Sharing Default
-// panics with "name bytes_read already used" when several inputs open brokers
-// at once. A nil parent gets a private registry so CheckConfig/tests stay off
-// the process global.
 func attachSaramaMetrics(k *sarama.Config, parent *monitoring.Registry, logger *logp.Logger) {
 	if parent == nil {
 		parent = monitoring.NewRegistry()

--- a/filebeat/input/kafka/config.go
+++ b/filebeat/input/kafka/config.go
@@ -232,19 +232,30 @@ func newSaramaConfig(config kafkaInputConfig, logger *logp.Logger) (*sarama.Conf
 	// configure client ID
 	k.ClientID = config.ClientID
 
+	if err := k.Validate(); err != nil {
+		return nil, err
+	}
+	return k, nil
+}
+
+// attachSaramaMetrics registers Sarama's go-metrics on parent instead of
+// monitoring.Default. parent should be the input's MetricsRegistry so each
+// Kafka input (and each filebeatreceiver) has its own tree. Sharing Default
+// panics with "name bytes_read already used" when several inputs open brokers
+// at once. A nil parent gets a private registry so CheckConfig/tests stay off
+// the process global.
+func attachSaramaMetrics(k *sarama.Config, parent *monitoring.Registry, logger *logp.Logger) {
+	if parent == nil {
+		parent = monitoring.NewRegistry()
+	}
 	k.MetricRegistry = adapter.GetGoMetrics(
-		monitoring.Default,
-		"filebeat.inputs.kafka",
+		parent,
+		"kafka",
 		logger,
 		adapter.Rename("incoming-byte-rate", "bytes_read"),
 		adapter.Rename("outgoing-byte-rate", "bytes_write"),
 		adapter.GoMetricsNilify,
 	)
-
-	if err := k.Validate(); err != nil {
-		return nil, err
-	}
-	return k, nil
 }
 
 // asSaramaOffset converts an initialOffset enum to the corresponding

--- a/filebeat/input/kafka/config_test.go
+++ b/filebeat/input/kafka/config_test.go
@@ -19,13 +19,16 @@ package kafka
 
 import (
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
+	metrics "github.com/rcrowley/go-metrics"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/monitoring"
 )
 
 // TestNewSaramaConfigDefaults verifies that the default input config maps the
@@ -33,7 +36,11 @@ import (
 // existing configurations are unaffected by these options being added.
 func TestNewSaramaConfigDefaults(t *testing.T) {
 	saramaConfig, err := newSaramaConfig(defaultConfig(), logp.NewNopLogger())
-	require.NoError(t, err)
+	require.NoError(t, err, "default config should produce a valid sarama config")
+	assert.Nil(t, monitoring.Default.Get("filebeat.inputs.kafka"),
+		"config construction must not register Sarama metrics on monitoring.Default")
+	assert.Nil(t, monitoring.Default.Get("kafka"),
+		"config construction must not register Sarama metrics on monitoring.Default")
 
 	assert.Equal(t, 10*time.Second, saramaConfig.Consumer.Group.Session.Timeout)
 	assert.Equal(t, 3*time.Second, saramaConfig.Consumer.Group.Heartbeat.Interval)
@@ -118,4 +125,60 @@ func TestNewSaramaConfigGroupInstanceIDInvalid(t *testing.T) {
 				"invalid group_instance_id %q must be rejected", id)
 		})
 	}
+}
+
+func TestAttachSaramaMetricsUsesParentRegistry(t *testing.T) {
+	parent := monitoring.NewRegistry()
+	cfg, err := newSaramaConfig(defaultConfig(), logp.NewNopLogger())
+	require.NoError(t, err, "default config should produce a valid sarama config")
+
+	attachSaramaMetrics(cfg, parent, logp.NewNopLogger())
+	require.NotNil(t, cfg.MetricRegistry, "Sarama should have a metric registry after attach")
+
+	metrics.GetOrRegisterMeter("incoming-byte-rate", cfg.MetricRegistry)
+	assert.NotNil(t, parent.Get("kafka.bytes_read"),
+		"incoming-byte-rate should be renamed to bytes_read on the provided parent")
+	assert.Nil(t, monitoring.Default.Get("filebeat.inputs.kafka.bytes_read"),
+		"must not register Kafka input metrics on the process-global registry")
+	assert.Nil(t, monitoring.Default.Get("kafka.bytes_read"),
+		"must not register Kafka input metrics on the process-global registry")
+}
+
+func TestAttachSaramaMetricsNilParentDoesNotUseDefault(t *testing.T) {
+	cfg, err := newSaramaConfig(defaultConfig(), logp.NewNopLogger())
+	require.NoError(t, err, "default config should produce a valid sarama config")
+
+	attachSaramaMetrics(cfg, nil, logp.NewNopLogger())
+	require.NotNil(t, cfg.MetricRegistry, "nil parent should still get a private registry")
+
+	metrics.GetOrRegisterMeter("incoming-byte-rate", cfg.MetricRegistry)
+	assert.Nil(t, monitoring.Default.Get("filebeat.inputs.kafka.bytes_read"),
+		"nil parent must not fall back to monitoring.Default")
+	assert.Nil(t, monitoring.Default.Get("kafka.bytes_read"),
+		"nil parent must not fall back to monitoring.Default")
+}
+
+func TestAttachSaramaMetricsIsolatedPerParent(t *testing.T) {
+	const n = 32
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			parent := monitoring.NewRegistry()
+			cfg, err := newSaramaConfig(defaultConfig(), logp.NewNopLogger())
+			assert.NoError(t, err, "default config should produce a valid sarama config")
+			if err != nil {
+				return
+			}
+			attachSaramaMetrics(cfg, parent, logp.NewNopLogger())
+			metrics.GetOrRegisterMeter("incoming-byte-rate", cfg.MetricRegistry)
+			metrics.GetOrRegisterMeter("outgoing-byte-rate", cfg.MetricRegistry)
+			assert.NotNil(t, parent.Get("kafka.bytes_read"),
+				"each parent should own its own bytes_read metric")
+			assert.NotNil(t, parent.Get("kafka.bytes_write"),
+				"each parent should own its own bytes_write metric")
+		}()
+	}
+	wg.Wait()
 }

--- a/filebeat/input/kafka/config_test.go
+++ b/filebeat/input/kafka/config_test.go
@@ -162,7 +162,7 @@ func TestAttachSaramaMetricsIsolatedPerParent(t *testing.T) {
 	const n = 32
 	var wg sync.WaitGroup
 	wg.Add(n)
-	for i := 0; i < n; i++ {
+	for range n {
 		go func() {
 			defer wg.Done()
 			parent := monitoring.NewRegistry()

--- a/filebeat/input/kafka/input.go
+++ b/filebeat/input/kafka/input.go
@@ -120,6 +120,8 @@ func (input *kafkaInput) Test(ctx input.TestContext) error {
 func (input *kafkaInput) Run(ctx input.Context, pipeline beat.Pipeline) error {
 	log := ctx.Logger.Named("kafka input").With("hosts", input.config.Hosts)
 
+	attachSaramaMetrics(input.saramaConfig, ctx.MetricsRegistry, log)
+
 	client, err := pipeline.ConnectWith(beat.ClientConfig{
 		EventListener: acker.ConnectionOnly(
 			acker.EventPrivateReporter(func(_ int, events []any) {

--- a/filebeat/input/kafka/kafka_integration_test.go
+++ b/filebeat/input/kafka/kafka_integration_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/elastic/elastic-agent-libs/mapstr"
+	"github.com/elastic/elastic-agent-libs/monitoring"
 
 	"github.com/stretchr/testify/assert"
 
@@ -568,8 +569,9 @@ func newV2Context() (v2.Context, func()) {
 	ctx, cancel := context.WithCancel(context.Background())
 	logger, _ := logp.NewDevelopmentLogger("kafka_test")
 	return v2.Context{
-		Logger:      logger,
-		ID:          "test_id",
-		Cancelation: ctx,
+		Logger:          logger,
+		ID:              "test_id",
+		Cancelation:     ctx,
+		MetricsRegistry: monitoring.NewRegistry(),
 	}, cancel
 }


### PR DESCRIPTION
## Proposed commit message
This PR solves two problems on Kafka input

1. Kafka input uses global registry for monitoring metrics. When multiple kafka input units are configured from elastic-agent (in otel runtime), they incorrectly report process wide metrics - even when each units runs as its own receiver. This PR isolates that. We now provide unique monitoring registry per input ID. 

2. When multiple kafka inputs are configured in standalone mode - we share a global monitoring registry across inputa [here](https://github.com/elastic/beats/blob/main/filebeat/input/kafka/config.go#L236). When sarama attempts to register a metric name - a race condition is observed [here](https://github.com/elastic/elastic-agent-libs/blob/main/monitoring/adapter/go-metrics.go#L171) which results in [panic](https://github.com/elastic/elastic-agent-libs/blob/main/monitoring/registry.go#L190-L198). This was reported in an SDH. 

Since we isolate the parent registry on each input now - the panic is resolved.  
 
Panic stack can be observed on this issue https://github.com/elastic/beats/issues/34919
## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact
Kafka input metrics are now reported per input instead of process wide

## How to test this PR locally

A simple test produces the panic on main. 

```go
func TestReproduce(t *testing.T) {
	logger := logp.NewNopLogger()
	const n = 8
	cfgs := make([]*sarama.Config, n)
	for i := range n {
		cfg, err := newSaramaConfig(defaultConfig(), logger)
		require.NoError(t, err, "default config should produce a valid sarama config")
		cfgs[i] = cfg
	}

	var wg sync.WaitGroup
	wg.Add(n)
	for _, cfg := range cfgs {
		go func(cfg *sarama.Config) {
			defer wg.Done()
			metrics.GetOrRegisterMeter("incoming-byte-rate", cfg.MetricRegistry)
		}(cfg)

	}
	wg.Wait()
}
```

The new tests cover: metrics land on the provided parent, a nil parent does not fall back to `monitoring.Default`, and many goroutines each with their own parent can register `bytes_read` / `bytes_write` without panicking.

## Related issues
From this SDH https://github.com/elastic/sdh-beats/issues/7581
Closes https://github.com/elastic/beats/issues/34919
