### PR TITLE
fix(metricbeat/azure): honour Cost Management rate-limit hints and se…

### DIFF
--- a/changelog/fragments/1789040000-azure-billing-throttling-retry.yaml
+++ b/changelog/fragments/1789040000-azure-billing-throttling-retry.yaml
@@ -1,0 +1,39 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# Change summary; a 80ish characters long description of the change.
+summary: Stop losing a day of azure/billing data when Cost Management returns HTTP 429
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+description: >
+  The azure/billing metricset now honours the throttling hints Azure Cost
+  Management and Consumption return on HTTP 429. Those hints arrive in
+  "x-ms-ratelimit-microsoft.*-retry-after" headers, which the Azure SDK retry
+  policy ignores, so a throttled fetch used to fail after a few seconds of
+  backoff and, with no cursor and a 1440m period, the whole day of billing data
+  was lost. The hint is now translated into the standard Retry-After header, the
+  retry budget was raised so a per-minute quota window can clear (up to 5
+  retries, 10s base delay, 5m cap), and every request carries a ClientType
+  header so the calls no longer share the default Cost Management quota pool
+  with all unidentified callers in the tenant.
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: metricbeat
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+# issue: https://github.com/owner/repo/1234

--- a/x-pack/metricbeat/module/azure/billing/retry.go
+++ b/x-pack/metricbeat/module/azure/billing/retry.go
@@ -1,0 +1,289 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+//go:build !requirefips
+
+package billing
+
+import (
+	"math"
+	"net/http"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+
+	"github.com/elastic/beats/v7/x-pack/metricbeat/module/azure"
+	"github.com/elastic/elastic-agent-libs/logp"
+)
+
+// Azure Cost Management and Consumption throttle aggressively (per tenant, per
+// entity, per client type, and on a query-processing-unit budget) and answer with
+// HTTP 429. The wait hint comes back in vendor specific headers:
+//
+//	x-ms-ratelimit-microsoft.costmanagement-qpu-retry-after
+//	x-ms-ratelimit-microsoft.costmanagement-entity-retry-after
+//	x-ms-ratelimit-microsoft.costmanagement-tenant-retry-after
+//	x-ms-ratelimit-microsoft.costmanagement-client-retry-after
+//	x-ms-ratelimit-microsoft.consumption-retry-after
+//	x-ms-ratelimit-microsoft.consumption-clientappid-retry-after  (observed live)
+//	x-ms-ratelimit-microsoft.consumption-tenant-retry-after       (observed live)
+//
+// azcore's retry policy only understands "Retry-After", "Retry-After-Ms" and
+// "x-ms-retry-after-ms" (see shared.RetryAfter), so without translation it ignores
+// the service hint and falls back to its own short exponential backoff.
+//
+// Instead of enumerating the header names (Azure adds new limit dimensions without
+// notice) we match any header with the vendor rate limit prefix and the retry-after
+// suffix below. That covers all the names above plus future variants.
+const (
+	rateLimitRetryAfterHeaderPrefix = "x-ms-ratelimit-microsoft."
+	rateLimitRetryAfterHeaderSuffix = "-retry-after"
+)
+
+// retryAfterHeaderName is the standard header azcore's retry policy reads and the
+// one we synthesise from Azure's vendor specific hints.
+const retryAfterHeaderName = "Retry-After"
+
+// standardRetryAfterHeaders lists (lower cased) the headers azcore's retry policy
+// already reads. If the service sent one of them we must not touch anything: azcore
+// is already going to honour it, and overwriting it could shorten the requested wait.
+var standardRetryAfterHeaders = []string{
+	"retry-after",
+	"retry-after-ms",
+	"x-ms-retry-after-ms",
+}
+
+// Cost Management applies part of its throttling per "client type". Callers that do
+// not identify themselves share a single default quota pool with every other
+// unidentified caller in the tenant, so a noisy neighbour can exhaust our budget.
+// Sending a ClientType header moves us into our own pool.
+//
+// The header is not part of the published REST reference; it is the mitigation
+// documented by Microsoft in the Cost Management throttling guidance / support
+// answers for HTTP 429. Header names are case insensitive on the wire, but we set
+// the map key directly (instead of Header.Set, which would canonicalise it to
+// "Clienttype") so the exact documented spelling reaches the service.
+const (
+	clientTypeHeaderName  = "ClientType"
+	clientTypeHeaderValue = "elastic-metricbeat-azure-billing"
+)
+
+// Retry budget.
+//
+// azcore's defaults (3 retries, 800ms base, 60s cap) total roughly 7-11s, which is
+// useless against a per-minute quota, and it gives up entirely when a Retry-After
+// exceeds MaxRetryDelay. We therefore raise all three.
+//
+// The fallback delay used when the service sends no hint is
+// ((2^try)-1) * RetryDelay * jitter, jitter in [0.8, 1.3), capped at MaxRetryDelay:
+//
+//	try 1: 10s  (max 13s)
+//	try 2: 30s  (max 39s)
+//	try 3: 70s  (max 91s)
+//	try 4: 150s (max 195s)
+//	try 5: 310s (capped at 300s)
+//
+// Worst case total wait is therefore ~638s (~10m40s) spread over 6 attempts, which
+// is enough for the 1 minute and most of the 10 second quota windows to refill.
+// When the service does send a hint we honour it verbatim up to MaxRetryDelay.
+//
+// There is plenty of headroom: the metricset period is 1440m, mb defaults Timeout to
+// Period, and the service issues its calls with context.Background().
+const (
+	billingRetryDelay    = 10 * time.Second
+	billingMaxRetryDelay = 5 * time.Minute
+	billingMaxRetries    = int32(5)
+
+	// maxParsableRetryAfterSeconds bounds header values before they are turned into
+	// a time.Duration. Anything larger is nonsensical and would risk overflowing.
+	maxParsableRetryAfterSeconds = float64(24 * 60 * 60)
+)
+
+// newRetryOptions returns the retry configuration shared by both billing clients.
+//
+// StatusCodes is deliberately left unset so azcore keeps its defaults
+// (408, 429, 500, 502, 503, 504); 429 is the one we care about here.
+func newRetryOptions() policy.RetryOptions {
+	return policy.RetryOptions{
+		MaxRetries:    billingMaxRetries,
+		RetryDelay:    billingRetryDelay,
+		MaxRetryDelay: billingMaxRetryDelay,
+	}
+}
+
+// newClientOptions builds the ARM client options shared by the usage details and
+// forecast clients.
+func newClientOptions(config azure.Config, logger *logp.Logger) arm.ClientOptions {
+	return arm.ClientOptions{
+		ClientOptions: policy.ClientOptions{
+			Cloud: azure.BuildCloudConfig(config),
+			Retry: newRetryOptions(),
+			// Runs once per request, before the retry policy.
+			PerCallPolicies: []policy.Policy{clientTypePolicy{}},
+			// Runs inside the retry loop, after the retry policy, so it sees every
+			// try's response before the retry policy inspects it for a wait hint.
+			PerRetryPolicies: []policy.Policy{newRetryAfterTranslationPolicy(logger)},
+		},
+	}
+}
+
+// clientTypePolicy stamps the Cost Management ClientType header on every request.
+type clientTypePolicy struct{}
+
+func (clientTypePolicy) Do(req *policy.Request) (*http.Response, error) {
+	// Assign the map key directly to preserve the documented header casing.
+	req.Raw().Header[clientTypeHeaderName] = []string{clientTypeHeaderValue}
+
+	return req.Next()
+}
+
+// retryAfterTranslationPolicy copies the Azure Cost Management / Consumption rate
+// limit wait hint into the standard Retry-After header so azcore's retry policy
+// honours it instead of falling back to its own exponential backoff.
+type retryAfterTranslationPolicy struct {
+	log *logp.Logger
+}
+
+func newRetryAfterTranslationPolicy(logger *logp.Logger) *retryAfterTranslationPolicy {
+	p := &retryAfterTranslationPolicy{}
+	if logger != nil {
+		p.log = logger.Named("azure billing retry")
+	}
+
+	return p
+}
+
+func (p *retryAfterTranslationPolicy) Do(req *policy.Request) (*http.Response, error) {
+	resp, err := req.Next()
+	if err != nil {
+		return resp, err
+	}
+
+	p.translateRetryAfter(resp)
+
+	return resp, nil
+}
+
+// translateRetryAfter sets Retry-After from the vendor rate limit headers, if needed.
+func (p *retryAfterTranslationPolicy) translateRetryAfter(resp *http.Response) {
+	if resp == nil || resp.Header == nil {
+		return
+	}
+
+	// Only error responses can be retried. Restricting the rewrite to them keeps us
+	// from advertising a Retry-After on successful responses (Cost Management also
+	// reports its remaining budget on 200s). We deliberately do not restrict this to
+	// 429 so throttling surfaced as 503 or 500 is handled too.
+	if resp.StatusCode < http.StatusBadRequest {
+		return
+	}
+
+	// Never overwrite a hint azcore can already read.
+	if hasStandardRetryAfter(resp.Header) {
+		return
+	}
+
+	name, delay := maxRateLimitRetryAfter(resp.Header)
+	if delay <= 0 {
+		return
+	}
+
+	// azcore abandons the request outright when Retry-After exceeds MaxRetryDelay.
+	// Retrying after the cap is strictly better than dropping the day's data: if the
+	// quota has not cleared yet we simply get another 429 with a fresh hint.
+	if delay > billingMaxRetryDelay {
+		delay = billingMaxRetryDelay
+	}
+
+	seconds := int(math.Ceil(delay.Seconds()))
+	resp.Header.Set(retryAfterHeaderName, strconv.Itoa(seconds))
+
+	if p.log != nil {
+		p.log.Debugw(
+			"translating Azure rate limit retry hint into a Retry-After header",
+			"http.response.status_code", resp.StatusCode,
+			"azure.billing.rate_limit.header", name,
+			"azure.billing.rate_limit.retry_after_seconds", seconds,
+		)
+	}
+}
+
+// hasStandardRetryAfter reports whether the response already carries a non-empty
+// "retry after" header that azcore's retry policy understands. Header keys are
+// compared case insensitively: http.Header canonicalises keys on the wire, but
+// azcore looks some of them up in non canonical form.
+func hasStandardRetryAfter(header http.Header) bool {
+	for name, values := range header {
+		lower := strings.ToLower(name)
+		if !slices.Contains(standardRetryAfterHeaders, lower) {
+			continue
+		}
+
+		for _, value := range values {
+			if strings.TrimSpace(value) != "" {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+// maxRateLimitRetryAfter returns the longest wait advertised by any Azure rate limit
+// "retry after" header, together with the name of the header it came from. It returns
+// a zero duration when no usable header is present.
+func maxRateLimitRetryAfter(header http.Header) (string, time.Duration) {
+	var (
+		maxName  string
+		maxDelay time.Duration
+	)
+
+	for name, values := range header {
+		// http.Header canonicalises keys, so compare case insensitively.
+		lower := strings.ToLower(name)
+		if !strings.HasPrefix(lower, rateLimitRetryAfterHeaderPrefix) ||
+			!strings.HasSuffix(lower, rateLimitRetryAfterHeaderSuffix) {
+			continue
+		}
+
+		for _, value := range values {
+			delay, ok := parseRetryAfterSeconds(value)
+			if !ok || delay <= maxDelay {
+				continue
+			}
+
+			maxName, maxDelay = name, delay
+		}
+	}
+
+	return maxName, maxDelay
+}
+
+// parseRetryAfterSeconds parses a rate limit header value expressed in seconds.
+// Surrounding whitespace is tolerated; anything that is not a positive number is
+// ignored so a malformed header can never break or stall a fetch.
+func parseRetryAfterSeconds(value string) (time.Duration, bool) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return 0, false
+	}
+
+	// Be lenient: the service documents integer seconds, but accept decimals too.
+	seconds, err := strconv.ParseFloat(value, 64)
+	if err != nil || math.IsNaN(seconds) || seconds <= 0 {
+		return 0, false
+	}
+
+	// Bound the value before converting so an absurd header cannot overflow the
+	// duration into something negative. The caller clamps to MaxRetryDelay anyway.
+	if seconds > maxParsableRetryAfterSeconds {
+		seconds = maxParsableRetryAfterSeconds
+	}
+
+	return time.Duration(seconds * float64(time.Second)), true
+}

--- a/x-pack/metricbeat/module/azure/billing/retry_test.go
+++ b/x-pack/metricbeat/module/azure/billing/retry_test.go
@@ -1,0 +1,426 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+//go:build !requirefips
+
+package billing
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/beats/v7/x-pack/metricbeat/module/azure"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
+)
+
+const testEndpoint = "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Consumption/usageDetails"
+
+// stubTransport is a policy.Transporter that replays canned responses and records
+// the headers of every request it receives.
+type stubTransport struct {
+	mu        sync.Mutex
+	responses []func(*http.Request) *http.Response
+	requests  []http.Header
+}
+
+func (t *stubTransport) Do(req *http.Request) (*http.Response, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.requests = append(t.requests, req.Header.Clone())
+
+	build := t.responses[len(t.responses)-1]
+	if len(t.requests) <= len(t.responses) {
+		build = t.responses[len(t.requests)-1]
+	}
+
+	resp := build(req)
+	resp.Request = req
+	if resp.Body == nil {
+		resp.Body = http.NoBody
+	}
+	if resp.Header == nil {
+		resp.Header = http.Header{}
+	}
+
+	return resp, nil
+}
+
+func (t *stubTransport) requestCount() int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	return len(t.requests)
+}
+
+func (t *stubTransport) recordedRequests() []http.Header {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	return append([]http.Header(nil), t.requests...)
+}
+
+// response returns a canned response builder with the given status and headers.
+func response(status int, headers map[string]string) func(*http.Request) *http.Response {
+	return func(*http.Request) *http.Response {
+		header := http.Header{}
+		for name, value := range headers {
+			// Assign directly so the exact (non canonical) header casing used by
+			// Azure survives into the test fixture.
+			header[name] = []string{value}
+		}
+
+		return &http.Response{StatusCode: status, Header: header, Body: http.NoBody}
+	}
+}
+
+// headerValueInsensitive looks a header up ignoring key casing, which is required
+// because we intentionally store some header keys in non canonical form.
+func headerValueInsensitive(header http.Header, name string) (string, bool) {
+	for key, values := range header {
+		if strings.EqualFold(key, name) && len(values) > 0 {
+			return values[0], true
+		}
+	}
+
+	return "", false
+}
+
+// doThroughPolicy runs a single response through the retry-after translation policy
+// and returns the (possibly rewritten) response.
+func doThroughPolicy(t *testing.T, status int, headers map[string]string) *http.Response {
+	t.Helper()
+
+	transport := &stubTransport{responses: []func(*http.Request) *http.Response{response(status, headers)}}
+
+	pipeline := runtime.NewPipeline("azurebillingtest", "v0.0.0", runtime.PipelineOptions{}, &policy.ClientOptions{
+		Transport: transport,
+		// Disable retries: this test only exercises the translation policy.
+		Retry:            policy.RetryOptions{MaxRetries: -1},
+		PerRetryPolicies: []policy.Policy{newRetryAfterTranslationPolicy(logptest.NewTestingLogger(t, ""))},
+	})
+
+	req, err := runtime.NewRequest(context.Background(), http.MethodGet, testEndpoint)
+	require.NoError(t, err)
+
+	resp, err := pipeline.Do(req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	return resp
+}
+
+func TestRetryAfterTranslationPolicy(t *testing.T) {
+	tests := []struct {
+		name             string
+		status           int
+		headers          map[string]string
+		wantRetryAfter   string
+		wantNoRetryAfter bool
+	}{
+		{
+			name:           "qpu retry after is translated",
+			status:         http.StatusTooManyRequests,
+			headers:        map[string]string{"x-ms-ratelimit-microsoft.costmanagement-qpu-retry-after": "3"},
+			wantRetryAfter: "3",
+		},
+		{
+			name:           "entity retry after is translated",
+			status:         http.StatusTooManyRequests,
+			headers:        map[string]string{"x-ms-ratelimit-microsoft.costmanagement-entity-retry-after": "45"},
+			wantRetryAfter: "45",
+		},
+		{
+			name:           "tenant retry after is translated",
+			status:         http.StatusTooManyRequests,
+			headers:        map[string]string{"x-ms-ratelimit-microsoft.costmanagement-tenant-retry-after": "60"},
+			wantRetryAfter: "60",
+		},
+		{
+			name:           "client retry after is translated",
+			status:         http.StatusTooManyRequests,
+			headers:        map[string]string{"x-ms-ratelimit-microsoft.costmanagement-client-retry-after": "17"},
+			wantRetryAfter: "17",
+		},
+		{
+			name:           "consumption retry after is translated",
+			status:         http.StatusTooManyRequests,
+			headers:        map[string]string{"x-ms-ratelimit-microsoft.consumption-retry-after": "22"},
+			wantRetryAfter: "22",
+		},
+		{
+			// Header names as actually returned by the Consumption usageDetails API
+			// (captured from a live run; the SDK canonicalises the casing this way).
+			name:           "consumption clientappid retry after (observed live) is translated",
+			status:         http.StatusTooManyRequests,
+			headers:        map[string]string{"X-Ms-Ratelimit-Microsoft.consumption-Clientappid-Retry-After": "40"},
+			wantRetryAfter: "40",
+		},
+		{
+			name:           "consumption tenant retry after (observed live) is translated",
+			status:         http.StatusTooManyRequests,
+			headers:        map[string]string{"X-Ms-Ratelimit-Microsoft.consumption-Tenant-Retry-After": "55"},
+			wantRetryAfter: "55",
+		},
+		{
+			name:   "remaining quota headers observed live are not retry hints",
+			status: http.StatusTooManyRequests,
+			headers: map[string]string{
+				"X-Ms-Ratelimit-Remaining-Microsoft.consumption-Clientappid-Requests": "14",
+				"X-Ms-Ratelimit-Remaining-Microsoft.consumption-Tenant-Requests":      "9",
+				"X-Ms-Ratelimit-Remaining-Subscription-Reads":                         "11999",
+			},
+			wantNoRetryAfter: true,
+		},
+		{
+			name:   "the maximum of several headers wins",
+			status: http.StatusTooManyRequests,
+			headers: map[string]string{
+				"x-ms-ratelimit-microsoft.costmanagement-qpu-retry-after":    "10",
+				"x-ms-ratelimit-microsoft.costmanagement-entity-retry-after": "90",
+				"x-ms-ratelimit-microsoft.costmanagement-tenant-retry-after": "30",
+			},
+			wantRetryAfter: "90",
+		},
+		{
+			name:   "an existing Retry-After is not overwritten",
+			status: http.StatusTooManyRequests,
+			headers: map[string]string{
+				"Retry-After": "5",
+				"x-ms-ratelimit-microsoft.costmanagement-qpu-retry-after": "120",
+			},
+			wantRetryAfter: "5",
+		},
+		{
+			name:   "an existing x-ms-retry-after-ms is not overwritten",
+			status: http.StatusTooManyRequests,
+			headers: map[string]string{
+				"x-ms-retry-after-ms": "1500",
+				"x-ms-ratelimit-microsoft.costmanagement-qpu-retry-after": "120",
+			},
+			wantNoRetryAfter: true,
+		},
+		{
+			name:   "an existing Retry-After-Ms is not overwritten",
+			status: http.StatusTooManyRequests,
+			headers: map[string]string{
+				"Retry-After-Ms": "1500",
+				"x-ms-ratelimit-microsoft.costmanagement-qpu-retry-after": "120",
+			},
+			wantNoRetryAfter: true,
+		},
+		{
+			name:             "invalid values are ignored",
+			status:           http.StatusTooManyRequests,
+			headers:          map[string]string{"x-ms-ratelimit-microsoft.costmanagement-qpu-retry-after": "soon"},
+			wantNoRetryAfter: true,
+		},
+		{
+			name:             "empty values are ignored",
+			status:           http.StatusTooManyRequests,
+			headers:          map[string]string{"x-ms-ratelimit-microsoft.costmanagement-qpu-retry-after": "   "},
+			wantNoRetryAfter: true,
+		},
+		{
+			name:             "non positive values are ignored",
+			status:           http.StatusTooManyRequests,
+			headers:          map[string]string{"x-ms-ratelimit-microsoft.costmanagement-qpu-retry-after": "-4"},
+			wantNoRetryAfter: true,
+		},
+		{
+			name:   "invalid values do not mask valid ones",
+			status: http.StatusTooManyRequests,
+			headers: map[string]string{
+				"x-ms-ratelimit-microsoft.costmanagement-qpu-retry-after":    "nope",
+				"x-ms-ratelimit-microsoft.costmanagement-entity-retry-after": "7",
+			},
+			wantRetryAfter: "7",
+		},
+		{
+			name:           "fractional seconds are rounded up",
+			status:         http.StatusTooManyRequests,
+			headers:        map[string]string{"x-ms-ratelimit-microsoft.costmanagement-qpu-retry-after": "2.4"},
+			wantRetryAfter: "3",
+		},
+		{
+			name:           "hints above the retry cap are clamped so azcore retries instead of giving up",
+			status:         http.StatusTooManyRequests,
+			headers:        map[string]string{"x-ms-ratelimit-microsoft.costmanagement-qpu-retry-after": "3600"},
+			wantRetryAfter: strconv.Itoa(int(billingMaxRetryDelay.Seconds())),
+		},
+		{
+			name:           "absurdly large values are bounded, not overflowed",
+			status:         http.StatusTooManyRequests,
+			headers:        map[string]string{"x-ms-ratelimit-microsoft.costmanagement-qpu-retry-after": "1e300"},
+			wantRetryAfter: strconv.Itoa(int(billingMaxRetryDelay.Seconds())),
+		},
+		{
+			name:   "quota reporting headers are not retry hints",
+			status: http.StatusTooManyRequests,
+			headers: map[string]string{
+				"x-ms-ratelimit-microsoft.costmanagement-qpu-consumed":  "1",
+				"x-ms-ratelimit-microsoft.costmanagement-qpu-remaining": "11",
+			},
+			wantNoRetryAfter: true,
+		},
+		{
+			name:             "successful responses are left alone",
+			status:           http.StatusOK,
+			headers:          map[string]string{"x-ms-ratelimit-microsoft.costmanagement-qpu-retry-after": "9"},
+			wantNoRetryAfter: true,
+		},
+		{
+			name:           "throttling reported as 503 is translated too",
+			status:         http.StatusServiceUnavailable,
+			headers:        map[string]string{"x-ms-ratelimit-microsoft.costmanagement-tenant-retry-after": "12"},
+			wantRetryAfter: "12",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			resp := doThroughPolicy(t, test.status, test.headers)
+
+			got, found := headerValueInsensitive(resp.Header, "Retry-After")
+			if test.wantNoRetryAfter {
+				assert.False(t, found, "Retry-After must not be set, got %q", got)
+				return
+			}
+
+			require.True(t, found, "Retry-After must be set")
+			assert.Equal(t, test.wantRetryAfter, got)
+		})
+	}
+}
+
+func TestRetryAfterTranslationPolicyHandlesMissingHeaders(t *testing.T) {
+	// A response with no headers at all must not panic nor gain a Retry-After.
+	resp := doThroughPolicy(t, http.StatusTooManyRequests, nil)
+
+	_, found := headerValueInsensitive(resp.Header, "Retry-After")
+	assert.False(t, found)
+}
+
+func TestNewRetryOptionsKeepsAzcoreDefaultStatusCodes(t *testing.T) {
+	options := newRetryOptions()
+
+	assert.Nil(t, options.StatusCodes,
+		"StatusCodes must stay nil so azcore keeps its defaults, which include 429")
+	assert.Equal(t, billingMaxRetries, options.MaxRetries)
+	assert.Equal(t, billingRetryDelay, options.RetryDelay)
+	assert.Equal(t, billingMaxRetryDelay, options.MaxRetryDelay)
+
+	// A per-minute quota must be able to clear within a single retry delay.
+	assert.GreaterOrEqual(t, options.MaxRetryDelay, time.Minute,
+		"MaxRetryDelay must exceed the Cost Management per-minute window, "+
+			"otherwise azcore abandons the request instead of waiting")
+}
+
+func TestNewClientOptionsWiresBothPolicies(t *testing.T) {
+	options := newClientOptions(azure.Config{
+		ActiveDirectoryEndpoint: "https://login.microsoftonline.com/",
+	}, logptest.NewTestingLogger(t, ""))
+
+	require.Len(t, options.PerCallPolicies, 1, "the ClientType policy must run once per request")
+	require.IsType(t, clientTypePolicy{}, options.PerCallPolicies[0])
+
+	require.Len(t, options.PerRetryPolicies, 1, "the Retry-After translation must run on every try")
+	require.IsType(t, &retryAfterTranslationPolicy{}, options.PerRetryPolicies[0])
+
+	assert.Equal(t, newRetryOptions(), options.Retry)
+	assert.NotEmpty(t, options.Cloud.Services, "the cloud configuration must be preserved")
+}
+
+// TestRetryAfterTranslationEndToEnd drives a full azcore pipeline, configured exactly
+// like the billing clients, against a transport that throttles the first try with only
+// a Cost Management rate limit header. It asserts the request is retried and succeeds,
+// and that ClientType is stamped on every try.
+func TestRetryAfterTranslationEndToEnd(t *testing.T) {
+	transport := &stubTransport{
+		responses: []func(*http.Request) *http.Response{
+			// First try: throttled, with a hint azcore alone cannot read.
+			response(http.StatusTooManyRequests, map[string]string{
+				"x-ms-ratelimit-microsoft.costmanagement-qpu-retry-after": "1",
+			}),
+			// Second try: success.
+			response(http.StatusOK, nil),
+		},
+	}
+
+	clientOptions := newClientOptions(azure.Config{
+		ActiveDirectoryEndpoint: "https://login.microsoftonline.com/",
+	}, logptest.NewTestingLogger(t, ""))
+	clientOptions.Transport = transport
+	// Keep the test fast: the hint is 1s, so no exponential fallback is needed, but
+	// cap the delay well below the 5m production ceiling as a safety net.
+	clientOptions.Retry.MaxRetryDelay = 5 * time.Second
+
+	pipeline := runtime.NewPipeline("azurebillingtest", "v0.0.0", runtime.PipelineOptions{}, &clientOptions.ClientOptions)
+
+	req, err := runtime.NewRequest(context.Background(), http.MethodGet, testEndpoint)
+	require.NoError(t, err)
+
+	start := time.Now()
+	resp, err := pipeline.Do(req)
+	elapsed := time.Since(start)
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, http.StatusOK, resp.StatusCode, "the retried request must succeed")
+	assert.Equal(t, 2, transport.requestCount(), "the throttled request must be retried exactly once")
+
+	// The wait must come from the translated header (~1s), not from azcore's
+	// exponential fallback, whose first delay would be at least 8s (0.8 * 10s).
+	assert.Less(t, elapsed, 5*time.Second,
+		"the retry must have used the 1s service hint, not the exponential fallback")
+	assert.GreaterOrEqual(t, elapsed, 900*time.Millisecond,
+		"the retry must have honoured the 1s service hint")
+
+	requests := transport.recordedRequests()
+	require.Len(t, requests, 2)
+	for i, header := range requests {
+		value, found := headerValueInsensitive(header, clientTypeHeaderName)
+		assert.True(t, found, "request %d must carry a %s header", i, clientTypeHeaderName)
+		assert.Equal(t, clientTypeHeaderValue, value, "request %d must identify this caller", i)
+	}
+}
+
+// TestExponentialFallbackWithoutHint documents that a 429 carrying no usable hint
+// still falls back to azcore's exponential backoff, seeded with our larger base delay.
+func TestExponentialFallbackWithoutHint(t *testing.T) {
+	transport := &stubTransport{
+		responses: []func(*http.Request) *http.Response{
+			response(http.StatusTooManyRequests, nil),
+			response(http.StatusOK, nil),
+		},
+	}
+
+	clientOptions := newClientOptions(azure.Config{
+		ActiveDirectoryEndpoint: "https://login.microsoftonline.com/",
+	}, logptest.NewTestingLogger(t, ""))
+	clientOptions.Transport = transport
+	// Shrink the production delays so the test does not sleep for 10s.
+	clientOptions.Retry.RetryDelay = 10 * time.Millisecond
+	clientOptions.Retry.MaxRetryDelay = 100 * time.Millisecond
+
+	pipeline := runtime.NewPipeline("azurebillingtest", "v0.0.0", runtime.PipelineOptions{}, &clientOptions.ClientOptions)
+
+	req, err := runtime.NewRequest(context.Background(), http.MethodGet, testEndpoint)
+	require.NoError(t, err)
+
+	resp, err := pipeline.Do(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, 2, transport.requestCount(), "429 must be retried even without a hint")
+}

