### PR TITLE
provider/azuread/fetcher: fix registered owner/user accumulation and deleted-device enrichment

### DIFF
--- a/changelog/fragments/1788993269-fix-azuread-device-registered-owner-accumulation.yaml
+++ b/changelog/fragments/1788993269-fix-azuread-device-registered-owner-accumulation.yaml
@@ -1,0 +1,11 @@
+kind: bug-fix
+summary: Fix Azure AD entity analytics accumulating stale registered owners and users on devices.
+description: |
+  Device.Merge was accumulating RegisteredOwners and RegisteredUsers across syncs
+  instead of replacing them. Because the Graph API always returns the complete
+  current list, the correct behaviour is replacement. Stale entries persisted
+  indefinitely, eventually bloating the kvstore.
+
+  Additionally, registered owner and user lookups were issued for deleted devices,
+  causing noisy 404 errors from the Graph API.
+component: filebeat

--- a/x-pack/filebeat/input/entityanalytics/provider/azuread/fetcher/device.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/azuread/fetcher/device.go
@@ -39,8 +39,11 @@ type Device struct {
 	Deleted bool `json:"deleted"`
 }
 
-// Merge will merge the attributes, owners, users and group memberships of
-// another Device instance into this Device. The IDs of the devices must match.
+// Merge merges the attributes and group memberships of other into d, and
+// replaces d's registered owners and users with those from other. Group
+// memberships are accumulated because the delta API returns incremental
+// changes; registered owners and users are replaced because the API always
+// returns the complete current set. The IDs of the devices must match.
 func (d *Device) Merge(other *Device) {
 	if d.ID != other.ID {
 		return
@@ -52,11 +55,7 @@ func (d *Device) Merge(other *Device) {
 	other.TransitiveMemberOf.ForEach(func(elem uuid.UUID) {
 		d.TransitiveMemberOf.Add(elem)
 	})
-	other.RegisteredOwners.ForEach(func(elem uuid.UUID) {
-		d.RegisteredOwners.Add(elem)
-	})
-	other.RegisteredUsers.ForEach(func(elem uuid.UUID) {
-		d.RegisteredUsers.Add(elem)
-	})
+	d.RegisteredOwners = other.RegisteredOwners
+	d.RegisteredUsers = other.RegisteredUsers
 	d.Deleted = other.Deleted
 }

--- a/x-pack/filebeat/input/entityanalytics/provider/azuread/fetcher/device_test.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/azuread/fetcher/device_test.go
@@ -67,10 +67,8 @@ func TestDevice_Merge(t *testing.T) {
 				),
 				RegisteredOwners: collections.NewUUIDSet(
 					uuid.Must(uuid.FromString("81d1b5cd-7cd6-469d-9fe8-0a5c6cf2a7b6")),
-					uuid.Must(uuid.FromString("c59fbdb8-e442-46b1-8d72-c8ac0b78ec0a")),
 				),
 				RegisteredUsers: collections.NewUUIDSet(
-					uuid.Must(uuid.FromString("27cea005-7377-4175-b2ef-e9d64c977f4d")),
 					uuid.Must(uuid.FromString("5e6d279a-ce2b-43b8-a38f-3110907e1974")),
 					uuid.Must(uuid.FromString("c59fbdb8-e442-46b1-8d72-c8ac0b78ec0a")),
 				),

--- a/x-pack/filebeat/input/entityanalytics/provider/azuread/fetcher/graph/graph.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/azuread/fetcher/graph/graph.go
@@ -359,8 +359,10 @@ func (f *graph) Devices(ctx context.Context, deltaLink string) ([]*fetcher.Devic
 			}
 			f.logger.Debugf("Got device %q from API", device.ID)
 
-			f.addRegistered(ctx, device, "registeredOwners", &device.RegisteredOwners)
-			f.addRegistered(ctx, device, "registeredUsers", &device.RegisteredUsers)
+			if !device.Deleted {
+				f.addRegistered(ctx, device, "registeredOwners", &device.RegisteredOwners)
+				f.addRegistered(ctx, device, "registeredUsers", &device.RegisteredUsers)
+			}
 
 			devices = append(devices, device)
 		}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message
```
provider/azuread/fetcher: fix registered owner/user accumulation and deleted-device enrichment

Device.Merge accumulated RegisteredOwners and RegisteredUsers across
syncs instead of replacing them. Because addRegistered always fetches
the complete current list from Graph, the correct behaviour is to
replace the stored set, not extend it. Stale owners and users persisted
indefinitely, eventually bloating the kvstore.

Additionally, addRegistered was called unconditionally for devices that
appeared in the delta response with a deleted flag, causing noisy 404
errors from the Graph API.

Fixes #53132
```
<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

<!--
Will the changes introduced by this PR cause disruption to users in any way? If so, please describe what changes users
could make on their end to nullify or minimize this disruption. Consider impacts in related systems, not just directly
when using Beats.
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Fixes #53132

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
