### PR TITLE
filestream: add take_over.from_any_id for ID-agnostic state takeover

### DIFF
--- a/changelog/fragments/1788890286-filestream-take-over-from-id-patterns.yaml
+++ b/changelog/fragments/1788890286-filestream-take-over-from-id-patterns.yaml
@@ -1,0 +1,7 @@
+kind: enhancement
+
+summary: filestream take_over now supports regex patterns via from_id_patterns
+
+component: filebeat
+
+issue: https://github.com/elastic/beats/issues/53097

--- a/changelog/fragments/1788890286-filestream-take-over-from-id-patterns.yaml
+++ b/changelog/fragments/1788890286-filestream-take-over-from-id-patterns.yaml
@@ -1,7 +1,0 @@
-kind: enhancement
-
-summary: filestream take_over now supports regex patterns via from_id_patterns
-
-component: filebeat
-
-issue: https://github.com/elastic/beats/issues/53097

--- a/changelog/fragments/1788963414-filestream-take-over-from-any-id.yaml
+++ b/changelog/fragments/1788963414-filestream-take-over-from-any-id.yaml
@@ -1,0 +1,7 @@
+kind: enhancement
+
+summary: filestream take_over supports from_any_id to migrate from any previous filestream input
+
+component: filebeat
+
+issue: https://github.com/elastic/beats/issues/51307

--- a/docs/reference/filebeat/filebeat-input-filestream.md
+++ b/docs/reference/filebeat/filebeat-input-filestream.md
@@ -389,6 +389,20 @@ take_over:
   from_ids: ["foo", "bar"]
 ```
 
+When the source input IDs share a common pattern — for example when IDs are generated dynamically —
+use `take_over.from_id_patterns` instead of (or in addition to) `from_ids`.
+Each entry is a [Go regular expression](https://pkg.go.dev/regexp/syntax) matched against the
+input ID segment of registry keys. Invalid patterns are rejected at startup.
+
+```yaml
+take_over:
+  enabled: true
+  from_id_patterns: ["old-input-.*", "legacy-[0-9]+"]
+```
+
+`from_ids` and `from_id_patterns` can be combined; both are matched.
+When either is set, files are not taken over from `log` inputs.
+
 This take over mode was created to enable smooth migration from
 deprecated `log` inputs to the new `filestream` inputs and to allow
 changing `filestream` input IDs without data re-ingestion.

--- a/docs/reference/filebeat/filebeat-input-filestream.md
+++ b/docs/reference/filebeat/filebeat-input-filestream.md
@@ -389,19 +389,19 @@ take_over:
   from_ids: ["foo", "bar"]
 ```
 