--- a/x-pack/metricbeat/module/azure/billing/service.go
+++ b/x-pack/metricbeat/module/azure/billing/service.go
@@ -14,7 +14,6 @@ import (
 	"github.com/elastic/beats/v7/x-pack/metricbeat/module/azure"
 	"github.com/elastic/elastic-agent-libs/logp"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/consumption/armconsumption"
@@ -48,27 +47,27 @@ type UsageService struct {
 
 // NewService builds a new UsageService using the given config.
 func NewService(config azure.Config, logger *logp.Logger) (*UsageService, error) {
-	clientOptions := policy.ClientOptions{
-		Cloud: azure.BuildCloudConfig(config),
-	}
-
 	credential, err := azidentity.NewClientSecretCredential(config.TenantId, config.ClientId, config.ClientSecret, &azidentity.ClientSecretCredentialOptions{
-		ClientOptions: clientOptions,
+		ClientOptions: policy.ClientOptions{
+			Cloud: azure.BuildCloudConfig(config),
+		},
 	})
 	if err != nil {
 		return nil, fmt.Errorf("couldn't create client credentials: %w", err)
 	}
 
-	usageDetailsClient, err := armconsumption.NewUsageDetailsClient(credential, &arm.ClientOptions{
-		ClientOptions: clientOptions,
-	})
+	// Both billing clients share the same throttling mitigations: a ClientType
+	// header, a retry budget sized for Cost Management's per-minute quotas, and a
+	// policy that translates Azure's vendor specific rate limit hints into the
+	// Retry-After header azcore understands. See retry.go.
+	clientOptions := newClientOptions(config, logger)
+
+	usageDetailsClient, err := armconsumption.NewUsageDetailsClient(credential, &clientOptions)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't create usage details client: %w", err)
 	}
 
-	forecastsClient, err := armcostmanagement.NewForecastClient(credential, &arm.ClientOptions{
-		ClientOptions: clientOptions,
-	})
+	forecastsClient, err := armcostmanagement.NewForecastClient(credential, &clientOptions)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't create forecast client: %w", err)
 	}


### PR DESCRIPTION
When several azure/billing inputs start together, Cost Management returns 429 with its wait hint in x-ms-ratelimit-microsoft.*-retry-after headers that the Azure SDK retry policy does not read, so the fetch gives up after ~10s of backoff and, with a 1440m period and no cursor, the whole day's billing data is lost.

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
-

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
