### PR TITLE
libbeat: Fix Elasticsearch unhealthy in docker:composeUP

### DIFF
--- a/libbeat/docker-compose.yml
+++ b/libbeat/docker-compose.yml
@@ -27,6 +27,22 @@ services:
     ports:
       - 9200:9200
 
+  elasticsearch_setup:
+    extends:
+      file: ${ES_BEATS}/testing/environments/${TESTING_ENVIRONMENT}.yml
+      service: elasticsearch
+    entrypoint: ["/bin/bash"]
+    command:
+      - -ec
+      - |
+        curl --fail --silent --show-error -u admin:testing \
+          -H 'Content-Type: application/json' \
+          -X PUT http://elasticsearch:9200/_index_template/beats-integration-workflow-replicas \
+          -d '{"index_patterns":[".workflows-*"],"priority":500,"template":{"settings":{"index.number_of_replicas":0}}}'
+    depends_on:
+      elasticsearch:
+        condition: service_healthy
+
   elasticsearchssl:
     extends:
       file: ${ES_BEATS}/testing/environments/${TESTING_ENVIRONMENT}.yml
@@ -126,6 +142,9 @@ services:
       - ADVERTISED_HOST=kafka
 
   kibana:
+    depends_on:
+      elasticsearch_setup:
+        condition: service_completed_successfully
     extends:
       file: ${ES_BEATS}/testing/environments/${TESTING_ENVIRONMENT}.yml
       service: kibana

--- a/x-pack/libbeat/docker-compose.yml
+++ b/x-pack/libbeat/docker-compose.yml
@@ -27,9 +27,26 @@ services:
     ports:
       - 9200:9200
 
+  elasticsearch_setup:
+    extends:
+      file: ${ES_BEATS}/testing/environments/${TESTING_ENVIRONMENT}.yml
+      service: elasticsearch
+    entrypoint: ["/bin/bash"]
+    command:
+      - -ec
+      - |
+        curl --fail --silent --show-error -u admin:testing \
+          -H 'Content-Type: application/json' \
+          -X PUT http://elasticsearch:9200/_index_template/beats-integration-workflow-replicas \
+          -d '{"index_patterns":[".workflows-*"],"priority":500,"template":{"settings":{"index.number_of_replicas":0}}}'
+    depends_on:
+      elasticsearch:
+        condition: service_healthy
+
   kibana:
     depends_on:
-      - elasticsearch
+      elasticsearch_setup:
+        condition: service_completed_successfully
     extends:
       file: ${ES_BEATS}/testing/environments/${TESTING_ENVIRONMENT}.yml
       service: kibana


### PR DESCRIPTION
## Proposed commit message

```
Install a zero-replica template for Kibana workflow indices before Kibana starts. This prevents expected replica allocation on single-node integration clusters from leaving Elasticsearch yellow and failing green-only healthchecks.

Assisted-by: Cursor, Model: GPT-5.6 Terra Agent Mode
```

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.~~
- [ ] ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).~~

~~## Disruptive User Impact~~
## How to test this PR locally

```
cd libbeat
mage -v docker:composeUp

cd ../x-pack/libbeat
mage -v docker:composeUp
```

In both cases all containers should be healthy and Elasticsearch cluster must be green, check the cluster status with:
```
curl --insecure -u admin:testing 'http://localhost:9200/_cat/health?pretty'
```

## Related issues


- Closes https://github.com/elastic/beats/issues/53131

~~## Use cases~~
~~## Screenshots~~
~~## Logs~~