-When the source input IDs share a common pattern — for example when IDs are generated dynamically —
-use `take_over.from_id_patterns` instead of (or in addition to) `from_ids`.
-Each entry is a [Go regular expression](https://pkg.go.dev/regexp/syntax) matched against the
-input ID segment of registry keys. Invalid patterns are rejected at startup.
+When the previous input IDs are unknown — for example when migrating from many
+dynamically-created autodiscover inputs to a single static `filestream` input —
+use `take_over.from_any_id: true` instead of listing individual IDs.
+This takes over states from every previous `filestream` input, regardless of ID.
+`from_any_id` is mutually exclusive with `from_ids`.
 
 ```yaml
 take_over:
   enabled: true
-  from_id_patterns: ["old-input-.*", "legacy-[0-9]+"]
+  from_any_id: true
 ```
 
-`from_ids` and `from_id_patterns` can be combined; both are matched.
-When either is set, files are not taken over from `log` inputs.
+When `from_ids` or `from_any_id` is set, files are not taken over from `log` inputs.
 
 This take over mode was created to enable smooth migration from
 deprecated `log` inputs to the new `filestream` inputs and to allow

--- a/docs/reference/filebeat/filebeat-input-filestream.md
+++ b/docs/reference/filebeat/filebeat-input-filestream.md
@@ -389,6 +389,9 @@ take_over:
   from_ids: ["foo", "bar"]
 ```
 
+```{applies_to}
+stack: beta 9.6.0
+```
 When the previous input IDs are unknown — for example when migrating from many
 dynamically-created autodiscover inputs to a single static `filestream` input —
 use `take_over.from_any_id: true` instead of listing individual IDs.
@@ -402,6 +405,13 @@ take_over:
 ```
 
 When `from_ids` or `from_any_id` is set, files are not taken over from `log` inputs.
+
+::::{warning}
+`from_any_id` assumes each file is tracked by only one previous input. If multiple
+inputs have registry state for the same file, it is non-deterministic which state
+will be migrated. Use `from_ids` instead when multiple inputs may have tracked the
+same files.
+::::
 
 This take over mode was created to enable smooth migration from
 deprecated `log` inputs to the new `filestream` inputs and to allow

--- a/docs/reference/filebeat/filebeat-reference-yml.md
+++ b/docs/reference/filebeat/filebeat-reference-yml.md
@@ -899,10 +899,18 @@ filebeat.inputs:
   # Available options: since_first_start, since_last_start.
   #ignore_inactive: ""
 
-  # If `take_over` is set to `true`, this `filestream` will take over all files
-  # from `log` inputs if they match at least one of the `paths` set in the `filestream`.
+  # When enabled, this `filestream` input takes over states from `log` inputs
+  # or other `filestream` inputs. Only files actively matched by `paths` are migrated.
   # This functionality is still in beta.
-  #take_over: false
+  #take_over:
+  #  enabled: true
+  #  # Take over from specific filestream inputs by exact ID.
+  #  # When set, files are not taken over from `log` inputs.
+  #  #from_ids: ["foo", "bar"]
+  #  # Take over from filestream inputs whose ID matches any of these Go regexes.
+  #  # Invalid patterns are rejected at startup. Can be combined with from_ids.
+  #  # When set, files are not taken over from `log` inputs.
+  #  #from_id_patterns: ["old-input-.*", "legacy-[0-9]+"]
 
   # Defines the buffer size every harvester uses when fetching the file
   #harvester_buffer_size: 16384

--- a/docs/reference/filebeat/filebeat-reference-yml.md
+++ b/docs/reference/filebeat/filebeat-reference-yml.md
@@ -907,10 +907,10 @@ filebeat.inputs:
   #  # Take over from specific filestream inputs by exact ID.
   #  # When set, files are not taken over from `log` inputs.
   #  #from_ids: ["foo", "bar"]
-  #  # Take over from filestream inputs whose ID matches any of these Go regexes.
-  #  # Invalid patterns are rejected at startup. Can be combined with from_ids.
+  #  # Take over from any previous filestream input, regardless of ID.
+  #  # Mutually exclusive with from_ids.
   #  # When set, files are not taken over from `log` inputs.
-  #  #from_id_patterns: ["old-input-.*", "legacy-[0-9]+"]
+  #  #from_any_id: false
 
   # Defines the buffer size every harvester uses when fetching the file
   #harvester_buffer_size: 16384

--- a/docs/reference/filebeat/migrate-to-filestream.md
+++ b/docs/reference/filebeat/migrate-to-filestream.md
@@ -113,6 +113,9 @@ Every `filestream` input **must** have a unique identifier as `id`. Using meanin
 
 ::::{important}
 Never change the ID of an input, or you will end up with duplicate events.
+If you do need to rename an input ID, use [`take_over.from_ids`](/reference/filebeat/filebeat-input-filestream.md#filebeat-input-filestream-take-over)
+to migrate the existing registry state to the new ID without re-ingesting data.
+To migrate from multiple inputs whose IDs share a pattern, use `take_over.from_id_patterns` instead.
 ::::
 
 Let's start the migration process with this simple set of `filestream` inputs without any additional parameters for now:

--- a/docs/reference/filebeat/migrate-to-filestream.md
+++ b/docs/reference/filebeat/migrate-to-filestream.md
@@ -112,10 +112,11 @@ The intermediate configuration snippets are for illustration purposes only.
 Every `filestream` input **must** have a unique identifier as `id`. Using meaningful identifiers for each new `filestream` input will also make it easier to troubleshoot if something goes wrong.
 
 ::::{important}
-Never change the ID of an input, or you will end up with duplicate events.
-If you do need to rename an input ID, use [`take_over.from_ids`](/reference/filebeat/filebeat-input-filestream.md#filebeat-input-filestream-take-over)
-to migrate the existing registry state to the new ID without re-ingesting data.
-To migrate from many inputs without knowing their IDs in advance, use `take_over.from_any_id: true` instead.
+Changing an input ID can result in duplicate events. To migrate an existing input to a new ID
+without re-ingesting data, use [`take_over.from_ids`](/reference/filebeat/filebeat-input-filestream.md#filebeat-input-filestream-take-over) to transfer its registry state.
+
+To migrate registry state from multiple inputs when their IDs are unknown, use
+`take_over.from_any_id: true`.
 ::::
 
 Let's start the migration process with this simple set of `filestream` inputs without any additional parameters for now:

--- a/docs/reference/filebeat/migrate-to-filestream.md
+++ b/docs/reference/filebeat/migrate-to-filestream.md
@@ -115,7 +115,7 @@ Every `filestream` input **must** have a unique identifier as `id`. Using meanin
 Never change the ID of an input, or you will end up with duplicate events.
 If you do need to rename an input ID, use [`take_over.from_ids`](/reference/filebeat/filebeat-input-filestream.md#filebeat-input-filestream-take-over)
 to migrate the existing registry state to the new ID without re-ingesting data.
-To migrate from multiple inputs whose IDs share a pattern, use `take_over.from_id_patterns` instead.
+To migrate from many inputs without knowing their IDs in advance, use `take_over.from_any_id: true` instead.
 ::::
 
 Let's start the migration process with this simple set of `filestream` inputs without any additional parameters for now:

--- a/filebeat/_meta/config/filebeat.inputs.reference.yml.tmpl
+++ b/filebeat/_meta/config/filebeat.inputs.reference.yml.tmpl
@@ -504,12 +504,10 @@ filebeat.inputs:
   #  from `filestream` inputs that were assigned these IDs.
   #  Taking over from `log` inputs is disabled when `from_ids` is set.
   #  from_ids: ["foo", "bar"]
-  #  If `from_id_patterns` is set, files are taken over from any `filestream`
-  #  input whose ID matches one of the provided Go regular expressions.
-  #  Patterns are matched only against the input ID segment of registry keys.
-  #  Invalid patterns are rejected at startup. Can be combined with `from_ids`.
-  #  Taking over from `log` inputs is disabled when `from_id_patterns` is set.
-  #  from_id_patterns: ["old-input-.*", "legacy-[0-9]+"]
+  #  If `from_any_id` is true, files are taken over from any previous
+  #  `filestream` input, regardless of its ID. Mutually exclusive with `from_ids`.
+  #  Taking over from `log` inputs is disabled when `from_any_id` is set.
+  #  from_any_id: false
 
   # Defines the buffer size every harvester uses when fetching the file
   #harvester_buffer_size: 16384

--- a/filebeat/_meta/config/filebeat.inputs.reference.yml.tmpl
+++ b/filebeat/_meta/config/filebeat.inputs.reference.yml.tmpl
@@ -504,6 +504,12 @@ filebeat.inputs:
   #  from `filestream` inputs that were assigned these IDs.
   #  Taking over from `log` inputs is disabled when `from_ids` is set.
   #  from_ids: ["foo", "bar"]
+  #  If `from_id_patterns` is set, files are taken over from any `filestream`
+  #  input whose ID matches one of the provided Go regular expressions.
+  #  Patterns are matched only against the input ID segment of registry keys.
+  #  Invalid patterns are rejected at startup. Can be combined with `from_ids`.
+  #  Taking over from `log` inputs is disabled when `from_id_patterns` is set.
+  #  from_id_patterns: ["old-input-.*", "legacy-[0-9]+"]
 
   # Defines the buffer size every harvester uses when fetching the file
   #harvester_buffer_size: 16384

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -923,6 +923,12 @@ filebeat.inputs:
   #  from `filestream` inputs that were assigned these IDs.
   #  Taking over from `log` inputs is disabled when `from_ids` is set.
   #  from_ids: ["foo", "bar"]
+  #  If `from_id_patterns` is set, files are taken over from any `filestream`
+  #  input whose ID matches one of the provided Go regular expressions.
+  #  Patterns are matched only against the input ID segment of registry keys.
+  #  Invalid patterns are rejected at startup. Can be combined with `from_ids`.
+  #  Taking over from `log` inputs is disabled when `from_id_patterns` is set.
+  #  from_id_patterns: ["old-input-.*", "legacy-[0-9]+"]
 
   # Defines the buffer size every harvester uses when fetching the file
   #harvester_buffer_size: 16384

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -923,12 +923,10 @@ filebeat.inputs:
   #  from `filestream` inputs that were assigned these IDs.
   #  Taking over from `log` inputs is disabled when `from_ids` is set.
   #  from_ids: ["foo", "bar"]
-  #  If `from_id_patterns` is set, files are taken over from any `filestream`
-  #  input whose ID matches one of the provided Go regular expressions.
-  #  Patterns are matched only against the input ID segment of registry keys.
-  #  Invalid patterns are rejected at startup. Can be combined with `from_ids`.
-  #  Taking over from `log` inputs is disabled when `from_id_patterns` is set.
-  #  from_id_patterns: ["old-input-.*", "legacy-[0-9]+"]
+  #  If `from_any_id` is true, files are taken over from any previous
+  #  `filestream` input, regardless of its ID. Mutually exclusive with `from_ids`.
+  #  Taking over from `log` inputs is disabled when `from_any_id` is set.
+  #  from_any_id: false
 
   # Defines the buffer size every harvester uses when fetching the file
   #harvester_buffer_size: 16384

--- a/filebeat/input/filestream/internal/input-logfile/input.go
+++ b/filebeat/input/filestream/internal/input-logfile/input.go
@@ -37,7 +37,7 @@ type managedInput struct {
 	manager                *InputManager
 	ackCH                  *updateChan
 	sourceIdentifier       *SourceIdentifier
-	previousSrcIdentifiers []*SourceIdentifier
+	previousSrcIdentifiers []InputMatcher
 	prospector             Prospector
 	harvester              Harvester
 	cleanTimeout           time.Duration

--- a/filebeat/input/filestream/internal/input-logfile/input.go
+++ b/filebeat/input/filestream/internal/input-logfile/input.go
@@ -37,7 +37,7 @@ type managedInput struct {
 	manager                *InputManager
 	ackCH                  *updateChan
 	sourceIdentifier       *SourceIdentifier
-	previousSrcIdentifiers []InputMatcher
+	previousMatchers []InputMatcher
 	takeOverAnyID          bool
 	prospector             Prospector
 	harvester              Harvester
@@ -87,7 +87,7 @@ func (inp *managedInput) Run(
 		return err
 	}
 	defer prospectorStore.Release()
-	sourceStore := newSourceStore(prospectorStore, inp.sourceIdentifier, inp.previousSrcIdentifiers, inp.takeOverAnyID)
+	sourceStore := newSourceStore(prospectorStore, inp.sourceIdentifier, inp.previousMatchers, inp.takeOverAnyID)
 
 	// Setup cancellation using a custom cancel context. All harvesters will be
 	// stopped if one failed badly by returning an error.

--- a/filebeat/input/filestream/internal/input-logfile/input.go
+++ b/filebeat/input/filestream/internal/input-logfile/input.go
@@ -33,19 +33,19 @@ import (
 type managedInput struct {
 	// id is the input ID, it is defined by setting 'id'
 	// in the input configuration
-	id                     string
-	manager                *InputManager
-	ackCH                  *updateChan
-	sourceIdentifier       *SourceIdentifier
-	previousMatchers []InputMatcher
-	takeOverAnyID          bool
-	prospector             Prospector
-	harvester              Harvester
-	cleanTimeout           time.Duration
-	harvesterLimit         uint64
-	readUntilEOF           ReadUntilEOFConfig
-	backoff                BackoffConfig
-	stateCheckInterval     time.Duration
+	id                 string
+	manager            *InputManager
+	ackCH              *updateChan
+	sourceIdentifier   *SourceIdentifier
+	previousMatchers   []InputMatcher
+	takeOverAnyID      bool
+	prospector         Prospector
+	harvester          Harvester
+	cleanTimeout       time.Duration
+	harvesterLimit     uint64
+	readUntilEOF       ReadUntilEOFConfig
+	backoff            BackoffConfig
+	stateCheckInterval time.Duration
 }
 
 // Name is required to implement the v2.Input interface

--- a/filebeat/input/filestream/internal/input-logfile/input.go
+++ b/filebeat/input/filestream/internal/input-logfile/input.go
@@ -38,6 +38,7 @@ type managedInput struct {
 	ackCH                  *updateChan
 	sourceIdentifier       *SourceIdentifier
 	previousSrcIdentifiers []InputMatcher
+	takeOverAnyID          bool
 	prospector             Prospector
 	harvester              Harvester
 	cleanTimeout           time.Duration
@@ -86,7 +87,7 @@ func (inp *managedInput) Run(
 		return err
 	}
 	defer prospectorStore.Release()
-	sourceStore := newSourceStore(prospectorStore, inp.sourceIdentifier, inp.previousSrcIdentifiers)
+	sourceStore := newSourceStore(prospectorStore, inp.sourceIdentifier, inp.previousSrcIdentifiers, inp.takeOverAnyID)
 
 	// Setup cancellation using a custom cancel context. All harvesters will be
 	// stopped if one failed badly by returning an error.

--- a/filebeat/input/filestream/internal/input-logfile/manager.go
+++ b/filebeat/input/filestream/internal/input-logfile/manager.go
@@ -20,6 +20,7 @@ package input_logfile
 import (
 	"errors"
 	"fmt"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -260,7 +261,7 @@ func (cim *InputManager) Create(config *conf.C) (inp v2.Input, retErr error) {
 		return nil, errNoInputRunner
 	}
 
-	var previousSrcIdentifiers []*SourceIdentifier
+	var previousMatchers []InputMatcher
 	if settings.TakeOver.Enabled {
 		for _, id := range settings.TakeOver.FromIDs {
 			si, err := NewSourceIdentifier(cim.Type, id)
@@ -270,12 +271,21 @@ func (cim *InputManager) Create(config *conf.C) (inp v2.Input, retErr error) {
 						"[ID: %q] error while creating source identifier for previous ID %q: %w",
 						settings.ID, id, err)
 			}
-
-			previousSrcIdentifiers = append(previousSrcIdentifiers, si)
+			previousMatchers = append(previousMatchers, si)
+		}
+		for _, pattern := range settings.TakeOver.FromIDPatterns {
+			rm, err := newRegexInputMatcher(cim.Type, pattern)
+			if err != nil {
+				return nil,
+					fmt.Errorf(
+						"[ID: %q] error while creating regex matcher for pattern %q: %w",
+						settings.ID, pattern, err)
+			}
+			previousMatchers = append(previousMatchers, rm)
 		}
 	}
 
-	prospectorStore := newSourceStore(pStore, srcIdentifier, previousSrcIdentifiers)
+	prospectorStore := newSourceStore(pStore, srcIdentifier, previousMatchers)
 
 	// create a store with the deprecated global ID. This will be used to
 	// migrate the entries in the registry to use the new input ID.
@@ -300,7 +310,7 @@ func (cim *InputManager) Create(config *conf.C) (inp v2.Input, retErr error) {
 		backoff:                settings.Backoff,
 		stateCheckInterval:     settings.Close.OnStateChange.CheckInterval,
 		sourceIdentifier:       srcIdentifier,
-		previousSrcIdentifiers: previousSrcIdentifiers,
+		previousSrcIdentifiers: previousMatchers,
 		cleanTimeout:           settings.CleanInactive,
 		harvesterLimit:         settings.HarvesterLimit,
 	}, nil
@@ -383,13 +393,53 @@ func (i *SourceIdentifier) MatchesInput(id string) bool {
 	return strings.HasPrefix(id, i.prefix)
 }
 
+// InputMatcher reports whether a registry key belongs to a given input.
+type InputMatcher interface {
+	MatchesInput(key string) bool
+}
+
+// RegexInputMatcher matches registry keys whose input ID segment matches a compiled regexp.
+type RegexInputMatcher struct {
+	pluginPrefix string
+	pattern      *regexp.Regexp
+}
+
+func newRegexInputMatcher(pluginName, pattern string) (*RegexInputMatcher, error) {
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return nil, fmt.Errorf("invalid from_id_patterns entry %q: %w", pattern, err)
+	}
+	return &RegexInputMatcher{
+		pluginPrefix: pluginName + "::",
+		pattern:      re,
+	}, nil
+}
+
+func (r *RegexInputMatcher) MatchesInput(key string) bool {
+	if !strings.HasPrefix(key, r.pluginPrefix) {
+		return false
+	}
+	rest := key[len(r.pluginPrefix):]
+	idx := strings.Index(rest, "::")
+	var inputID string
+	if idx < 0 {
+		inputID = rest
+	} else {
+		inputID = rest[:idx]
+	}
+	return r.pattern.MatchString(inputID)
+}
+
 // TakeOverConfig is the configuration for the take over mode.
 // It allows the Filestream input to take over states from the log
 // input or other Filestream inputs
 type TakeOverConfig struct {
 	Enabled bool `config:"enabled"`
-	// Filestream IDs to take over states
+	// Filestream IDs to take over states (exact match).
 	FromIDs []string `config:"from_ids"`
+	// Go regular expressions matched against the input ID segment of registry
+	// keys. Compiled at parse time; an invalid pattern is a config error.
+	FromIDPatterns []string `config:"from_id_patterns"`
 	// Stream from the container input to take over from.
 	// Valid values: stderr, stdout or it can be empty. An empty stream means
 	// all streams.
@@ -419,20 +469,36 @@ func (t *TakeOverConfig) Unpack(value any) error {
 		}
 
 		rawFromIDs, exists := v["from_ids"]
-		if !exists {
-			return nil
+		if exists {
+			fromIDs, ok := rawFromIDs.([]any)
+			if !ok {
+				return fmt.Errorf("cannot parse '%[1]v' (type %[1]T) as []any", rawFromIDs)
+			}
+			for _, el := range fromIDs {
+				strEl, ok := el.(string)
+				if !ok {
+					return fmt.Errorf("cannot parse '%[1]v' (type %[1]T) as string", el)
+				}
+				t.FromIDs = append(t.FromIDs, strEl)
+			}
 		}
 
-		fromIDs, ok := rawFromIDs.([]any)
-		if !ok {
-			return fmt.Errorf("cannot parse '%[1]v' (type %[1]T) as []any", rawFromIDs)
-		}
-		for _, el := range fromIDs {
-			strEl, ok := el.(string)
+		rawFromIDPatterns, exists := v["from_id_patterns"]
+		if exists {
+			fromIDPatterns, ok := rawFromIDPatterns.([]any)
 			if !ok {
-				return fmt.Errorf("cannot parse '%[1]v' (type %[1]T) as string", el)
+				return fmt.Errorf("cannot parse '%[1]v' (type %[1]T) as []any", rawFromIDPatterns)
 			}
-			t.FromIDs = append(t.FromIDs, strEl)
+			for _, el := range fromIDPatterns {
+				strEl, ok := el.(string)
+				if !ok {
+					return fmt.Errorf("cannot parse '%[1]v' (type %[1]T) as string", el)
+				}
+				if _, err := regexp.Compile(strEl); err != nil {
+					return fmt.Errorf("invalid from_id_patterns entry %q: %w", strEl, err)
+				}
+				t.FromIDPatterns = append(t.FromIDPatterns, strEl)
+			}
 		}
 
 	default:
@@ -449,7 +515,7 @@ func (t *TakeOverConfig) LogWarnings(logger *logp.Logger) {
 }
 
 func (t *TakeOverConfig) FromFilestream() bool {
-	return len(t.FromIDs) != 0
+	return len(t.FromIDs) != 0 || len(t.FromIDPatterns) != 0
 }
 
 // ReadUntilEOFConfig configures the behaviour to keep reading the current

--- a/filebeat/input/filestream/internal/input-logfile/manager.go
+++ b/filebeat/input/filestream/internal/input-logfile/manager.go
@@ -290,19 +290,19 @@ func (cim *InputManager) Create(config *conf.C) (inp v2.Input, retErr error) {
 	}
 
 	return &managedInput{
-		manager:                cim,
-		ackCH:                  entry.ackCH,
-		id:                     settings.ID,
-		prospector:             prospector,
-		harvester:              harvester,
-		readUntilEOF:           settings.ReadUntilEOF,
-		backoff:                settings.Backoff,
-		stateCheckInterval:     settings.Close.OnStateChange.CheckInterval,
-		sourceIdentifier:       srcIdentifier,
-		previousMatchers: previousMatchers,
-		takeOverAnyID:          settings.TakeOver.FromAnyID,
-		cleanTimeout:           settings.CleanInactive,
-		harvesterLimit:         settings.HarvesterLimit,
+		manager:            cim,
+		ackCH:              entry.ackCH,
+		id:                 settings.ID,
+		prospector:         prospector,
+		harvester:          harvester,
+		readUntilEOF:       settings.ReadUntilEOF,
+		backoff:            settings.Backoff,
+		stateCheckInterval: settings.Close.OnStateChange.CheckInterval,
+		sourceIdentifier:   srcIdentifier,
+		previousMatchers:   previousMatchers,
+		takeOverAnyID:      settings.TakeOver.FromAnyID,
+		cleanTimeout:       settings.CleanInactive,
+		harvesterLimit:     settings.HarvesterLimit,
 	}, nil
 }
 

--- a/filebeat/input/filestream/internal/input-logfile/manager.go
+++ b/filebeat/input/filestream/internal/input-logfile/manager.go
@@ -420,13 +420,7 @@ func (r *RegexInputMatcher) MatchesInput(key string) bool {
 		return false
 	}
 	rest := key[len(r.pluginPrefix):]
-	idx := strings.Index(rest, "::")
-	var inputID string
-	if idx < 0 {
-		inputID = rest
-	} else {
-		inputID = rest[:idx]
-	}
+	inputID, _, _ := strings.Cut(rest, "::")
 	return r.pattern.MatchString(inputID)
 }
 

--- a/filebeat/input/filestream/internal/input-logfile/manager.go
+++ b/filebeat/input/filestream/internal/input-logfile/manager.go
@@ -299,7 +299,7 @@ func (cim *InputManager) Create(config *conf.C) (inp v2.Input, retErr error) {
 		backoff:                settings.Backoff,
 		stateCheckInterval:     settings.Close.OnStateChange.CheckInterval,
 		sourceIdentifier:       srcIdentifier,
-		previousSrcIdentifiers: previousMatchers,
+		previousMatchers: previousMatchers,
 		takeOverAnyID:          settings.TakeOver.FromAnyID,
 		cleanTimeout:           settings.CleanInactive,
 		harvesterLimit:         settings.HarvesterLimit,

--- a/filebeat/input/filestream/internal/input-logfile/manager.go
+++ b/filebeat/input/filestream/internal/input-logfile/manager.go
@@ -20,7 +20,6 @@ package input_logfile
 import (
 	"errors"
 	"fmt"
-	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -273,19 +272,9 @@ func (cim *InputManager) Create(config *conf.C) (inp v2.Input, retErr error) {
 			}
 			previousMatchers = append(previousMatchers, si)
 		}
-		for _, pattern := range settings.TakeOver.FromIDPatterns {
-			rm, err := newRegexInputMatcher(cim.Type, pattern)
-			if err != nil {
-				return nil,
-					fmt.Errorf(
-						"[ID: %q] error while creating regex matcher for pattern %q: %w",
-						settings.ID, pattern, err)
-			}
-			previousMatchers = append(previousMatchers, rm)
-		}
 	}
 
-	prospectorStore := newSourceStore(pStore, srcIdentifier, previousMatchers)
+	prospectorStore := newSourceStore(pStore, srcIdentifier, previousMatchers, settings.TakeOver.FromAnyID)
 
 	// create a store with the deprecated global ID. This will be used to
 	// migrate the entries in the registry to use the new input ID.
@@ -293,7 +282,7 @@ func (cim *InputManager) Create(config *conf.C) (inp v2.Input, retErr error) {
 	if err != nil {
 		return nil, fmt.Errorf("cannot create global identifier for input: %w", err)
 	}
-	globalStore := newSourceStore(pStore, globalIdentifier, nil)
+	globalStore := newSourceStore(pStore, globalIdentifier, nil, false)
 
 	err = prospector.Init(prospectorStore, globalStore, srcIdentifier.ID)
 	if err != nil {
@@ -311,6 +300,7 @@ func (cim *InputManager) Create(config *conf.C) (inp v2.Input, retErr error) {
 		stateCheckInterval:     settings.Close.OnStateChange.CheckInterval,
 		sourceIdentifier:       srcIdentifier,
 		previousSrcIdentifiers: previousMatchers,
+		takeOverAnyID:          settings.TakeOver.FromAnyID,
 		cleanTimeout:           settings.CleanInactive,
 		harvesterLimit:         settings.HarvesterLimit,
 	}, nil
@@ -398,32 +388,6 @@ type InputMatcher interface {
 	MatchesInput(key string) bool
 }
 
-// RegexInputMatcher matches registry keys whose input ID segment matches a compiled regexp.
-type RegexInputMatcher struct {
-	pluginPrefix string
-	pattern      *regexp.Regexp
-}
-
-func newRegexInputMatcher(pluginName, pattern string) (*RegexInputMatcher, error) {
-	re, err := regexp.Compile(pattern)
-	if err != nil {
-		return nil, fmt.Errorf("invalid from_id_patterns entry %q: %w", pattern, err)
-	}
-	return &RegexInputMatcher{
-		pluginPrefix: pluginName + "::",
-		pattern:      re,
-	}, nil
-}
-
-func (r *RegexInputMatcher) MatchesInput(key string) bool {
-	if !strings.HasPrefix(key, r.pluginPrefix) {
-		return false
-	}
-	rest := key[len(r.pluginPrefix):]
-	inputID, _, _ := strings.Cut(rest, "::")
-	return r.pattern.MatchString(inputID)
-}
-
 // TakeOverConfig is the configuration for the take over mode.
 // It allows the Filestream input to take over states from the log
 // input or other Filestream inputs
@@ -431,9 +395,9 @@ type TakeOverConfig struct {
 	Enabled bool `config:"enabled"`
 	// Filestream IDs to take over states (exact match).
 	FromIDs []string `config:"from_ids"`
-	// Go regular expressions matched against the input ID segment of registry
-	// keys. Compiled at parse time; an invalid pattern is a config error.
-	FromIDPatterns []string `config:"from_id_patterns"`
+	// FromAnyID, when true, takes over states from any previous filestream
+	// input ID, regardless of what that ID was. Mutually exclusive with FromIDs.
+	FromAnyID bool `config:"from_any_id"`
 	// Stream from the container input to take over from.
 	// Valid values: stderr, stdout or it can be empty. An empty stream means
 	// all streams.
@@ -477,22 +441,17 @@ func (t *TakeOverConfig) Unpack(value any) error {
 			}
 		}
 
-		rawFromIDPatterns, exists := v["from_id_patterns"]
+		rawFromAnyID, exists := v["from_any_id"]
 		if exists {
-			fromIDPatterns, ok := rawFromIDPatterns.([]any)
+			fromAnyID, ok := rawFromAnyID.(bool)
 			if !ok {
-				return fmt.Errorf("cannot parse '%[1]v' (type %[1]T) as []any", rawFromIDPatterns)
+				return fmt.Errorf("cannot parse '%[1]v' (type %[1]T) as bool", rawFromAnyID)
 			}
-			for _, el := range fromIDPatterns {
-				strEl, ok := el.(string)
-				if !ok {
-					return fmt.Errorf("cannot parse '%[1]v' (type %[1]T) as string", el)
-				}
-				if _, err := regexp.Compile(strEl); err != nil {
-					return fmt.Errorf("invalid from_id_patterns entry %q: %w", strEl, err)
-				}
-				t.FromIDPatterns = append(t.FromIDPatterns, strEl)
-			}
+			t.FromAnyID = fromAnyID
+		}
+
+		if t.FromAnyID && len(t.FromIDs) > 0 {
+			return fmt.Errorf("'from_any_id' and 'from_ids' are mutually exclusive")
 		}
 
 	default:
@@ -509,7 +468,7 @@ func (t *TakeOverConfig) LogWarnings(logger *logp.Logger) {
 }
 
 func (t *TakeOverConfig) FromFilestream() bool {
-	return len(t.FromIDs) != 0 || len(t.FromIDPatterns) != 0
+	return len(t.FromIDs) != 0 || t.FromAnyID
 }
 
 // ReadUntilEOFConfig configures the behaviour to keep reading the current

--- a/filebeat/input/filestream/internal/input-logfile/manager_test.go
+++ b/filebeat/input/filestream/internal/input-logfile/manager_test.go
@@ -716,34 +716,36 @@ take_over:
 			cfgYAML:   "take_over: 42",
 			expectErr: true,
 		},
-		"new mode with id patterns": {
+		"from_any_id enabled": {
 			cfgYAML: `
 take_over:
   enabled: true
-  from_id_patterns: ["foo-.*", "bar-[0-9]+"]`,
+  from_any_id: true`,
 			expected: TakeOverConfig{
-				Enabled:        true,
-				FromIDPatterns: []string{"foo-.*", "bar-[0-9]+"},
+				Enabled:   true,
+				FromAnyID: true,
 			},
 		},
-		"new mode with ids and id patterns": {
+		"from_any_id disabled": {
 			cfgYAML: `
 take_over:
   enabled: true
-  from_ids: ["exact-id"]
-  from_id_patterns: ["prefix-.*"]`,
+  from_any_id: false`,
 			expected: TakeOverConfig{
-				Enabled:        true,
-				FromIDs:        []string{"exact-id"},
-				FromIDPatterns: []string{"prefix-.*"},
+				Enabled:   true,
+				FromAnyID: false,
 			},
 		},
-		"invalid from_id_patterns regex": {
-			cfgYAML:   `take_over.from_id_patterns: ["[invalid"]`,
+		"from_any_id invalid type": {
+			cfgYAML:   `take_over.from_any_id: "yes"`,
 			expectErr: true,
 		},
-		"invalid from_id_patterns element type": {
-			cfgYAML:   `take_over.from_id_patterns: ["foo", 42]`,
+		"from_any_id and from_ids are mutually exclusive": {
+			cfgYAML: `
+take_over:
+  enabled: true
+  from_any_id: true
+  from_ids: ["foo"]`,
 			expectErr: true,
 		},
 	}
@@ -762,60 +764,6 @@ take_over:
 			}
 
 			assert.Equal(t, tc.expected, outer.TakeOver, "TakeOverConfig was not parsed correctly")
-		})
-	}
-}
-
-func TestRegexInputMatcher(t *testing.T) {
-	testCases := []struct {
-		name    string
-		pattern string
-		key     string
-		want    bool
-	}{
-		{
-			name:    "matches input ID",
-			pattern: `foo-.*`,
-			key:     "filestream::foo-bar::native::123",
-			want:    true,
-		},
-		{
-			name:    "no match on different ID",
-			pattern: `foo-.*`,
-			key:     "filestream::baz::native::123",
-			want:    false,
-		},
-		{
-			name:    "no match on different plugin",
-			pattern: `foo-.*`,
-			key:     "logfile::foo-bar::native::123",
-			want:    false,
-		},
-		{
-			name:    "pattern anchored to full ID segment",
-			pattern: `foo`,
-			key:     "filestream::foo-bar::native::123",
-			want:    true, // regexp.MatchString is a substring match
-		},
-		{
-			name:    "anchored pattern no match",
-			pattern: `^foo$`,
-			key:     "filestream::foo-bar::native::123",
-			want:    false,
-		},
-		{
-			name:    "exact match with anchors",
-			pattern: `^foo-bar$`,
-			key:     "filestream::foo-bar::native::123",
-			want:    true,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			m, err := newRegexInputMatcher("filestream", tc.pattern)
-			require.NoError(t, err)
-			assert.Equal(t, tc.want, m.MatchesInput(tc.key))
 		})
 	}
 }

--- a/filebeat/input/filestream/internal/input-logfile/manager_test.go
+++ b/filebeat/input/filestream/internal/input-logfile/manager_test.go
@@ -716,6 +716,36 @@ take_over:
 			cfgYAML:   "take_over: 42",
 			expectErr: true,
 		},
+		"new mode with id patterns": {
+			cfgYAML: `
+take_over:
+  enabled: true
+  from_id_patterns: ["foo-.*", "bar-[0-9]+"]`,
+			expected: TakeOverConfig{
+				Enabled:        true,
+				FromIDPatterns: []string{"foo-.*", "bar-[0-9]+"},
+			},
+		},
+		"new mode with ids and id patterns": {
+			cfgYAML: `
+take_over:
+  enabled: true
+  from_ids: ["exact-id"]
+  from_id_patterns: ["prefix-.*"]`,
+			expected: TakeOverConfig{
+				Enabled:        true,
+				FromIDs:        []string{"exact-id"},
+				FromIDPatterns: []string{"prefix-.*"},
+			},
+		},
+		"invalid from_id_patterns regex": {
+			cfgYAML:   `take_over.from_id_patterns: ["[invalid"]`,
+			expectErr: true,
+		},
+		"invalid from_id_patterns element type": {
+			cfgYAML:   `take_over.from_id_patterns: ["foo", 42]`,
+			expectErr: true,
+		},
 	}
 
 	for name, tc := range testCases {
@@ -732,6 +762,60 @@ take_over:
 			}
 
 			assert.Equal(t, tc.expected, outer.TakeOver, "TakeOverConfig was not parsed correctly")
+		})
+	}
+}
+
+func TestRegexInputMatcher(t *testing.T) {
+	testCases := []struct {
+		name    string
+		pattern string
+		key     string
+		want    bool
+	}{
+		{
+			name:    "matches input ID",
+			pattern: `foo-.*`,
+			key:     "filestream::foo-bar::native::123",
+			want:    true,
+		},
+		{
+			name:    "no match on different ID",
+			pattern: `foo-.*`,
+			key:     "filestream::baz::native::123",
+			want:    false,
+		},
+		{
+			name:    "no match on different plugin",
+			pattern: `foo-.*`,
+			key:     "logfile::foo-bar::native::123",
+			want:    false,
+		},
+		{
+			name:    "pattern anchored to full ID segment",
+			pattern: `foo`,
+			key:     "filestream::foo-bar::native::123",
+			want:    true, // regexp.MatchString is a substring match
+		},
+		{
+			name:    "anchored pattern no match",
+			pattern: `^foo$`,
+			key:     "filestream::foo-bar::native::123",
+			want:    false,
+		},
+		{
+			name:    "exact match with anchors",
+			pattern: `^foo-bar$`,
+			key:     "filestream::foo-bar::native::123",
+			want:    true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			m, err := newRegexInputMatcher("filestream", tc.pattern)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, m.MatchesInput(tc.key))
 		})
 	}
 }

--- a/filebeat/input/filestream/internal/input-logfile/store.go
+++ b/filebeat/input/filestream/internal/input-logfile/store.go
@@ -47,6 +47,9 @@ type sourceStore struct {
 	// identifiersToTakeOver are matchers for previous input instances whose
 	// states this sourceStore will take over.
 	identifiersToTakeOver []InputMatcher
+	// takeOverAnyID, when true, takes over states from any previous filestream
+	// input ID rather than only those in identifiersToTakeOver.
+	takeOverAnyID bool
 	// store is the underlying store that encapsulates
 	// the in-memory and persistent store.
 	store *store
@@ -184,12 +187,14 @@ func newSourceStore(
 	s *store,
 	identifier *SourceIdentifier,
 	identifiersToTakeOver []InputMatcher,
+	takeOverAnyID bool,
 ) *sourceStore {
 
 	return &sourceStore{
 		store:                 s,
 		identifier:            identifier,
 		identifiersToTakeOver: identifiersToTakeOver,
+		takeOverAnyID:         takeOverAnyID,
 	}
 }
 
@@ -430,12 +435,15 @@ func (s *sourceStore) TakeOver(fn func(TakeOverState) (string, any)) {
 	defer s.store.ephemeralStore.mu.Unlock()
 
 	matchPreviousFilestreamIDs := func(key string) bool {
+		if s.takeOverAnyID {
+			// Match any filestream key that isn't from the current input.
+			return strings.HasPrefix(key, "filestream::") && !s.identifier.MatchesInput(key)
+		}
 		for _, identifier := range s.identifiersToTakeOver {
 			if identifier.MatchesInput(key) {
 				return true
 			}
 		}
-
 		return false
 	}
 
@@ -460,9 +468,9 @@ func (s *sourceStore) TakeOver(fn func(TakeOverState) (string, any)) {
 	// Iterate through the whole store, no matter input type or input ID.
 	// That's the only way to access the log input states.
 	// We only iterate through the whole store if we're not migrating from
-	// a Filestream input
+	// a Filestream input.
 	fromLogInput := map[string]TakeOverState{}
-	if len(s.identifiersToTakeOver) == 0 {
+	if len(s.identifiersToTakeOver) == 0 && !s.takeOverAnyID {
 		_ = s.store.persistentStore.Each(func(key string, value statestore.ValueDecoder) (bool, error) {
 			if strings.HasPrefix(key, "filebeat::logs::") {
 				logSt := inpFile.State{}

--- a/filebeat/input/filestream/internal/input-logfile/store.go
+++ b/filebeat/input/filestream/internal/input-logfile/store.go
@@ -44,9 +44,9 @@ var ErrKeyGone = errors.New("registry key does not exist")
 type sourceStore struct {
 	// identifier is the sourceIdentifier used to generate IDs fro this store.
 	identifier *SourceIdentifier
-	// identifiersToTakeOver are sourceIdentifier from previous input instances
-	// that this sourceStore will take states over.
-	identifiersToTakeOver []*SourceIdentifier
+	// identifiersToTakeOver are matchers for previous input instances whose
+	// states this sourceStore will take over.
+	identifiersToTakeOver []InputMatcher
 	// store is the underlying store that encapsulates
 	// the in-memory and persistent store.
 	store *store
@@ -183,7 +183,7 @@ func openStore(log *logp.Logger, statestore statestore.States, prefix string) (*
 func newSourceStore(
 	s *store,
 	identifier *SourceIdentifier,
-	identifiersToTakeOver []*SourceIdentifier,
+	identifiersToTakeOver []InputMatcher,
 ) *sourceStore {
 
 	return &sourceStore{

--- a/filebeat/input/filestream/internal/input-logfile/store_test.go
+++ b/filebeat/input/filestream/internal/input-logfile/store_test.go
@@ -468,6 +468,59 @@ func TestSourceStoreTakeOver(t *testing.T) {
 	checkEqualStoreState(t, want, backend.snapshot())
 }
 
+func TestSourceStoreTakeOverAnyID(t *testing.T) {
+	backend := createSampleStore(t, map[string]state{
+		"filestream::old-input-a::key1": {
+			TTL:  60 * time.Second,
+			Meta: testMeta{IdentifierName: "test-file-identity"},
+		},
+		"filestream::old-input-b::key2": {
+			TTL:  60 * time.Second,
+			Meta: testMeta{IdentifierName: "test-file-identity"},
+		},
+		"filestream::current-id::key3": { // Already owned — must not be touched
+			TTL:  60 * time.Second,
+			Meta: testMeta{IdentifierName: "test-file-identity"},
+		},
+	})
+	s := testOpenStore(t, "filestream", backend)
+	defer s.Release()
+	store := &sourceStore{
+		identifier:    &SourceIdentifier{"filestream::current-id::"},
+		takeOverAnyID: true,
+		store:         s,
+	}
+
+	store.TakeOver(func(v TakeOverState) (string, any) {
+		m := testMeta{IdentifierName: v.IdentifierName}
+		// Remap both old IDs to current-id
+		newKey := strings.Replace(v.Key, "old-input-a::", "current-id::", 1)
+		newKey = strings.Replace(newKey, "old-input-b::", "current-id::", 1)
+		return newKey, m
+	})
+
+	s.ephemeralStore.mu.Lock()
+	want := map[string]state{
+		"filestream::current-id::key1": {
+			Updated: s.ephemeralStore.table["filestream::current-id::key1"].internalState.Updated,
+			TTL:     60 * time.Second,
+			Meta:    map[string]any{"identifier_name": "test-file-identity"},
+		},
+		"filestream::current-id::key2": {
+			Updated: s.ephemeralStore.table["filestream::current-id::key2"].internalState.Updated,
+			TTL:     60 * time.Second,
+			Meta:    map[string]any{"identifier_name": "test-file-identity"},
+		},
+		"filestream::current-id::key3": { // Unchanged
+			TTL:  60 * time.Second,
+			Meta: map[string]any{"identifier_name": "test-file-identity"},
+		},
+	}
+	s.ephemeralStore.mu.Unlock()
+
+	checkEqualStoreState(t, want, backend.snapshot())
+}
+
 func TestSourceStoreTakeOverFromLogInput(t *testing.T) {
 	const (
 		logKey           = "filebeat::logs::native::inode:device"

--- a/filebeat/input/filestream/internal/input-logfile/store_test.go
+++ b/filebeat/input/filestream/internal/input-logfile/store_test.go
@@ -431,7 +431,7 @@ func TestSourceStoreTakeOver(t *testing.T) {
 	defer s.Release()
 	store := &sourceStore{
 		identifier:            &SourceIdentifier{"filestream::current-id::"},
-		identifiersToTakeOver: []*SourceIdentifier{{"filestream::previous-id::"}},
+		identifiersToTakeOver: []InputMatcher{&SourceIdentifier{"filestream::previous-id::"}},
 		store:                 s,
 	}
 

--- a/filebeat/tests/integration/filestream_test.go
+++ b/filebeat/tests/integration/filestream_test.go
@@ -796,6 +796,78 @@ func TestFilestreamTakeOverFromFilestream(t *testing.T) {
 	}
 }
 
+// TestFilestreamTakeOverFromAnyID ensures that take_over.from_any_id: true
+// migrates state from a previous filestream input without requiring the old
+// input ID to be listed explicitly.
+//
+// The test runs Filebeat with one input ID, stops it, then restarts with a
+// different ID and from_any_id: true. It asserts that no events are
+// re-ingested and the registry is correctly migrated.
+//
+// File fingerprints (64-byte prefix):
+//   - 01.log: 6fb3cb6c565bdba1354f64a42dd47ef937964019400dd571f25c2cd13a9fb5be
+//   - 02.log: db8399294e69089070405b13d4f057672f3852fa8e0f56ce4b6c92398aef1b6a
+func TestFilestreamTakeOverFromAnyID(t *testing.T) {
+	oldID := "first-id"
+	newID := "second-id"
+
+	testDataPath, err := filepath.Abs("./testdata")
+	if err != nil {
+		t.Fatalf("cannot get absolute path for 'testdata': %s", err)
+	}
+
+	logFiles := []string{}
+	for _, f := range []string{"01.log", "02.log", "01.txt", "02.txt"} {
+		logFiles = append(logFiles, filepath.Join(testDataPath, "take-over", f))
+	}
+
+	filebeat := integration.NewBeat(
+		t,
+		"filebeat",
+		"../../filebeat.test",
+	)
+	workDir := filebeat.TempDir()
+	outputFile := filepath.Join(workDir, "output-file*")
+
+	// Phase 1: ingest with the old ID.
+	vars := map[string]any{
+		"inputID":  oldID,
+		"homePath": workDir,
+		"testdata": testDataPath,
+	}
+	cfgYAML := getConfig(t, vars, "take-over", "from-any-id.yml")
+	filebeat.WriteConfigFile(cfgYAML)
+	filebeat.Start()
+
+	waitForEOF(t, filebeat, logFiles)
+	requirePublishedEvents(t, filebeat, 8, outputFile)
+	filebeat.Stop()
+
+	// Phase 2: restart with a new ID and from_any_id: true.
+	// No events should be re-ingested.
+	vars["inputID"] = newID
+	vars["takeOver"] = true
+
+	cfgYAML = getConfig(t, vars, "take-over", "from-any-id.yml")
+	filebeat.WriteConfigFile(cfgYAML)
+	filebeat.RemoveLogFiles()
+
+	filebeat.Start()
+	waitForEOF(t, filebeat, logFiles)
+	requirePublishedEvents(t, filebeat, 8, outputFile)
+	filebeat.Stop()
+
+	assertRegistry(
+		t,
+		workDir,
+		testDataPath,
+		filepath.Join(testDataPath,
+			"take-over",
+			"expected-registry-happy-path.json"),
+		"Entries in the registry are different from the expectation",
+	)
+}
+
 func TestFilestreamTakeOverFromLogInput(t *testing.T) {
 	testDataPath, err := filepath.Abs("./testdata")
 	if err != nil {

--- a/filebeat/tests/integration/testdata/take-over/from-any-id.yml
+++ b/filebeat/tests/integration/testdata/take-over/from-any-id.yml
@@ -1,0 +1,50 @@
+filebeat.inputs:
+  - type: filestream
+    id: "{{.inputID}}"
+    paths:
+      - {{.testdata}}/take-over/*.log
+{{ if .takeOver }}
+    take_over:
+      enabled: true
+      from_any_id: true
+{{ end }}
+    file_identity.fingerprint: ~
+    prospector:
+      scanner:
+        fingerprint:
+          enabled: true
+          length: 64
+        check_interval: 0.1s
+
+  - type: filestream
+    id: "not-in-test-input"
+    paths:
+      - {{.testdata}}/take-over/*.txt
+    file_identity.fingerprint: ~
+    prospector:
+      scanner:
+        fingerprint:
+          enabled: true
+          length: 64
+        check_interval: 0.1s
+
+queue.mem:
+  flush.timeout: 0s
+
+path.home: {{.homePath}}
+
+output.file:
+  path: ${path.home}
+  filename: "output-file"
+  rotate_on_startup: false
+
+filebeat.registry:
+  cleanup_interval: 5s
+  flush: 1s
+
+logging:
+  level: debug
+  selectors:
+    - "*"
+  metrics:
+    enabled: false

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -2623,12 +2623,10 @@ filebeat.inputs:
   #  from `filestream` inputs that were assigned these IDs.
   #  Taking over from `log` inputs is disabled when `from_ids` is set.
   #  from_ids: ["foo", "bar"]
-  #  If `from_id_patterns` is set, files are taken over from any `filestream`
-  #  input whose ID matches one of the provided Go regular expressions.
-  #  Patterns are matched only against the input ID segment of registry keys.
-  #  Invalid patterns are rejected at startup. Can be combined with `from_ids`.
-  #  Taking over from `log` inputs is disabled when `from_id_patterns` is set.
-  #  from_id_patterns: ["old-input-.*", "legacy-[0-9]+"]
+  #  If `from_any_id` is true, files are taken over from any previous
+  #  `filestream` input, regardless of its ID. Mutually exclusive with `from_ids`.
+  #  Taking over from `log` inputs is disabled when `from_any_id` is set.
+  #  from_any_id: false
 
   # Defines the buffer size every harvester uses when fetching the file
   #harvester_buffer_size: 16384

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -2623,6 +2623,12 @@ filebeat.inputs:
   #  from `filestream` inputs that were assigned these IDs.
   #  Taking over from `log` inputs is disabled when `from_ids` is set.
   #  from_ids: ["foo", "bar"]
+  #  If `from_id_patterns` is set, files are taken over from any `filestream`
+  #  input whose ID matches one of the provided Go regular expressions.
+  #  Patterns are matched only against the input ID segment of registry keys.
+  #  Invalid patterns are rejected at startup. Can be combined with `from_ids`.
+  #  Taking over from `log` inputs is disabled when `from_id_patterns` is set.
+  #  from_id_patterns: ["old-input-.*", "legacy-[0-9]+"]
 
   # Defines the buffer size every harvester uses when fetching the file
   #harvester_buffer_size: 16384


### PR DESCRIPTION
## What does this PR do?

Adds `take_over.from_any_id: true` to the filestream input. When set, the input takes over registry state from any previous `filestream` input, regardless of what its ID was — without having to enumerate IDs or patterns.

This is the primary use case for migrating from many dynamically-created autodiscover inputs (e.g. one per Kubernetes container) to a single static `filestream` input.

```yaml
filestream:
  id: my-new-input
  take_over:
    enabled: true
    from_any_id: true
  paths: [/var/log/pods/*/*/*.log]
```

`from_any_id` is mutually exclusive with `from_ids`. The existing `from_ids` (exact ID list) and log-input takeover paths are unchanged.

## Why is it important?

Closes #51307. The existing `from_ids` approach requires knowing every previous input ID up front, which is impractical when IDs are generated dynamically by autodiscover.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature works
- [x] I have added an entry in `changelog/fragments`
- [x] I have made corresponding change to the default configuration files