### PR TITLE
filestream: cache directory listings across inputs sharing the same base directory

### DIFF
--- a/changelog/fragments/1788982248-filestream-cache-directory-listings.yaml
+++ b/changelog/fragments/1788982248-filestream-cache-directory-listings.yaml
@@ -13,7 +13,8 @@ kind: enhancement
 # Change summary; a 80ish characters long description of the change.
 summary: Cache directory listings across filestream inputs sharing the same base directory
 
-
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
 # Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
 component: filebeat
 

--- a/changelog/fragments/1788982248-filestream-cache-directory-listings.yaml
+++ b/changelog/fragments/1788982248-filestream-cache-directory-listings.yaml
@@ -13,18 +13,6 @@ kind: enhancement
 # Change summary; a 80ish characters long description of the change.
 summary: Cache directory listings across filestream inputs sharing the same base directory
 
-# Long description; in case the summary is not enough to describe the change
-# this field accommodate a description without length limits.
-description: >
-  When many filestream inputs watch the same base directory (for example, the
-  Kubernetes integration running 1,600 inputs all watching
-  /var/log/containers), each input previously called readdir on that directory
-  independently on every check_interval tick. A node with 1,600 container-log
-  inputs and 500 files in the directory generated 1,600 readdir syscalls and
-  800,000 os.DirEntry allocations per tick. The scanner now uses a
-  process-wide cached directory reader with a 1 s TTL: N inputs watching the
-  same base directory make a single readdir call per TTL window instead of N
-  calls, eliminating nearly all redundant syscalls and allocations.
 
 # Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
 component: filebeat

--- a/changelog/fragments/1788982248-filestream-cache-directory-listings.yaml
+++ b/changelog/fragments/1788982248-filestream-cache-directory-listings.yaml
@@ -1,0 +1,36 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user's deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: enhancement
+
+# Change summary; a 80ish characters long description of the change.
+summary: Cache directory listings across filestream inputs sharing the same base directory
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+description: >
+  When many filestream inputs watch the same base directory (for example, the
+  Kubernetes integration running 1,600 inputs all watching
+  /var/log/containers), each input previously called readdir on that directory
+  independently on every check_interval tick. A node with 1,600 container-log
+  inputs and 500 files in the directory generated 1,600 readdir syscalls and
+  800,000 os.DirEntry allocations per tick. The scanner now uses a
+  process-wide cached directory reader with a 1 s TTL: N inputs watching the
+  same base directory make a single readdir call per TTL window instead of N
+  calls, eliminating nearly all redundant syscalls and allocations.
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: filebeat
+
+# PR URL; optional; the PR number that added the changeset.
+# pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+issue: https://github.com/elastic/beats/issues/53130

--- a/filebeat/input/filestream/dir_reader.go
+++ b/filebeat/input/filestream/dir_reader.go
@@ -25,13 +25,11 @@ import (
 	"time"
 )
 
-// maxDirCacheAge caps how long a directory listing may be served from cache.
 const maxDirCacheAge = time.Second
 
-// dirCacheEntry holds a cached directory listing protected by its own mutex.
-// The per-entry mutex allows concurrent reads of distinct directories while
-// serialising concurrent reads of the same directory so at most one OS call
-// runs per directory at a time.
+// dirCacheEntry holds a cached directory listing. The per-entry mutex
+// serialises concurrent reads of the same directory without blocking reads
+// of distinct directories.
 type dirCacheEntry struct {
 	mu      sync.Mutex
 	fetched atomic.Int64 // Unix nanoseconds; zero means no valid entry
@@ -47,8 +45,7 @@ func (e *dirCacheEntry) age() time.Duration {
 	return time.Since(time.Unix(0, f))
 }
 
-// set stores names/entries and timestamps the entry. Passing nil for both
-// clears the entry so the next caller retries (used when an OS read fails).
+// set timestamps the entry. Passing nil for both clears it so the next caller retries.
 func (e *dirCacheEntry) set(names []string, entries []os.DirEntry) {
 	e.names = names
 	e.entries = entries
@@ -59,15 +56,9 @@ func (e *dirCacheEntry) set(names []string, entries []os.DirEntry) {
 	}
 }
 
-// dirCache is a process-wide cache of directory listings. A single instance is
-// shared across all filestream Plugin() invocations via acquireSharedDirReader.
-//
-// Locking discipline:
-//   - mu guards the entries map (held only while looking up / inserting entries).
-//   - Each dirCacheEntry has its own mutex that serialises concurrent reads of
-//     the same directory; reads for distinct directories proceed fully in parallel.
-//   - Sweep runs inline on every miss path (under defer, after e.mu is released).
-//     A swept timestamp throttles actual work to at most once per maxDirCacheAge.
+// dirCache is a process-wide singleton cache of directory listings shared across
+// all filestream inputs via acquireSharedDirReader. mu guards the entries map
+// only; per-entry locking is handled by dirCacheEntry.mu.
 type dirCache struct {
 	mu      sync.Mutex
 	entries map[string]*dirCacheEntry
@@ -78,8 +69,7 @@ func newDirCache() *dirCache {
 	return &dirCache{entries: make(map[string]*dirCacheEntry)}
 }
 
-// reset clears all cached entries. Called when the last receiver releases the
-// singleton so the GC can reclaim any pinned slices.
+// reset clears all cached entries on last release so the GC can reclaim them.
 func (c *dirCache) reset() {
 	c.mu.Lock()
 	c.entries = make(map[string]*dirCacheEntry)
@@ -87,7 +77,6 @@ func (c *dirCache) reset() {
 	c.mu.Unlock()
 }
 
-// entry returns the cache entry for dir, creating it if absent.
 func (c *dirCache) entry(dir string) *dirCacheEntry {
 	c.mu.Lock()
 	e := c.entries[dir]
@@ -99,9 +88,8 @@ func (c *dirCache) entry(dir string) *dirCacheEntry {
 	return e
 }
 
-// readDirNames returns sorted file names for dir from the cache (when fresh
-// and shared=true) or from the OS. shared=false bypasses the cache so
-// sub-directories are always read directly; only the walk root is cached.
+// readDirNames returns sorted names for dir. shared=false bypasses the cache;
+// only the walk root passes shared=true so sub-directories are never cached.
 func (c *dirCache) readDirNames(dir string, maxAge time.Duration, shared bool) ([]string, error) {
 	if !shared {
 		return osDirNames(dir)
@@ -128,8 +116,7 @@ func (c *dirCache) readDirNames(dir string, maxAge time.Duration, shared bool) (
 	return names, nil
 }
 
-// readDirEntries returns sorted DirEntries for dir from the cache (when fresh
-// and shared=true) or from the OS. shared=false bypasses the cache.
+// readDirEntries returns sorted DirEntries for dir. shared=false bypasses the cache.
 func (c *dirCache) readDirEntries(dir string, maxAge time.Duration, shared bool) ([]os.DirEntry, error) {
 	if !shared {
 		return os.ReadDir(dir)
@@ -150,10 +137,8 @@ func (c *dirCache) readDirEntries(dir string, maxAge time.Duration, shared bool)
 	return entries, nil
 }
 
-// sweep removes entries older than maxDirCacheAge from the map. It is throttled
-// by the swept timestamp so at most one sweep runs per maxDirCacheAge even if
-// many misses occur concurrently. Sweep is called via defer after each OS read,
-// so it executes after e.mu has been released — it only needs c.mu.
+// sweep removes stale entries. Throttled to at most once per maxDirCacheAge;
+// called via defer after each OS read so it runs after e.mu is released.
 func (c *dirCache) sweep() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -169,9 +154,8 @@ func (c *dirCache) sweep() {
 	}
 }
 
-// osDirNames reads sorted entry names from dir directly from the OS.
-// Using Readdirnames + sort avoids allocating DirEntry objects, which is
-// significantly faster for leaf directories that only need names.
+// osDirNames reads sorted entry names directly from the OS using
+// Readdirnames, which avoids DirEntry allocation for leaf directories.
 func osDirNames(dir string) ([]string, error) {
 	f, err := os.Open(dir)
 	if err != nil {
@@ -186,7 +170,6 @@ func osDirNames(dir string) ([]string, error) {
 	return names, nil
 }
 
-// entryNames extracts sorted names from a slice of DirEntry values.
 func entryNames(entries []os.DirEntry) []string {
 	names := make([]string, len(entries))
 	for i, e := range entries {
@@ -195,20 +178,14 @@ func entryNames(entries []os.DirEntry) []string {
 	return names
 }
 
-// Process-wide singleton dir cache shared across all filestream Plugin()
-// invocations. acquireSharedDirReader / release follow the same ref-counted
-// acquire/release pattern as oteltelemetry.AcquireSystemBridge.
 var (
 	dirReaderMu   sync.Mutex
 	dirReaderInst *dirCache
 	dirReaderRefs int
 )
 
-// acquireSharedDirReader returns the process-wide dirCache and a release
-// function the caller must invoke on shutdown. On first call the singleton is
-// created. Subsequent calls increment the reference count. When the last caller
-// releases, the cache is cleared and the singleton is discarded — no background
-// goroutine is involved, so cleanup is immediate and complete.
+// acquireSharedDirReader returns the process-wide dirCache and a release func.
+// When the last caller releases, the cache is cleared and the singleton is nil'd.
 func acquireSharedDirReader() (*dirCache, func()) {
 	dirReaderMu.Lock()
 	defer dirReaderMu.Unlock()

--- a/filebeat/input/filestream/dir_reader.go
+++ b/filebeat/input/filestream/dir_reader.go
@@ -60,7 +60,6 @@ func acquireSharedDirReader() (dirReader, func()) {
 
 	if dirReaderInst == nil {
 		dirReaderInst = newCachedDirReader(time.Second)
-		go dirReaderInst.sweepLoop()
 	}
 	dirReaderRefs++
 
@@ -97,11 +96,13 @@ type cachedDirReader struct {
 }
 
 func newCachedDirReader(ttl time.Duration) *cachedDirReader {
-	return &cachedDirReader{
+	c := &cachedDirReader{
 		ttl:    ttl,
 		cache:  make(map[string]cachedDirListing),
 		stopCh: make(chan struct{}),
 	}
+	go c.sweepLoop()
+	return c
 }
 
 // sweepLoop removes expired cache entries every TTL. Run in a goroutine.

--- a/filebeat/input/filestream/dir_reader.go
+++ b/filebeat/input/filestream/dir_reader.go
@@ -138,6 +138,17 @@ func (c *cachedDirReader) stop() {
 	close(c.stopCh)
 }
 
+// lowerTTL shrinks the cache TTL if d is smaller than the current one.
+// Called when an input is configured with a check_interval shorter than the
+// current TTL so the cache does not serve listings stale beyond that interval.
+func (c *cachedDirReader) lowerTTL(d time.Duration) {
+	c.mu.Lock()
+	if d < c.ttl {
+		c.ttl = d
+	}
+	c.mu.Unlock()
+}
+
 // readDir returns the cached listing for dir, refreshing it from the OS if
 // the entry is absent or older than the TTL. The lock is held during the
 // underlying os.ReadDir call so that concurrent callers for the same directory

--- a/filebeat/input/filestream/dir_reader.go
+++ b/filebeat/input/filestream/dir_reader.go
@@ -18,65 +18,203 @@
 package filestream
 
 import (
-	"math"
 	"os"
-	"path/filepath"
-	"strings"
+	"slices"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
-// dirListing holds the entries and sorted names for a single directory.
-type dirListing struct {
-	entries []os.DirEntry
+// maxDirCacheAge caps how long a directory listing may be served from cache.
+const maxDirCacheAge = time.Second
+
+// dirCacheEntry holds a cached directory listing protected by its own mutex.
+// The per-entry mutex allows concurrent reads of distinct directories while
+// serialising concurrent reads of the same directory so at most one OS call
+// runs per directory at a time.
+type dirCacheEntry struct {
+	mu      sync.Mutex
+	fetched atomic.Int64 // Unix nanoseconds; zero means no valid entry
 	names   []string
-	fetched time.Time
+	entries []os.DirEntry
 }
 
-// dirReader abstracts reading a directory's entries. The abstraction allows a
-// caching implementation to be shared across fileScanner instances so that many
-// inputs watching the same base directory make only one readdir syscall per TTL
-// window instead of one per input.
-type dirReader interface {
-	// readDir returns the sorted entries and names for dir.
-	readDir(dir string) (dirListing, error)
+func (e *dirCacheEntry) age() time.Duration {
+	f := e.fetched.Load()
+	if f == 0 {
+		return time.Duration(int64(^uint64(0) >> 1)) // max int64 — always stale
+	}
+	return time.Since(time.Unix(0, f))
 }
 
-// osDirReader reads directories directly from the OS without caching.
-type osDirReader struct{}
+// set stores names/entries and timestamps the entry. Passing nil for both
+// clears the entry so the next caller retries (used when an OS read fails).
+func (e *dirCacheEntry) set(names []string, entries []os.DirEntry) {
+	e.names = names
+	e.entries = entries
+	if names != nil || entries != nil {
+		e.fetched.Store(time.Now().UnixNano())
+	} else {
+		e.fetched.Store(0)
+	}
+}
 
-func (osDirReader) readDir(dir string) (dirListing, error) {
+// dirCache is a process-wide cache of directory listings. A single instance is
+// shared across all filestream Plugin() invocations via acquireSharedDirReader.
+//
+// Locking discipline:
+//   - mu guards the entries map (held only while looking up / inserting entries).
+//   - Each dirCacheEntry has its own mutex that serialises concurrent reads of
+//     the same directory; reads for distinct directories proceed fully in parallel.
+//   - Sweep runs inline on every miss path (under defer, after e.mu is released).
+//     A swept timestamp throttles actual work to at most once per maxDirCacheAge.
+type dirCache struct {
+	mu      sync.Mutex
+	entries map[string]*dirCacheEntry
+	swept   time.Time
+}
+
+func newDirCache() *dirCache {
+	return &dirCache{entries: make(map[string]*dirCacheEntry)}
+}
+
+// reset clears all cached entries. Called when the last receiver releases the
+// singleton so the GC can reclaim any pinned slices.
+func (c *dirCache) reset() {
+	c.mu.Lock()
+	c.entries = make(map[string]*dirCacheEntry)
+	c.swept = time.Time{}
+	c.mu.Unlock()
+}
+
+// entry returns the cache entry for dir, creating it if absent.
+func (c *dirCache) entry(dir string) *dirCacheEntry {
+	c.mu.Lock()
+	e := c.entries[dir]
+	if e == nil {
+		e = &dirCacheEntry{}
+		c.entries[dir] = e
+	}
+	c.mu.Unlock()
+	return e
+}
+
+// readDirNames returns sorted file names for dir from the cache (when fresh
+// and shared=true) or from the OS. shared=false bypasses the cache so
+// sub-directories are always read directly; only the walk root is cached.
+func (c *dirCache) readDirNames(dir string, maxAge time.Duration, shared bool) ([]string, error) {
+	if !shared {
+		return osDirNames(dir)
+	}
+	e := c.entry(dir)
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.age() < maxAge {
+		if e.names != nil {
+			return e.names, nil
+		}
+		if e.entries != nil {
+			e.names = entryNames(e.entries)
+			return e.names, nil
+		}
+	}
+	defer c.sweep()
+	names, err := osDirNames(dir)
+	if err != nil {
+		e.set(nil, nil)
+		return nil, err
+	}
+	e.set(names, nil)
+	return names, nil
+}
+
+// readDirEntries returns sorted DirEntries for dir from the cache (when fresh
+// and shared=true) or from the OS. shared=false bypasses the cache.
+func (c *dirCache) readDirEntries(dir string, maxAge time.Duration, shared bool) ([]os.DirEntry, error) {
+	if !shared {
+		return os.ReadDir(dir)
+	}
+	e := c.entry(dir)
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.age() < maxAge && e.entries != nil {
+		return e.entries, nil
+	}
+	defer c.sweep()
 	entries, err := os.ReadDir(dir)
 	if err != nil {
-		return dirListing{}, err
+		e.set(nil, nil)
+		return nil, err
 	}
+	e.set(nil, entries)
+	return entries, nil
+}
+
+// sweep removes entries older than maxDirCacheAge from the map. It is throttled
+// by the swept timestamp so at most one sweep runs per maxDirCacheAge even if
+// many misses occur concurrently. Sweep is called via defer after each OS read,
+// so it executes after e.mu has been released — it only needs c.mu.
+func (c *dirCache) sweep() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	now := time.Now()
+	if now.Sub(c.swept) < maxDirCacheAge {
+		return
+	}
+	c.swept = now
+	for dir, e := range c.entries {
+		if now.Sub(time.Unix(0, e.fetched.Load())) >= maxDirCacheAge {
+			delete(c.entries, dir)
+		}
+	}
+}
+
+// osDirNames reads sorted entry names from dir directly from the OS.
+// Using Readdirnames + sort avoids allocating DirEntry objects, which is
+// significantly faster for leaf directories that only need names.
+func osDirNames(dir string) ([]string, error) {
+	f, err := os.Open(dir)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	names, err := f.Readdirnames(-1)
+	if err != nil {
+		return nil, err
+	}
+	slices.Sort(names)
+	return names, nil
+}
+
+// entryNames extracts sorted names from a slice of DirEntry values.
+func entryNames(entries []os.DirEntry) []string {
 	names := make([]string, len(entries))
 	for i, e := range entries {
 		names[i] = e.Name()
 	}
-	return dirListing{entries: entries, names: names}, nil
+	return names
 }
 
-// Process-wide singleton dir reader shared across all filestream Plugin()
-// instances. acquireSharedDirReader / releaseSharedDirReader follow the same
-// ref-counted acquire/release pattern as oteltelemetry.AcquireSystemBridge.
+// Process-wide singleton dir cache shared across all filestream Plugin()
+// invocations. acquireSharedDirReader / release follow the same ref-counted
+// acquire/release pattern as oteltelemetry.AcquireSystemBridge.
 var (
 	dirReaderMu   sync.Mutex
-	dirReaderInst *cachedDirReader
+	dirReaderInst *dirCache
 	dirReaderRefs int
 )
 
-// acquireSharedDirReader returns the process-wide cachedDirReader and a release
+// acquireSharedDirReader returns the process-wide dirCache and a release
 // function the caller must invoke on shutdown. On first call the singleton is
-// created and its sweep goroutine started. Subsequent calls increment the
-// reference count. When the last caller releases, the sweep goroutine is stopped
-// and the singleton is discarded.
-func acquireSharedDirReader() (dirReader, func()) {
+// created. Subsequent calls increment the reference count. When the last caller
+// releases, the cache is cleared and the singleton is discarded — no background
+// goroutine is involved, so cleanup is immediate and complete.
+func acquireSharedDirReader() (*dirCache, func()) {
 	dirReaderMu.Lock()
 	defer dirReaderMu.Unlock()
 
 	if dirReaderInst == nil {
-		dirReaderInst = newCachedDirReader(time.Second)
+		dirReaderInst = newDirCache()
 	}
 	dirReaderRefs++
 
@@ -87,180 +225,10 @@ func acquireSharedDirReader() (dirReader, func()) {
 			defer dirReaderMu.Unlock()
 			dirReaderRefs--
 			if dirReaderRefs <= 0 {
-				dirReaderInst.stop()
+				dirReaderInst.reset()
 				dirReaderInst = nil
 				dirReaderRefs = 0
 			}
 		})
 	}
-}
-
-// cachedDirReader caches directory listings for a configurable TTL. A single
-// instance shared across all fileScanner instances reduces readdir syscalls when
-// many inputs watch the same base directory.
-//
-// Locking discipline:
-//   - mu (RWMutex) guards cache and pathCounts. Readers hold RLock; writers hold Lock.
-//   - dirMus holds one *sync.Mutex per directory path. A goroutine acquires the
-//     per-dir lock before calling os.ReadDir, so concurrent reads for the same
-//     directory are serialised into one syscall while reads for distinct directories
-//     proceed in parallel.
-type cachedDirReader struct {
-	mu         sync.RWMutex
-	defaultTTL time.Duration
-	// pathCounts tracks how many callers have registered each (dir, interval) pair.
-	// The effective TTL for a dir is the minimum interval with a positive count.
-	// When a caller deregisters, its count is decremented; if it reaches zero the
-	// entry is removed and the TTL for that dir may rise.
-	pathCounts map[string]map[time.Duration]int
-	cache      map[string]dirListing
-	dirMus     sync.Map // map[string]*sync.Mutex — per-directory fetch locks
-	stopCh     chan struct{}
-}
-
-func newCachedDirReader(defaultTTL time.Duration) *cachedDirReader {
-	c := &cachedDirReader{
-		defaultTTL: defaultTTL,
-		pathCounts: make(map[string]map[time.Duration]int),
-		cache:      make(map[string]dirListing),
-		stopCh:     make(chan struct{}),
-	}
-	go c.sweepLoop()
-	return c
-}
-
-// registerPath records that an input with the given check interval is watching
-// dir. It returns a deregister function the caller must invoke when the input
-// stops. While at least one caller is registered for a dir the effective TTL
-// for that dir equals the minimum registered interval; when all callers
-// deregister it reverts to defaultTTL.
-func (c *cachedDirReader) registerPath(dir string, interval time.Duration) func() {
-	c.mu.Lock()
-	if c.pathCounts[dir] == nil {
-		c.pathCounts[dir] = make(map[time.Duration]int)
-	}
-	c.pathCounts[dir][interval]++
-	c.mu.Unlock()
-
-	var once sync.Once
-	return func() {
-		once.Do(func() {
-			c.mu.Lock()
-			if counts, ok := c.pathCounts[dir]; ok {
-				counts[interval]--
-				if counts[interval] == 0 {
-					delete(counts, interval)
-				}
-				if len(counts) == 0 {
-					delete(c.pathCounts, dir)
-				}
-				// Invalidate the cached entry so the next fetch uses the new TTL.
-				delete(c.cache, dir)
-			}
-			c.mu.Unlock()
-		})
-	}
-}
-
-// ttlForDir returns the effective TTL for dir. Must be called with c.mu held (read or write).
-func (c *cachedDirReader) ttlForDir(dir string) time.Duration {
-	counts, ok := c.pathCounts[dir]
-	if !ok || len(counts) == 0 {
-		return c.defaultTTL
-	}
-	min := time.Duration(math.MaxInt64)
-	for d := range counts {
-		if d < min {
-			min = d
-		}
-	}
-	return min
-}
-
-// sweepLoop removes expired cache entries every defaultTTL. Run in a goroutine.
-func (c *cachedDirReader) sweepLoop() {
-	ticker := time.NewTicker(c.defaultTTL)
-	defer ticker.Stop()
-	for {
-		select {
-		case <-ticker.C:
-			c.mu.Lock()
-			now := time.Now()
-			for dir, listing := range c.cache {
-				if now.Sub(listing.fetched) >= c.ttlForDir(dir) {
-					delete(c.cache, dir)
-				}
-			}
-			c.mu.Unlock()
-		case <-c.stopCh:
-			return
-		}
-	}
-}
-
-// stop signals sweepLoop to exit.
-func (c *cachedDirReader) stop() {
-	close(c.stopCh)
-}
-
-// readDir returns the cached listing for dir, refreshing it from the OS if the
-// entry is absent or older than the effective TTL for that dir.
-//
-// Reads for distinct directories proceed concurrently. Reads for the same
-// directory are serialised by a per-directory mutex so that at most one
-// os.ReadDir syscall runs for any given dir at a time; subsequent waiters
-// receive the result from the cache rather than issuing their own syscall.
-func (c *cachedDirReader) readDir(dir string) (dirListing, error) {
-	// Fast path: serve from cache under a read lock.
-	c.mu.RLock()
-	e, ok := c.cache[dir]
-	ttl := c.ttlForDir(dir)
-	c.mu.RUnlock()
-	if ok && time.Since(e.fetched) < ttl {
-		return e, nil
-	}
-
-	// Slow path: acquire the per-directory lock so only one goroutine calls
-	// os.ReadDir for this dir at a time while others block here.
-	muVal, _ := c.dirMus.LoadOrStore(dir, new(sync.Mutex))
-	dirMu := muVal.(*sync.Mutex) //nolint:errcheck
-	dirMu.Lock()
-	defer dirMu.Unlock()
-
-	// Re-check now that we hold the per-dir lock; another goroutine may have
-	// already fetched and populated the cache while we were waiting.
-	c.mu.RLock()
-	e, ok = c.cache[dir]
-	ttl = c.ttlForDir(dir)
-	c.mu.RUnlock()
-	if ok && time.Since(e.fetched) < ttl {
-		return e, nil
-	}
-
-	// os.ReadDir returns entries sorted by filename.
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		return dirListing{}, err
-	}
-	names := make([]string, len(entries))
-	for i, entry := range entries {
-		names[i] = entry.Name()
-	}
-	listing := dirListing{entries: entries, names: names, fetched: time.Now()}
-
-	c.mu.Lock()
-	c.cache[dir] = listing
-	c.mu.Unlock()
-
-	return listing, nil
-}
-
-// globBase returns the base directory for a glob pattern: the longest path
-// prefix that contains no wildcard metacharacters.
-func globBase(pattern string) string {
-	i := strings.IndexAny(pattern, "*?[")
-	if i < 0 {
-		return filepath.Dir(pattern)
-	}
-	return filepath.Dir(pattern[:i])
 }

--- a/filebeat/input/filestream/dir_reader.go
+++ b/filebeat/input/filestream/dir_reader.go
@@ -23,22 +23,36 @@ import (
 	"time"
 )
 
+// dirListing holds the entries and sorted names for a single directory.
+type dirListing struct {
+	entries []os.DirEntry
+	names   []string
+	fetched time.Time
+}
+
 // dirReader abstracts reading a directory's entries. The abstraction allows a
 // caching implementation to be shared across fileScanner instances so that many
 // inputs watching the same base directory make only one readdir syscall per TTL
 // window instead of one per input.
 type dirReader interface {
-	// readDirNames returns the sorted entry names of dir.
-	readDirNames(dir string) ([]string, error)
-	// readDir returns the sorted DirEntry slice for dir.
-	readDir(dir string) ([]os.DirEntry, error)
+	// readDir returns the sorted entries and names for dir.
+	readDir(dir string) (dirListing, error)
 }
 
 // osDirReader reads directories directly from the OS without caching.
 type osDirReader struct{}
 
-func (osDirReader) readDirNames(dir string) ([]string, error) { return readDirNames(dir) }
-func (osDirReader) readDir(dir string) ([]os.DirEntry, error) { return os.ReadDir(dir) }
+func (osDirReader) readDir(dir string) (dirListing, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return dirListing{}, err
+	}
+	names := make([]string, len(entries))
+	for i, e := range entries {
+		names[i] = e.Name()
+	}
+	return dirListing{entries: entries, names: names}, nil
+}
 
 // Process-wide singleton dir reader shared across all filestream Plugin()
 // instances. acquireSharedDirReader / releaseSharedDirReader follow the same
@@ -78,27 +92,20 @@ func acquireSharedDirReader() (dirReader, func()) {
 	}
 }
 
-// cachedDirListing holds a cached directory listing.
-type cachedDirListing struct {
-	entries []os.DirEntry
-	names   []string
-	fetched time.Time
-}
-
 // cachedDirReader caches directory listings for a configurable TTL. A single
 // instance shared across all fileScanner instances reduces readdir syscalls when
 // many inputs watch the same base directory.
 type cachedDirReader struct {
 	mu     sync.Mutex
 	ttl    time.Duration
-	cache  map[string]cachedDirListing
+	cache  map[string]dirListing
 	stopCh chan struct{}
 }
 
 func newCachedDirReader(ttl time.Duration) *cachedDirReader {
 	c := &cachedDirReader{
 		ttl:    ttl,
-		cache:  make(map[string]cachedDirListing),
+		cache:  make(map[string]dirListing),
 		stopCh: make(chan struct{}),
 	}
 	go c.sweepLoop()
@@ -131,11 +138,11 @@ func (c *cachedDirReader) stop() {
 	close(c.stopCh)
 }
 
-// getOrFetch returns the cached listing for dir, refreshing it from the OS if
+// readDir returns the cached listing for dir, refreshing it from the OS if
 // the entry is absent or older than the TTL. The lock is held during the
 // underlying os.ReadDir call so that concurrent callers for the same directory
 // wait for a single syscall rather than each issuing their own.
-func (c *cachedDirReader) getOrFetch(dir string) (cachedDirListing, error) {
+func (c *cachedDirReader) readDir(dir string) (dirListing, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -146,7 +153,7 @@ func (c *cachedDirReader) getOrFetch(dir string) (cachedDirListing, error) {
 	// os.ReadDir returns entries sorted by filename.
 	entries, err := os.ReadDir(dir)
 	if err != nil {
-		return cachedDirListing{}, err
+		return dirListing{}, err
 	}
 
 	names := make([]string, len(entries))
@@ -154,23 +161,7 @@ func (c *cachedDirReader) getOrFetch(dir string) (cachedDirListing, error) {
 		names[i] = entry.Name()
 	}
 
-	listing := cachedDirListing{entries: entries, names: names, fetched: time.Now()}
+	listing := dirListing{entries: entries, names: names, fetched: time.Now()}
 	c.cache[dir] = listing
 	return listing, nil
-}
-
-func (c *cachedDirReader) readDirNames(dir string) ([]string, error) {
-	listing, err := c.getOrFetch(dir)
-	if err != nil {
-		return nil, err
-	}
-	return listing.names, nil
-}
-
-func (c *cachedDirReader) readDir(dir string) ([]os.DirEntry, error) {
-	listing, err := c.getOrFetch(dir)
-	if err != nil {
-		return nil, err
-	}
-	return listing.entries, nil
 }

--- a/filebeat/input/filestream/dir_reader.go
+++ b/filebeat/input/filestream/dir_reader.go
@@ -18,7 +18,10 @@
 package filestream
 
 import (
+	"math"
 	"os"
+	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 )
@@ -96,34 +99,88 @@ func acquireSharedDirReader() (dirReader, func()) {
 // instance shared across all fileScanner instances reduces readdir syscalls when
 // many inputs watch the same base directory.
 type cachedDirReader struct {
-	mu     sync.Mutex
-	ttl    time.Duration
-	cache  map[string]dirListing
-	stopCh chan struct{}
+	mu         sync.Mutex
+	defaultTTL time.Duration
+	// pathCounts tracks how many callers have registered each (dir, interval) pair.
+	// The effective TTL for a dir is the minimum interval with a positive count.
+	// When a caller deregisters, its count is decremented; if it reaches zero the
+	// entry is removed and the TTL for that dir may rise.
+	pathCounts map[string]map[time.Duration]int
+	cache      map[string]dirListing
+	stopCh     chan struct{}
 }
 
-func newCachedDirReader(ttl time.Duration) *cachedDirReader {
+func newCachedDirReader(defaultTTL time.Duration) *cachedDirReader {
 	c := &cachedDirReader{
-		ttl:    ttl,
-		cache:  make(map[string]dirListing),
-		stopCh: make(chan struct{}),
+		defaultTTL: defaultTTL,
+		pathCounts: make(map[string]map[time.Duration]int),
+		cache:      make(map[string]dirListing),
+		stopCh:     make(chan struct{}),
 	}
 	go c.sweepLoop()
 	return c
 }
 
-// sweepLoop removes expired cache entries every TTL. Run in a goroutine.
+// registerPath records that an input with the given check interval is watching
+// dir. It returns a deregister function the caller must invoke when the input
+// stops. While at least one caller is registered for a dir the effective TTL
+// for that dir equals the minimum registered interval; when all callers
+// deregister it reverts to defaultTTL.
+func (c *cachedDirReader) registerPath(dir string, interval time.Duration) func() {
+	c.mu.Lock()
+	if c.pathCounts[dir] == nil {
+		c.pathCounts[dir] = make(map[time.Duration]int)
+	}
+	c.pathCounts[dir][interval]++
+	c.mu.Unlock()
+
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			c.mu.Lock()
+			if counts, ok := c.pathCounts[dir]; ok {
+				counts[interval]--
+				if counts[interval] == 0 {
+					delete(counts, interval)
+				}
+				if len(counts) == 0 {
+					delete(c.pathCounts, dir)
+				}
+				// Invalidate the cached entry so the next fetch uses the new TTL.
+				delete(c.cache, dir)
+			}
+			c.mu.Unlock()
+		})
+	}
+}
+
+// ttlForDir returns the effective TTL for dir. Must be called with c.mu held.
+func (c *cachedDirReader) ttlForDir(dir string) time.Duration {
+	counts, ok := c.pathCounts[dir]
+	if !ok || len(counts) == 0 {
+		return c.defaultTTL
+	}
+	min := time.Duration(math.MaxInt64)
+	for d := range counts {
+		if d < min {
+			min = d
+		}
+	}
+	return min
+}
+
+// sweepLoop removes expired cache entries every defaultTTL. Run in a goroutine.
 func (c *cachedDirReader) sweepLoop() {
-	ticker := time.NewTicker(c.ttl)
+	ticker := time.NewTicker(c.defaultTTL)
 	defer ticker.Stop()
 	for {
 		select {
 		case <-ticker.C:
 			c.mu.Lock()
 			now := time.Now()
-			for k, v := range c.cache {
-				if now.Sub(v.fetched) >= c.ttl {
-					delete(c.cache, k)
+			for dir, listing := range c.cache {
+				if now.Sub(listing.fetched) >= c.ttlForDir(dir) {
+					delete(c.cache, dir)
 				}
 			}
 			c.mu.Unlock()
@@ -138,26 +195,15 @@ func (c *cachedDirReader) stop() {
 	close(c.stopCh)
 }
 
-// lowerTTL shrinks the cache TTL if d is smaller than the current one.
-// Called when an input is configured with a check_interval shorter than the
-// current TTL so the cache does not serve listings stale beyond that interval.
-func (c *cachedDirReader) lowerTTL(d time.Duration) {
-	c.mu.Lock()
-	if d < c.ttl {
-		c.ttl = d
-	}
-	c.mu.Unlock()
-}
-
 // readDir returns the cached listing for dir, refreshing it from the OS if
-// the entry is absent or older than the TTL. The lock is held during the
-// underlying os.ReadDir call so that concurrent callers for the same directory
-// wait for a single syscall rather than each issuing their own.
+// the entry is absent or older than the effective TTL for that dir. The lock
+// is held during the underlying os.ReadDir call so that concurrent callers for
+// the same directory wait for a single syscall rather than each issuing their own.
 func (c *cachedDirReader) readDir(dir string) (dirListing, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	if e, ok := c.cache[dir]; ok && time.Since(e.fetched) < c.ttl {
+	if e, ok := c.cache[dir]; ok && time.Since(e.fetched) < c.ttlForDir(dir) {
 		return e, nil
 	}
 
@@ -175,4 +221,14 @@ func (c *cachedDirReader) readDir(dir string) (dirListing, error) {
 	listing := dirListing{entries: entries, names: names, fetched: time.Now()}
 	c.cache[dir] = listing
 	return listing, nil
+}
+
+// globBase returns the base directory for a glob pattern: the longest path
+// prefix that contains no wildcard metacharacters.
+func globBase(pattern string) string {
+	i := strings.IndexAny(pattern, "*?[")
+	if i < 0 {
+		return filepath.Dir(pattern)
+	}
+	return filepath.Dir(pattern[:i])
 }

--- a/filebeat/input/filestream/dir_reader.go
+++ b/filebeat/input/filestream/dir_reader.go
@@ -38,7 +38,7 @@ type dirReader interface {
 type osDirReader struct{}
 
 func (osDirReader) readDirNames(dir string) ([]string, error) { return readDirNames(dir) }
-func (osDirReader) readDir(dir string) ([]os.DirEntry, error)  { return os.ReadDir(dir) }
+func (osDirReader) readDir(dir string) ([]os.DirEntry, error) { return os.ReadDir(dir) }
 
 // Process-wide singleton dir reader shared across all filestream Plugin()
 // instances. acquireSharedDirReader / releaseSharedDirReader follow the same
@@ -90,10 +90,10 @@ type cachedDirListing struct {
 // instance shared across all fileScanner instances reduces readdir syscalls when
 // many inputs watch the same base directory.
 type cachedDirReader struct {
-	mu       sync.Mutex
-	ttl      time.Duration
-	cache    map[string]cachedDirListing
-	stopCh   chan struct{}
+	mu     sync.Mutex
+	ttl    time.Duration
+	cache  map[string]cachedDirListing
+	stopCh chan struct{}
 }
 
 func newCachedDirReader(ttl time.Duration) *cachedDirReader {

--- a/filebeat/input/filestream/dir_reader.go
+++ b/filebeat/input/filestream/dir_reader.go
@@ -1,0 +1,175 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package filestream
+
+import (
+	"os"
+	"sync"
+	"time"
+)
+
+// dirReader abstracts reading a directory's entries. The abstraction allows a
+// caching implementation to be shared across fileScanner instances so that many
+// inputs watching the same base directory make only one readdir syscall per TTL
+// window instead of one per input.
+type dirReader interface {
+	// readDirNames returns the sorted entry names of dir.
+	readDirNames(dir string) ([]string, error)
+	// readDir returns the sorted DirEntry slice for dir.
+	readDir(dir string) ([]os.DirEntry, error)
+}
+
+// osDirReader reads directories directly from the OS without caching.
+type osDirReader struct{}
+
+func (osDirReader) readDirNames(dir string) ([]string, error) { return readDirNames(dir) }
+func (osDirReader) readDir(dir string) ([]os.DirEntry, error)  { return os.ReadDir(dir) }
+
+// Process-wide singleton dir reader shared across all filestream Plugin()
+// instances. acquireSharedDirReader / releaseSharedDirReader follow the same
+// ref-counted acquire/release pattern as oteltelemetry.AcquireSystemBridge.
+var (
+	dirReaderMu   sync.Mutex
+	dirReaderInst *cachedDirReader
+	dirReaderRefs int
+)
+
+// acquireSharedDirReader returns the process-wide cachedDirReader and a release
+// function the caller must invoke on shutdown. On first call the singleton is
+// created and its sweep goroutine started. Subsequent calls increment the
+// reference count. When the last caller releases, the sweep goroutine is stopped
+// and the singleton is discarded.
+func acquireSharedDirReader() (dirReader, func()) {
+	dirReaderMu.Lock()
+	defer dirReaderMu.Unlock()
+
+	if dirReaderInst == nil {
+		dirReaderInst = newCachedDirReader(time.Second)
+		go dirReaderInst.sweepLoop()
+	}
+	dirReaderRefs++
+
+	var once sync.Once
+	return dirReaderInst, func() {
+		once.Do(func() {
+			dirReaderMu.Lock()
+			defer dirReaderMu.Unlock()
+			dirReaderRefs--
+			if dirReaderRefs <= 0 {
+				dirReaderInst.stop()
+				dirReaderInst = nil
+				dirReaderRefs = 0
+			}
+		})
+	}
+}
+
+// cachedDirListing holds a cached directory listing.
+type cachedDirListing struct {
+	entries []os.DirEntry
+	names   []string
+	fetched time.Time
+}
+
+// cachedDirReader caches directory listings for a configurable TTL. A single
+// instance shared across all fileScanner instances reduces readdir syscalls when
+// many inputs watch the same base directory.
+type cachedDirReader struct {
+	mu       sync.Mutex
+	ttl      time.Duration
+	cache    map[string]cachedDirListing
+	stopCh   chan struct{}
+}
+
+func newCachedDirReader(ttl time.Duration) *cachedDirReader {
+	return &cachedDirReader{
+		ttl:    ttl,
+		cache:  make(map[string]cachedDirListing),
+		stopCh: make(chan struct{}),
+	}
+}
+
+// sweepLoop removes expired cache entries every TTL. Run in a goroutine.
+func (c *cachedDirReader) sweepLoop() {
+	ticker := time.NewTicker(c.ttl)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			c.mu.Lock()
+			now := time.Now()
+			for k, v := range c.cache {
+				if now.Sub(v.fetched) >= c.ttl {
+					delete(c.cache, k)
+				}
+			}
+			c.mu.Unlock()
+		case <-c.stopCh:
+			return
+		}
+	}
+}
+
+// stop signals sweepLoop to exit.
+func (c *cachedDirReader) stop() {
+	close(c.stopCh)
+}
+
+// getOrFetch returns the cached listing for dir, refreshing it from the OS if
+// the entry is absent or older than the TTL. The lock is held during the
+// underlying os.ReadDir call so that concurrent callers for the same directory
+// wait for a single syscall rather than each issuing their own.
+func (c *cachedDirReader) getOrFetch(dir string) (cachedDirListing, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if e, ok := c.cache[dir]; ok && time.Since(e.fetched) < c.ttl {
+		return e, nil
+	}
+
+	// os.ReadDir returns entries sorted by filename.
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return cachedDirListing{}, err
+	}
+
+	names := make([]string, len(entries))
+	for i, entry := range entries {
+		names[i] = entry.Name()
+	}
+
+	listing := cachedDirListing{entries: entries, names: names, fetched: time.Now()}
+	c.cache[dir] = listing
+	return listing, nil
+}
+
+func (c *cachedDirReader) readDirNames(dir string) ([]string, error) {
+	listing, err := c.getOrFetch(dir)
+	if err != nil {
+		return nil, err
+	}
+	return listing.names, nil
+}
+
+func (c *cachedDirReader) readDir(dir string) ([]os.DirEntry, error) {
+	listing, err := c.getOrFetch(dir)
+	if err != nil {
+		return nil, err
+	}
+	return listing.entries, nil
+}

--- a/filebeat/input/filestream/dir_reader.go
+++ b/filebeat/input/filestream/dir_reader.go
@@ -98,8 +98,15 @@ func acquireSharedDirReader() (dirReader, func()) {
 // cachedDirReader caches directory listings for a configurable TTL. A single
 // instance shared across all fileScanner instances reduces readdir syscalls when
 // many inputs watch the same base directory.
+//
+// Locking discipline:
+//   - mu (RWMutex) guards cache and pathCounts. Readers hold RLock; writers hold Lock.
+//   - dirMus holds one *sync.Mutex per directory path. A goroutine acquires the
+//     per-dir lock before calling os.ReadDir, so concurrent reads for the same
+//     directory are serialised into one syscall while reads for distinct directories
+//     proceed in parallel.
 type cachedDirReader struct {
-	mu         sync.Mutex
+	mu         sync.RWMutex
 	defaultTTL time.Duration
 	// pathCounts tracks how many callers have registered each (dir, interval) pair.
 	// The effective TTL for a dir is the minimum interval with a positive count.
@@ -107,6 +114,7 @@ type cachedDirReader struct {
 	// entry is removed and the TTL for that dir may rise.
 	pathCounts map[string]map[time.Duration]int
 	cache      map[string]dirListing
+	dirMus     sync.Map // map[string]*sync.Mutex — per-directory fetch locks
 	stopCh     chan struct{}
 }
 
@@ -154,7 +162,7 @@ func (c *cachedDirReader) registerPath(dir string, interval time.Duration) func(
 	}
 }
 
-// ttlForDir returns the effective TTL for dir. Must be called with c.mu held.
+// ttlForDir returns the effective TTL for dir. Must be called with c.mu held (read or write).
 func (c *cachedDirReader) ttlForDir(dir string) time.Duration {
 	counts, ok := c.pathCounts[dir]
 	if !ok || len(counts) == 0 {
@@ -195,15 +203,37 @@ func (c *cachedDirReader) stop() {
 	close(c.stopCh)
 }
 
-// readDir returns the cached listing for dir, refreshing it from the OS if
-// the entry is absent or older than the effective TTL for that dir. The lock
-// is held during the underlying os.ReadDir call so that concurrent callers for
-// the same directory wait for a single syscall rather than each issuing their own.
+// readDir returns the cached listing for dir, refreshing it from the OS if the
+// entry is absent or older than the effective TTL for that dir.
+//
+// Reads for distinct directories proceed concurrently. Reads for the same
+// directory are serialised by a per-directory mutex so that at most one
+// os.ReadDir syscall runs for any given dir at a time; subsequent waiters
+// receive the result from the cache rather than issuing their own syscall.
 func (c *cachedDirReader) readDir(dir string) (dirListing, error) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
+	// Fast path: serve from cache under a read lock.
+	c.mu.RLock()
+	e, ok := c.cache[dir]
+	ttl := c.ttlForDir(dir)
+	c.mu.RUnlock()
+	if ok && time.Since(e.fetched) < ttl {
+		return e, nil
+	}
 
-	if e, ok := c.cache[dir]; ok && time.Since(e.fetched) < c.ttlForDir(dir) {
+	// Slow path: acquire the per-directory lock so only one goroutine calls
+	// os.ReadDir for this dir at a time while others block here.
+	muVal, _ := c.dirMus.LoadOrStore(dir, new(sync.Mutex))
+	dirMu := muVal.(*sync.Mutex) //nolint:errcheck
+	dirMu.Lock()
+	defer dirMu.Unlock()
+
+	// Re-check now that we hold the per-dir lock; another goroutine may have
+	// already fetched and populated the cache while we were waiting.
+	c.mu.RLock()
+	e, ok = c.cache[dir]
+	ttl = c.ttlForDir(dir)
+	c.mu.RUnlock()
+	if ok && time.Since(e.fetched) < ttl {
 		return e, nil
 	}
 
@@ -212,14 +242,16 @@ func (c *cachedDirReader) readDir(dir string) (dirListing, error) {
 	if err != nil {
 		return dirListing{}, err
 	}
-
 	names := make([]string, len(entries))
 	for i, entry := range entries {
 		names[i] = entry.Name()
 	}
-
 	listing := dirListing{entries: entries, names: names, fetched: time.Now()}
+
+	c.mu.Lock()
 	c.cache[dir] = listing
+	c.mu.Unlock()
+
 	return listing, nil
 }
 

--- a/filebeat/input/filestream/dir_reader_test.go
+++ b/filebeat/input/filestream/dir_reader_test.go
@@ -222,9 +222,13 @@ func TestAcquireSharedDirReaderSingleton(t *testing.T) {
 	dr1, release1 := acquireSharedDirReader()
 	dr2, release2 := acquireSharedDirReader()
 
+	rd1, ok1 := dr1.(*cachedDirReader)
+	rd2, ok2 := dr2.(*cachedDirReader)
+	require.True(t, ok1 && ok2, "acquireSharedDirReader must return *cachedDirReader")
+
 	dirReaderMu.Lock()
 	assert.Equal(t, 2, dirReaderRefs, "two acquires should give ref count 2")
-	assert.Same(t, dr1.(*cachedDirReader), dr2.(*cachedDirReader), "both acquires should return the same instance")
+	assert.Same(t, rd1, rd2, "both acquires should return the same instance")
 	dirReaderMu.Unlock()
 
 	release1()

--- a/filebeat/input/filestream/dir_reader_test.go
+++ b/filebeat/input/filestream/dir_reader_test.go
@@ -1,0 +1,259 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package filestream
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---- globBase ---------------------------------------------------------------
+
+func TestGlobBase(t *testing.T) {
+	tests := []struct {
+		pattern string
+		want    string
+	}{
+		// glob patterns
+		{"/var/log/containers/*.log", "/var/log/containers"},
+		{"/var/log/**/*.log", "/var/log"},
+		{"/var/log/*/containers.log", "/var/log"},
+		{"*.log", "."},
+		// literal file paths (no glob chars)
+		{"/var/log/containers/pod.log", "/var/log/containers"},
+		{"/var/log/containers/a/b.log", "/var/log/containers/a"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.pattern, func(t *testing.T) {
+			assert.Equal(t, filepath.FromSlash(tc.want), globBase(filepath.FromSlash(tc.pattern)))
+		})
+	}
+}
+
+// ---- per-path TTL ref counting ----------------------------------------------
+
+func TestPerPathTTLSingleRegistration(t *testing.T) {
+	dr := newCachedDirReader(time.Second)
+	defer dr.stop()
+
+	deregFn := dr.registerPath("/var/log/containers", 200*time.Millisecond)
+	defer deregFn()
+
+	dr.mu.Lock()
+	assert.Equal(t, 200*time.Millisecond, dr.ttlForDir("/var/log/containers"))
+	dr.mu.Unlock()
+}
+
+func TestPerPathTTLMinOfMultipleRegistrations(t *testing.T) {
+	dr := newCachedDirReader(time.Second)
+	defer dr.stop()
+
+	deregA := dr.registerPath("/var/log/containers", time.Second)
+	deregB := dr.registerPath("/var/log/containers", 200*time.Millisecond)
+	defer deregA()
+	defer deregB()
+
+	dr.mu.Lock()
+	assert.Equal(t, 200*time.Millisecond, dr.ttlForDir("/var/log/containers"))
+	dr.mu.Unlock()
+}
+
+func TestPerPathTTLRisesWhenFastWatcherDeregisters(t *testing.T) {
+	dr := newCachedDirReader(time.Second)
+	defer dr.stop()
+
+	deregA := dr.registerPath("/var/log/containers", time.Second)
+	deregB := dr.registerPath("/var/log/containers", 200*time.Millisecond)
+	defer deregA()
+
+	// B (fast) stops first: TTL rises back to A's interval
+	deregB()
+
+	dr.mu.Lock()
+	assert.Equal(t, time.Second, dr.ttlForDir("/var/log/containers"))
+	dr.mu.Unlock()
+}
+
+func TestPerPathTTLRevertsToDefaultWhenAllDeregister(t *testing.T) {
+	const defaultTTL = time.Second
+	dr := newCachedDirReader(defaultTTL)
+	defer dr.stop()
+
+	deregA := dr.registerPath("/var/log/containers", time.Second)
+	deregB := dr.registerPath("/var/log/containers", 200*time.Millisecond)
+
+	deregA()
+	deregB()
+
+	dr.mu.Lock()
+	assert.Equal(t, defaultTTL, dr.ttlForDir("/var/log/containers"))
+	dr.mu.Unlock()
+}
+
+func TestPerPathTTLDeregisterIdempotent(t *testing.T) {
+	dr := newCachedDirReader(time.Second)
+	defer dr.stop()
+
+	deregFn := dr.registerPath("/var/log/containers", 200*time.Millisecond)
+	deregFn()
+	deregFn() // second call must be a no-op
+
+	dr.mu.Lock()
+	assert.Equal(t, time.Second, dr.ttlForDir("/var/log/containers"), "double deregister must not undercount")
+	dr.mu.Unlock()
+}
+
+func TestPerPathTTLIndependentPaths(t *testing.T) {
+	dr := newCachedDirReader(time.Second)
+	defer dr.stop()
+
+	deregA := dr.registerPath("/var/log/containers", 200*time.Millisecond)
+	deregB := dr.registerPath("/var/log/pods", time.Second)
+	defer deregA()
+	defer deregB()
+
+	dr.mu.Lock()
+	assert.Equal(t, 200*time.Millisecond, dr.ttlForDir("/var/log/containers"))
+	assert.Equal(t, time.Second, dr.ttlForDir("/var/log/pods"))
+	dr.mu.Unlock()
+}
+
+// ---- cache hit / miss -------------------------------------------------------
+
+func TestCachedDirReaderCacheHit(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "a.log"), nil, 0o600))
+
+	// defaultTTL long enough that the per-path registration drives the TTL.
+	dr := newCachedDirReader(time.Second)
+	defer dr.stop()
+	deregFn := dr.registerPath(dir, 50*time.Millisecond)
+	defer deregFn()
+
+	// Warm the cache.
+	listing, err := dr.readDir(dir)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"a.log"}, listing.names)
+
+	// Add a file while the cache is warm.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "b.log"), nil, 0o600))
+
+	// Second read within TTL: still sees only a.log.
+	listing, err = dr.readDir(dir)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"a.log"}, listing.names)
+}
+
+func TestCachedDirReaderCacheMissAfterTTL(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "a.log"), nil, 0o600))
+
+	dr := newCachedDirReader(time.Second)
+	defer dr.stop()
+	deregFn := dr.registerPath(dir, 50*time.Millisecond)
+	defer deregFn()
+
+	// Warm the cache then add a file.
+	_, err := dr.readDir(dir)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "b.log"), nil, 0o600))
+
+	// Wait past the 50 ms per-path TTL.
+	time.Sleep(100 * time.Millisecond)
+
+	listing, err := dr.readDir(dir)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"a.log", "b.log"}, listing.names)
+}
+
+func TestCachedDirReaderDeregisterInvalidatesCache(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "a.log"), nil, 0o600))
+
+	// Use a very long TTL so the cache would not expire on its own.
+	dr := newCachedDirReader(time.Hour)
+	defer dr.stop()
+	deregFn := dr.registerPath(dir, time.Hour)
+
+	// Warm the cache then add a file.
+	_, err := dr.readDir(dir)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "b.log"), nil, 0o600))
+
+	// Deregister: must invalidate the cached entry.
+	deregFn()
+
+	listing, err := dr.readDir(dir)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"a.log", "b.log"}, listing.names)
+}
+
+// ---- singleton lifecycle ----------------------------------------------------
+
+func TestAcquireSharedDirReaderSingleton(t *testing.T) {
+	// Require clean global state — skip if another test left a reference.
+	dirReaderMu.Lock()
+	if dirReaderInst != nil {
+		dirReaderMu.Unlock()
+		t.Skip("singleton already held by another test")
+	}
+	dirReaderMu.Unlock()
+
+	dr1, release1 := acquireSharedDirReader()
+	dr2, release2 := acquireSharedDirReader()
+
+	dirReaderMu.Lock()
+	assert.Equal(t, 2, dirReaderRefs, "two acquires should give ref count 2")
+	assert.Same(t, dr1.(*cachedDirReader), dr2.(*cachedDirReader), "both acquires should return the same instance")
+	dirReaderMu.Unlock()
+
+	release1()
+	dirReaderMu.Lock()
+	assert.Equal(t, 1, dirReaderRefs)
+	assert.NotNil(t, dirReaderInst)
+	dirReaderMu.Unlock()
+
+	release2()
+	dirReaderMu.Lock()
+	assert.Equal(t, 0, dirReaderRefs)
+	assert.Nil(t, dirReaderInst, "singleton should be nil after last release")
+	dirReaderMu.Unlock()
+}
+
+func TestAcquireSharedDirReaderReleaseIdempotent(t *testing.T) {
+	dirReaderMu.Lock()
+	if dirReaderInst != nil {
+		dirReaderMu.Unlock()
+		t.Skip("singleton already held by another test")
+	}
+	dirReaderMu.Unlock()
+
+	_, release := acquireSharedDirReader()
+	release()
+	release() // second call must be a no-op
+
+	dirReaderMu.Lock()
+	assert.Equal(t, 0, dirReaderRefs)
+	assert.Nil(t, dirReaderInst)
+	dirReaderMu.Unlock()
+}

--- a/filebeat/input/filestream/dir_reader_test.go
+++ b/filebeat/input/filestream/dir_reader_test.go
@@ -20,6 +20,7 @@ package filestream
 import (
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -27,185 +28,104 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// ---- globBase ---------------------------------------------------------------
-
-func TestGlobBase(t *testing.T) {
-	tests := []struct {
-		pattern string
-		want    string
-	}{
-		// glob patterns
-		{"/var/log/containers/*.log", "/var/log/containers"},
-		{"/var/log/**/*.log", "/var/log"},
-		{"/var/log/*/containers.log", "/var/log"},
-		{"*.log", "."},
-		// literal file paths (no glob chars)
-		{"/var/log/containers/pod.log", "/var/log/containers"},
-		{"/var/log/containers/a/b.log", "/var/log/containers/a"},
-	}
-	for _, tc := range tests {
-		t.Run(tc.pattern, func(t *testing.T) {
-			assert.Equal(t, filepath.FromSlash(tc.want), globBase(filepath.FromSlash(tc.pattern)))
-		})
-	}
-}
-
-// ---- per-path TTL ref counting ----------------------------------------------
-
-func TestPerPathTTLSingleRegistration(t *testing.T) {
-	dr := newCachedDirReader(time.Second)
-	defer dr.stop()
-
-	deregFn := dr.registerPath("/var/log/containers", 200*time.Millisecond)
-	defer deregFn()
-
-	dr.mu.Lock()
-	assert.Equal(t, 200*time.Millisecond, dr.ttlForDir("/var/log/containers"))
-	dr.mu.Unlock()
-}
-
-func TestPerPathTTLMinOfMultipleRegistrations(t *testing.T) {
-	dr := newCachedDirReader(time.Second)
-	defer dr.stop()
-
-	deregA := dr.registerPath("/var/log/containers", time.Second)
-	deregB := dr.registerPath("/var/log/containers", 200*time.Millisecond)
-	defer deregA()
-	defer deregB()
-
-	dr.mu.Lock()
-	assert.Equal(t, 200*time.Millisecond, dr.ttlForDir("/var/log/containers"))
-	dr.mu.Unlock()
-}
-
-func TestPerPathTTLRisesWhenFastWatcherDeregisters(t *testing.T) {
-	dr := newCachedDirReader(time.Second)
-	defer dr.stop()
-
-	deregA := dr.registerPath("/var/log/containers", time.Second)
-	deregB := dr.registerPath("/var/log/containers", 200*time.Millisecond)
-	defer deregA()
-
-	// B (fast) stops first: TTL rises back to A's interval
-	deregB()
-
-	dr.mu.Lock()
-	assert.Equal(t, time.Second, dr.ttlForDir("/var/log/containers"))
-	dr.mu.Unlock()
-}
-
-func TestPerPathTTLRevertsToDefaultWhenAllDeregister(t *testing.T) {
-	const defaultTTL = time.Second
-	dr := newCachedDirReader(defaultTTL)
-	defer dr.stop()
-
-	deregA := dr.registerPath("/var/log/containers", time.Second)
-	deregB := dr.registerPath("/var/log/containers", 200*time.Millisecond)
-
-	deregA()
-	deregB()
-
-	dr.mu.Lock()
-	assert.Equal(t, defaultTTL, dr.ttlForDir("/var/log/containers"))
-	dr.mu.Unlock()
-}
-
-func TestPerPathTTLDeregisterIdempotent(t *testing.T) {
-	dr := newCachedDirReader(time.Second)
-	defer dr.stop()
-
-	deregFn := dr.registerPath("/var/log/containers", 200*time.Millisecond)
-	deregFn()
-	deregFn() // second call must be a no-op
-
-	dr.mu.Lock()
-	assert.Equal(t, time.Second, dr.ttlForDir("/var/log/containers"), "double deregister must not undercount")
-	dr.mu.Unlock()
-}
-
-func TestPerPathTTLIndependentPaths(t *testing.T) {
-	dr := newCachedDirReader(time.Second)
-	defer dr.stop()
-
-	deregA := dr.registerPath("/var/log/containers", 200*time.Millisecond)
-	deregB := dr.registerPath("/var/log/pods", time.Second)
-	defer deregA()
-	defer deregB()
-
-	dr.mu.Lock()
-	assert.Equal(t, 200*time.Millisecond, dr.ttlForDir("/var/log/containers"))
-	assert.Equal(t, time.Second, dr.ttlForDir("/var/log/pods"))
-	dr.mu.Unlock()
-}
-
 // ---- cache hit / miss -------------------------------------------------------
 
-func TestCachedDirReaderCacheHit(t *testing.T) {
+func TestDirCacheCacheHit(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "a.log"), nil, 0o600))
 
-	// defaultTTL long enough that the per-path registration drives the TTL.
-	dr := newCachedDirReader(time.Second)
-	defer dr.stop()
-	deregFn := dr.registerPath(dir, 50*time.Millisecond)
-	defer deregFn()
+	c := newDirCache()
+	maxAge := 100 * time.Millisecond
 
 	// Warm the cache.
-	listing, err := dr.readDir(dir)
+	names, err := c.readDirNames(dir, maxAge, true)
 	require.NoError(t, err)
-	assert.Equal(t, []string{"a.log"}, listing.names)
+	assert.Equal(t, []string{"a.log"}, names)
 
 	// Add a file while the cache is warm.
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "b.log"), nil, 0o600))
 
 	// Second read within TTL: still sees only a.log.
-	listing, err = dr.readDir(dir)
+	names, err = c.readDirNames(dir, maxAge, true)
 	require.NoError(t, err)
-	assert.Equal(t, []string{"a.log"}, listing.names)
+	assert.Equal(t, []string{"a.log"}, names)
 }
 
-func TestCachedDirReaderCacheMissAfterTTL(t *testing.T) {
+func TestDirCacheCacheMissAfterTTL(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "a.log"), nil, 0o600))
 
-	dr := newCachedDirReader(time.Second)
-	defer dr.stop()
-	deregFn := dr.registerPath(dir, 50*time.Millisecond)
-	defer deregFn()
+	c := newDirCache()
+	maxAge := 50 * time.Millisecond
 
 	// Warm the cache then add a file.
-	_, err := dr.readDir(dir)
+	_, err := c.readDirNames(dir, maxAge, true)
 	require.NoError(t, err)
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "b.log"), nil, 0o600))
 
-	// Wait past the 50 ms per-path TTL.
+	// Wait past the TTL.
 	time.Sleep(100 * time.Millisecond)
 
-	listing, err := dr.readDir(dir)
+	names, err := c.readDirNames(dir, maxAge, true)
 	require.NoError(t, err)
-	assert.Equal(t, []string{"a.log", "b.log"}, listing.names)
+	assert.Equal(t, []string{"a.log", "b.log"}, names)
 }
 
-func TestCachedDirReaderDeregisterInvalidatesCache(t *testing.T) {
+func TestDirCacheSharedFalseBypassesCache(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "a.log"), nil, 0o600))
 
-	// Use a very long TTL so the cache would not expire on its own.
-	dr := newCachedDirReader(time.Hour)
-	defer dr.stop()
-	deregFn := dr.registerPath(dir, time.Hour)
+	c := newDirCache()
+	maxAge := time.Hour
 
-	// Warm the cache then add a file.
-	_, err := dr.readDir(dir)
+	// Warm the cache.
+	_, err := c.readDirNames(dir, maxAge, true)
 	require.NoError(t, err)
+
+	// Add a file then read with shared=false — must see new file despite cache.
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "b.log"), nil, 0o600))
-
-	// Deregister: must invalidate the cached entry.
-	deregFn()
-
-	listing, err := dr.readDir(dir)
+	names, err := c.readDirNames(dir, maxAge, false)
 	require.NoError(t, err)
-	assert.Equal(t, []string{"a.log", "b.log"}, listing.names)
+	assert.Equal(t, []string{"a.log", "b.log"}, names)
+}
+
+func TestDirCacheErrorNotCached(t *testing.T) {
+	c := newDirCache()
+	// Read a non-existent directory.
+	_, err := c.readDirNames("/nonexistent/path/that/does/not/exist", time.Hour, true)
+	require.Error(t, err)
+
+	// Entry should be cleared so the next read retries the OS.
+	e := c.entry("/nonexistent/path/that/does/not/exist")
+	assert.Equal(t, int64(0), e.fetched.Load(), "error should clear the entry's fetched timestamp")
+}
+
+// ---- concurrent readers for the same directory ------------------------------
+
+func TestDirCacheConcurrentReaders(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "a.log"), nil, 0o600))
+
+	c := newDirCache()
+	maxAge := time.Second
+
+	const goroutines = 50
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	results := make([][]string, goroutines)
+	errs := make([]error, goroutines)
+	for i := range goroutines {
+		go func(i int) {
+			defer wg.Done()
+			results[i], errs[i] = c.readDirNames(dir, maxAge, true)
+		}(i)
+	}
+	wg.Wait()
+
+	for i := range goroutines {
+		require.NoError(t, errs[i])
+		assert.Equal(t, []string{"a.log"}, results[i])
+	}
 }
 
 // ---- singleton lifecycle ----------------------------------------------------
@@ -219,16 +139,12 @@ func TestAcquireSharedDirReaderSingleton(t *testing.T) {
 	}
 	dirReaderMu.Unlock()
 
-	dr1, release1 := acquireSharedDirReader()
-	dr2, release2 := acquireSharedDirReader()
-
-	rd1, ok1 := dr1.(*cachedDirReader)
-	rd2, ok2 := dr2.(*cachedDirReader)
-	require.True(t, ok1 && ok2, "acquireSharedDirReader must return *cachedDirReader")
+	dc1, release1 := acquireSharedDirReader()
+	dc2, release2 := acquireSharedDirReader()
 
 	dirReaderMu.Lock()
 	assert.Equal(t, 2, dirReaderRefs, "two acquires should give ref count 2")
-	assert.Same(t, rd1, rd2, "both acquires should return the same instance")
+	assert.Same(t, dc1, dc2, "both acquires should return the same instance")
 	dirReaderMu.Unlock()
 
 	release1()
@@ -260,4 +176,35 @@ func TestAcquireSharedDirReaderReleaseIdempotent(t *testing.T) {
 	assert.Equal(t, 0, dirReaderRefs)
 	assert.Nil(t, dirReaderInst)
 	dirReaderMu.Unlock()
+}
+
+func TestAcquireSharedDirReaderResetOnLastRelease(t *testing.T) {
+	dirReaderMu.Lock()
+	if dirReaderInst != nil {
+		dirReaderMu.Unlock()
+		t.Skip("singleton already held by another test")
+	}
+	dirReaderMu.Unlock()
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "a.log"), nil, 0o600))
+
+	dc, release := acquireSharedDirReader()
+
+	// Warm the cache.
+	_, err := dc.readDirNames(dir, time.Hour, true)
+	require.NoError(t, err)
+	require.NotEmpty(t, dc.entries)
+
+	// On last release, reset() clears the entries map — no leak.
+	release()
+
+	dirReaderMu.Lock()
+	assert.Nil(t, dirReaderInst, "singleton should be nil after last release")
+	dirReaderMu.Unlock()
+
+	// The old dc pointer's entries were cleared by reset().
+	dc.mu.Lock()
+	assert.Empty(t, dc.entries, "reset should clear all cached entries")
+	dc.mu.Unlock()
 }

--- a/filebeat/input/filestream/environment_test.go
+++ b/filebeat/input/filestream/environment_test.go
@@ -133,7 +133,7 @@ func (e *inputTestingEnvironment) startInput(ctx context.Context, id string, inp
 func (e *inputTestingEnvironment) waitUntilInputStops() {
 	e.wg.Wait()
 	//nolint:errcheck // It's a test, let it panic if the casting fails
-	e.getManager().(*loginp.InputManager).Close()
+	e.getManager().(*filestreamInputManager).Close()
 }
 
 // mustWriteToFile writes data to file and returns the full path

--- a/filebeat/input/filestream/fscanner.go
+++ b/filebeat/input/filestream/fscanner.go
@@ -635,8 +635,6 @@ func (s *fileScanner) walk(g *walkGroup, process func(filename string, orderInde
 	rec(g.root, 0, patterns)
 }
 
-
-
 // hasGlobMeta reports whether path contains any glob metacharacter, mirroring the
 // unexported path/filepath.hasMeta.
 func hasGlobMeta(path string) bool {

--- a/filebeat/input/filestream/fscanner.go
+++ b/filebeat/input/filestream/fscanner.go
@@ -142,7 +142,7 @@ type fileScanner struct {
 	pathIndex       map[string]int
 	pathsCanOverlap bool
 
-	// dirReader is the directory reader used by walk
+	// dirReader is the directory reader used by walk.
 	dirReader dirReader
 
 	// Everything below exists only to avoid per-file allocations
@@ -159,8 +159,7 @@ func newFileScanner(logger *logp.Logger, paths []string, config fileScannerConfi
 	return newFileScannerWithReader(logger, paths, config, compression, osDirReader{})
 }
 
-// newFileScannerWithReader is like newFileScanner but accepts an explicit
-// dirReader.
+// newFileScannerWithReader is like newFileScanner but accepts an explicit dirReader.
 func newFileScannerWithReader(logger *logp.Logger, paths []string, config fileScannerConfig, compression string, dr dirReader) (*fileScanner, error) {
 	s := fileScanner{
 		paths:       paths,

--- a/filebeat/input/filestream/fscanner.go
+++ b/filebeat/input/filestream/fscanner.go
@@ -142,9 +142,7 @@ type fileScanner struct {
 	pathIndex       map[string]int
 	pathsCanOverlap bool
 
-	// dirReader is the directory reader used by walk. It defaults to
-	// sharedDirReader so that all scanners in the process share a single cached
-	// readdir result per directory per TTL window.
+	// dirReader is the directory reader used by walk
 	dirReader dirReader
 
 	// Everything below exists only to avoid per-file allocations
@@ -162,8 +160,7 @@ func newFileScanner(logger *logp.Logger, paths []string, config fileScannerConfi
 }
 
 // newFileScannerWithReader is like newFileScanner but accepts an explicit
-// dirReader. Pass sharedDirReader in the production path to share cached
-// directory reads across inputs watching the same base directory.
+// dirReader.
 func newFileScannerWithReader(logger *logp.Logger, paths []string, config fileScannerConfig, compression string, dr dirReader) (*fileScanner, error) {
 	s := fileScanner{
 		paths:       paths,

--- a/filebeat/input/filestream/fscanner.go
+++ b/filebeat/input/filestream/fscanner.go
@@ -576,25 +576,20 @@ func (s *fileScanner) walk(g *walkGroup, process func(filename string, orderInde
 			}
 		}
 
-		// With nothing deeper to descend into, entry types are irrelevant: read
-		// only the names, avoiding os.ReadDir's per-entry os.DirEntry allocation.
+		listing, err := s.dirReader.readDir(dir)
+		if err != nil {
+			onReadError(err)
+			return
+		}
+
 		if len(deeper) == 0 {
-			names, err := s.dirReader.readDirNames(dir)
-			if err != nil {
-				onReadError(err)
-				return
-			}
-			for _, name := range names {
+			for _, name := range listing.names {
 				matchLeaf(name)
 			}
 			return
 		}
 
-		entries, err := s.dirReader.readDir(dir)
-		if err != nil {
-			onReadError(err)
-			return
-		}
+		entries := listing.entries
 
 		for _, e := range entries {
 			matchLeaf(e.Name())
@@ -640,22 +635,7 @@ func (s *fileScanner) walk(g *walkGroup, process func(filename string, orderInde
 	rec(g.root, 0, patterns)
 }
 
-// readDirNames returns the sorted entry names of dir, reading names only to avoid
-// os.ReadDir's per-entry os.DirEntry allocation. Used for leaf directories, where
-// entry types are not needed. Sorted to keep traversal order stable.
-func readDirNames(dir string) ([]string, error) {
-	f, err := os.Open(dir)
-	if err != nil {
-		return nil, err
-	}
-	names, err := f.Readdirnames(-1)
-	_ = f.Close()
-	if err != nil {
-		return nil, err
-	}
-	slices.Sort(names)
-	return names, nil
-}
+
 
 // hasGlobMeta reports whether path contains any glob metacharacter, mirroring the
 // unexported path/filepath.hasMeta.

--- a/filebeat/input/filestream/fscanner.go
+++ b/filebeat/input/filestream/fscanner.go
@@ -142,8 +142,10 @@ type fileScanner struct {
 	pathIndex       map[string]int
 	pathsCanOverlap bool
 
-	// dirReader is the directory reader used by walk.
-	dirReader dirReader
+	// dirCache is the shared process-wide directory cache; nil means read directly.
+	// dirCacheMaxAge is min(check_interval, maxDirCacheAge) and is passed per call.
+	dirCache       *dirCache
+	dirCacheMaxAge time.Duration
 
 	// Everything below exists only to avoid per-file allocations
 
@@ -156,18 +158,21 @@ type fileScanner struct {
 }
 
 func newFileScanner(logger *logp.Logger, paths []string, config fileScannerConfig, compression string) (*fileScanner, error) {
-	return newFileScannerWithReader(logger, paths, config, compression, osDirReader{})
+	return newFileScannerWithCache(logger, paths, config, compression, nil, 0)
 }
 
-// newFileScannerWithReader is like newFileScanner but accepts an explicit dirReader.
-func newFileScannerWithReader(logger *logp.Logger, paths []string, config fileScannerConfig, compression string, dr dirReader) (*fileScanner, error) {
+// newFileScannerWithCache is like newFileScanner but accepts a shared dirCache
+// and the per-call maxAge (typically min(check_interval, maxDirCacheAge)).
+// dc=nil means directory reads go directly to the OS without caching.
+func newFileScannerWithCache(logger *logp.Logger, paths []string, config fileScannerConfig, compression string, dc *dirCache, maxAge time.Duration) (*fileScanner, error) {
 	s := fileScanner{
-		paths:       paths,
-		cfg:         config,
-		log:         logger.Named("scanner"),
-		hasher:      sha256.New(),
-		compression: compression,
-		dirReader:   dr,
+		paths:          paths,
+		cfg:            config,
+		log:            logger.Named("scanner"),
+		hasher:         sha256.New(),
+		compression:    compression,
+		dirCache:       dc,
+		dirCacheMaxAge: maxAge,
 	}
 
 	if s.cfg.Fingerprint.Enabled {
@@ -509,6 +514,26 @@ type walkPattern struct {
 	orderIndex int
 }
 
+// readNames returns sorted entry names for dir.
+// When shared is true and s.dirCache is non-nil the result is served from (or
+// stored into) the shared cache; otherwise the OS is read directly.
+func (s *fileScanner) readNames(dir string, shared bool) ([]string, error) {
+	if s.dirCache != nil {
+		return s.dirCache.readDirNames(dir, s.dirCacheMaxAge, shared)
+	}
+	return osDirNames(dir)
+}
+
+// readEntries returns sorted DirEntries for dir.
+// When shared is true and s.dirCache is non-nil the result is served from (or
+// stored into) the shared cache; otherwise the OS is read directly.
+func (s *fileScanner) readEntries(dir string, shared bool) ([]os.DirEntry, error) {
+	if s.dirCache != nil {
+		return s.dirCache.readDirEntries(dir, s.dirCacheMaxAge, shared)
+	}
+	return os.ReadDir(dir)
+}
+
 // walk traverses g.root once and invokes process for every entry matching one of
 // the group's patterns. A directory is only descended into when its name matches
 // the next component of some pattern. Pattern depth bounds the recursion, which
@@ -576,20 +601,28 @@ func (s *fileScanner) walk(g *walkGroup, process func(filename string, orderInde
 			}
 		}
 
-		listing, err := s.dirReader.readDir(dir)
-		if err != nil {
-			onReadError(err)
-			return
-		}
+		// Only cache the walk root (depth 0); sub-directories are read directly.
+		shared := depth == 0
 
 		if len(deeper) == 0 {
-			for _, name := range listing.names {
+			// Leaf directory: only names needed; use the fast Readdirnames path.
+			names, err := s.readNames(dir, shared)
+			if err != nil {
+				onReadError(err)
+				return
+			}
+			for _, name := range names {
 				matchLeaf(name)
 			}
 			return
 		}
 
-		entries := listing.entries
+		// Non-leaf: DirEntry values needed for IsDir / IsSymlink checks.
+		entries, err := s.readEntries(dir, shared)
+		if err != nil {
+			onReadError(err)
+			return
+		}
 
 		for _, e := range entries {
 			matchLeaf(e.Name())

--- a/filebeat/input/filestream/fscanner.go
+++ b/filebeat/input/filestream/fscanner.go
@@ -514,9 +514,6 @@ type walkPattern struct {
 	orderIndex int
 }
 
-// readNames returns sorted entry names for dir.
-// When shared is true and s.dirCache is non-nil the result is served from (or
-// stored into) the shared cache; otherwise the OS is read directly.
 func (s *fileScanner) readNames(dir string, shared bool) ([]string, error) {
 	if s.dirCache != nil {
 		return s.dirCache.readDirNames(dir, s.dirCacheMaxAge, shared)
@@ -524,9 +521,6 @@ func (s *fileScanner) readNames(dir string, shared bool) ([]string, error) {
 	return osDirNames(dir)
 }
 
-// readEntries returns sorted DirEntries for dir.
-// When shared is true and s.dirCache is non-nil the result is served from (or
-// stored into) the shared cache; otherwise the OS is read directly.
 func (s *fileScanner) readEntries(dir string, shared bool) ([]os.DirEntry, error) {
 	if s.dirCache != nil {
 		return s.dirCache.readDirEntries(dir, s.dirCacheMaxAge, shared)
@@ -601,11 +595,10 @@ func (s *fileScanner) walk(g *walkGroup, process func(filename string, orderInde
 			}
 		}
 
-		// Only cache the walk root (depth 0); sub-directories are read directly.
-		shared := depth == 0
+		shared := depth == 0 // only cache the walk root
 
 		if len(deeper) == 0 {
-			// Leaf directory: only names needed; use the fast Readdirnames path.
+			// Leaf: names only; Readdirnames avoids DirEntry allocation.
 			names, err := s.readNames(dir, shared)
 			if err != nil {
 				onReadError(err)

--- a/filebeat/input/filestream/fscanner.go
+++ b/filebeat/input/filestream/fscanner.go
@@ -142,6 +142,11 @@ type fileScanner struct {
 	pathIndex       map[string]int
 	pathsCanOverlap bool
 
+	// dirReader is the directory reader used by walk. It defaults to
+	// sharedDirReader so that all scanners in the process share a single cached
+	// readdir result per directory per TTL window.
+	dirReader dirReader
+
 	// Everything below exists only to avoid per-file allocations
 
 	hasher       hash.Hash
@@ -153,12 +158,20 @@ type fileScanner struct {
 }
 
 func newFileScanner(logger *logp.Logger, paths []string, config fileScannerConfig, compression string) (*fileScanner, error) {
+	return newFileScannerWithReader(logger, paths, config, compression, osDirReader{})
+}
+
+// newFileScannerWithReader is like newFileScanner but accepts an explicit
+// dirReader. Pass sharedDirReader in the production path to share cached
+// directory reads across inputs watching the same base directory.
+func newFileScannerWithReader(logger *logp.Logger, paths []string, config fileScannerConfig, compression string, dr dirReader) (*fileScanner, error) {
 	s := fileScanner{
 		paths:       paths,
 		cfg:         config,
 		log:         logger.Named("scanner"),
 		hasher:      sha256.New(),
 		compression: compression,
+		dirReader:   dr,
 	}
 
 	if s.cfg.Fingerprint.Enabled {
@@ -570,7 +583,7 @@ func (s *fileScanner) walk(g *walkGroup, process func(filename string, orderInde
 		// With nothing deeper to descend into, entry types are irrelevant: read
 		// only the names, avoiding os.ReadDir's per-entry os.DirEntry allocation.
 		if len(deeper) == 0 {
-			names, err := readDirNames(dir)
+			names, err := s.dirReader.readDirNames(dir)
 			if err != nil {
 				onReadError(err)
 				return
@@ -581,7 +594,7 @@ func (s *fileScanner) walk(g *walkGroup, process func(filename string, orderInde
 			return
 		}
 
-		entries, err := os.ReadDir(dir)
+		entries, err := s.dirReader.readDir(dir)
 		if err != nil {
 			onReadError(err)
 			return

--- a/filebeat/input/filestream/fswatch.go
+++ b/filebeat/input/filestream/fswatch.go
@@ -595,6 +595,14 @@ func (w *fileWatcher) Event() loginp.FSEvent {
 // completedFingerprints set, so these pre-watch scans cannot suppress the
 // bridging raw header a still-growing entry needs to migrate its registry key
 // after a restart.
+//
+// The dir-cache is bypassed: Init scans happen before the watch loop writes
+// any files, so caching their results would stale-serve the first watch scan.
 func (w *fileWatcher) GetFiles(opts loginp.FileScanOptions) loginp.ScanResults {
+	if fs, ok := w.scanner.(*fileScanner); ok {
+		dc := fs.dirCache
+		fs.dirCache = nil
+		defer func() { fs.dirCache = dc }()
+	}
 	return w.scanner.GetFiles(opts)
 }

--- a/filebeat/input/filestream/fswatch.go
+++ b/filebeat/input/filestream/fswatch.go
@@ -92,8 +92,7 @@ func newFileWatcher(
 	return newFileWatcherWithDirReader(logger, paths, config, compression, sendNotChanged, fi, srci, osDirReader{})
 }
 
-// newFileWatcherWithDirReader is like newFileWatcher but accepts an explicit
-// dirReader.
+// newFileWatcherWithDirReader is like newFileWatcher but accepts an explicit dirReader.
 func newFileWatcherWithDirReader(
 	logger *logp.Logger,
 	paths []string,

--- a/filebeat/input/filestream/fswatch.go
+++ b/filebeat/input/filestream/fswatch.go
@@ -89,10 +89,11 @@ func newFileWatcher(
 	fi fileIdentifier,
 	srci *loginp.SourceIdentifier,
 ) (*fileWatcher, error) {
-	return newFileWatcherWithDirReader(logger, paths, config, compression, sendNotChanged, fi, srci, osDirReader{})
+	return newFileWatcherWithDirReader(logger, paths, config, compression, sendNotChanged, fi, srci, nil, 0)
 }
 
-// newFileWatcherWithDirReader is like newFileWatcher but accepts an explicit dirReader.
+// newFileWatcherWithDirReader is like newFileWatcher but accepts a shared dirCache
+// and the per-call maxAge for the directory listing cache. dc=nil disables caching.
 func newFileWatcherWithDirReader(
 	logger *logp.Logger,
 	paths []string,
@@ -101,11 +102,12 @@ func newFileWatcherWithDirReader(
 	sendNotChanged bool,
 	fi fileIdentifier,
 	srci *loginp.SourceIdentifier,
-	dr dirReader,
+	dc *dirCache,
+	maxAge time.Duration,
 ) (*fileWatcher, error) {
 
 	config.SendNotChanged = sendNotChanged
-	scanner, err := newFileScannerWithReader(logger, paths, config.Scanner, compression, dr)
+	scanner, err := newFileScannerWithCache(logger, paths, config.Scanner, compression, dc, maxAge)
 	if err != nil {
 		return nil, err
 	}

--- a/filebeat/input/filestream/fswatch.go
+++ b/filebeat/input/filestream/fswatch.go
@@ -89,9 +89,25 @@ func newFileWatcher(
 	fi fileIdentifier,
 	srci *loginp.SourceIdentifier,
 ) (*fileWatcher, error) {
+	return newFileWatcherWithDirReader(logger, paths, config, compression, sendNotChanged, fi, srci, osDirReader{})
+}
+
+// newFileWatcherWithDirReader is like newFileWatcher but accepts an explicit
+// dirReader. Pass sharedDirReader in the production path so all inputs sharing
+// a base directory make only one readdir syscall per TTL window.
+func newFileWatcherWithDirReader(
+	logger *logp.Logger,
+	paths []string,
+	config fileWatcherConfig,
+	compression string,
+	sendNotChanged bool,
+	fi fileIdentifier,
+	srci *loginp.SourceIdentifier,
+	dr dirReader,
+) (*fileWatcher, error) {
 
 	config.SendNotChanged = sendNotChanged
-	scanner, err := newFileScanner(logger, paths, config.Scanner, compression)
+	scanner, err := newFileScannerWithReader(logger, paths, config.Scanner, compression, dr)
 	if err != nil {
 		return nil, err
 	}

--- a/filebeat/input/filestream/fswatch.go
+++ b/filebeat/input/filestream/fswatch.go
@@ -93,8 +93,7 @@ func newFileWatcher(
 }
 
 // newFileWatcherWithDirReader is like newFileWatcher but accepts an explicit
-// dirReader. Pass sharedDirReader in the production path so all inputs sharing
-// a base directory make only one readdir syscall per TTL window.
+// dirReader.
 func newFileWatcherWithDirReader(
 	logger *logp.Logger,
 	paths []string,

--- a/filebeat/input/filestream/fswatch_bench_test.go
+++ b/filebeat/input/filestream/fswatch_bench_test.go
@@ -419,11 +419,8 @@ func BenchmarkGetFilesIdentityCollision(b *testing.B) {
 	}
 }
 
-// BenchmarkGetFilesSharedDir models the Kubernetes pod-log case: N filestream
-// inputs each watching the same base directory with a different leaf glob.
-// With the shared cachedDirReader, N inputs make 1 readdir call total; without
-// it they make N calls. The benchmark uses the cached reader (the production
-// default) so it measures cache-hit throughput for cross-input sharing.
+// BenchmarkGetFilesSharedDir models N filestream inputs each watching the same
+// base directory with a different leaf glob.
 func BenchmarkGetFilesSharedDir(b *testing.B) {
 	for _, inputs := range []int{10, 100, 400} {
 		b.Run(fmt.Sprintf("inputs%d", inputs), func(b *testing.B) {
@@ -449,8 +446,7 @@ func BenchmarkGetFilesSharedDir(b *testing.B) {
 			}
 
 			b.ReportAllocs()
-			b.ResetTimer()
-			for range b.N {
+			for b.Loop() {
 				for _, s := range scanners {
 					s.GetFiles(loginp.FileScanOptions{})
 				}

--- a/filebeat/input/filestream/fswatch_bench_test.go
+++ b/filebeat/input/filestream/fswatch_bench_test.go
@@ -25,7 +25,6 @@ import (
 	"path/filepath"
 	"strconv"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -437,12 +436,12 @@ func BenchmarkGetFilesSharedDir(b *testing.B) {
 				Fingerprint:   fingerprintConfig{Enabled: false},
 			}
 			scanners := make([]*fileScanner, inputs)
-			dr := newCachedDirReader(time.Second)
-			b.Cleanup(dr.stop)
+			dc := newDirCache()
+			b.Cleanup(func() { dc.reset() })
 			for i := range inputs {
 				glob := filepath.Join(base, fmt.Sprintf("pod-%04d-container-*.log", i%total))
 				var err error
-				scanners[i], err = newFileScannerWithReader(logp.NewNopLogger(), []string{glob}, cfg, CompressionNone, dr)
+				scanners[i], err = newFileScannerWithCache(logp.NewNopLogger(), []string{glob}, cfg, CompressionNone, dc, maxDirCacheAge)
 				require.NoError(b, err)
 			}
 

--- a/filebeat/input/filestream/fswatch_bench_test.go
+++ b/filebeat/input/filestream/fswatch_bench_test.go
@@ -438,6 +438,7 @@ func BenchmarkGetFilesSharedDir(b *testing.B) {
 			}
 			scanners := make([]*fileScanner, inputs)
 			dr := newCachedDirReader(time.Second)
+			b.Cleanup(dr.stop)
 			for i := range inputs {
 				glob := filepath.Join(base, fmt.Sprintf("pod-%04d-container-*.log", i%total))
 				var err error
@@ -446,6 +447,7 @@ func BenchmarkGetFilesSharedDir(b *testing.B) {
 			}
 
 			b.ReportAllocs()
+			b.ResetTimer()
 			for b.Loop() {
 				for _, s := range scanners {
 					s.GetFiles(loginp.FileScanOptions{})

--- a/filebeat/input/filestream/fswatch_bench_test.go
+++ b/filebeat/input/filestream/fswatch_bench_test.go
@@ -25,6 +25,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -415,5 +416,45 @@ func BenchmarkGetFilesIdentityCollision(b *testing.B) {
 				}
 			})
 		}
+	}
+}
+
+// BenchmarkGetFilesSharedDir models the Kubernetes pod-log case: N filestream
+// inputs each watching the same base directory with a different leaf glob.
+// With the shared cachedDirReader, N inputs make 1 readdir call total; without
+// it they make N calls. The benchmark uses the cached reader (the production
+// default) so it measures cache-hit throughput for cross-input sharing.
+func BenchmarkGetFilesSharedDir(b *testing.B) {
+	for _, inputs := range []int{10, 100, 400} {
+		b.Run(fmt.Sprintf("inputs%d", inputs), func(b *testing.B) {
+			base := b.TempDir()
+			total := benchEnvInt(b, "BENCH_SHARED_FILES", 500)
+
+			for i := range total {
+				require.NoError(b, os.WriteFile(
+					filepath.Join(base, fmt.Sprintf("pod-%04d-container-abc123.log", i)), []byte("x"), 0o660))
+			}
+
+			cfg := fileScannerConfig{
+				RecursiveGlob: true,
+				Fingerprint:   fingerprintConfig{Enabled: false},
+			}
+			scanners := make([]*fileScanner, inputs)
+			dr := newCachedDirReader(time.Second)
+			for i := range inputs {
+				glob := filepath.Join(base, fmt.Sprintf("pod-%04d-container-*.log", i%total))
+				var err error
+				scanners[i], err = newFileScannerWithReader(logp.NewNopLogger(), []string{glob}, cfg, CompressionNone, dr)
+				require.NoError(b, err)
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for range b.N {
+				for _, s := range scanners {
+					s.GetFiles(loginp.FileScanOptions{})
+				}
+			}
+		})
 	}
 }

--- a/filebeat/input/filestream/fswatch_test.go
+++ b/filebeat/input/filestream/fswatch_test.go
@@ -2070,7 +2070,7 @@ func TestWalk(t *testing.T) {
 		require.NoError(t, os.WriteFile(path, []byte("data"), 0o660))
 	}
 	collect := func(g *walkGroup) []string {
-		s := &fileScanner{log: logger, dirReader: osDirReader{}}
+		s := &fileScanner{log: logger}
 		var got []string
 		s.walk(g, func(f string, _ int) { got = append(got, f) }, func(string) {})
 		return got
@@ -2154,7 +2154,7 @@ func TestWalk(t *testing.T) {
 		mkfile(t, filepath.Join(base, "appx", "f2.log"))
 
 		inMemoryLog, buff := logp.NewInMemoryLocal("", logp.JSONEncoderConfig())
-		sc := &fileScanner{log: inMemoryLog, dirReader: osDirReader{}}
+		sc := &fileScanner{log: inMemoryLog}
 		var got []string
 		// "app[" is a malformed pattern (unclosed character class) that
 		// buildWalkGroups cannot detect upfront: matching it against "" fails on

--- a/filebeat/input/filestream/fswatch_test.go
+++ b/filebeat/input/filestream/fswatch_test.go
@@ -2070,7 +2070,7 @@ func TestWalk(t *testing.T) {
 		require.NoError(t, os.WriteFile(path, []byte("data"), 0o660))
 	}
 	collect := func(g *walkGroup) []string {
-		s := &fileScanner{log: logger}
+		s := &fileScanner{log: logger, dirReader: osDirReader{}}
 		var got []string
 		s.walk(g, func(f string, _ int) { got = append(got, f) }, func(string) {})
 		return got
@@ -2154,7 +2154,7 @@ func TestWalk(t *testing.T) {
 		mkfile(t, filepath.Join(base, "appx", "f2.log"))
 
 		inMemoryLog, buff := logp.NewInMemoryLocal("", logp.JSONEncoderConfig())
-		sc := &fileScanner{log: inMemoryLog}
+		sc := &fileScanner{log: inMemoryLog, dirReader: osDirReader{}}
 		var got []string
 		// "app[" is a malformed pattern (unclosed character class) that
 		// buildWalkGroups cannot detect upfront: matching it against "" fails on

--- a/filebeat/input/filestream/idle_footprint_test.go
+++ b/filebeat/input/filestream/idle_footprint_test.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	loginp "github.com/elastic/beats/v7/filebeat/input/filestream/internal/input-logfile"
 	v2 "github.com/elastic/beats/v7/filebeat/input/v2"
 	"github.com/elastic/beats/v7/libbeat/beat"
 	conf "github.com/elastic/elastic-agent-libs/config"
@@ -82,7 +81,7 @@ paths:
 		// A fresh store each iteration so the fleet is re-read from offset 0.
 		p := Plugin(logger, createTestStore(b))
 		//nolint:errcheck // Close is a cleanup function and never returns an error
-		b.Cleanup(p.Manager.(*loginp.InputManager).Close)
+		b.Cleanup(p.Manager.(*filestreamInputManager).Close)
 		input, err := p.Manager.Create(c)
 		require.NoError(b, err)
 

--- a/filebeat/input/filestream/input.go
+++ b/filebeat/input/filestream/input.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"sync"
 	"time"
 
 	"golang.org/x/text/transform"
@@ -96,40 +95,26 @@ type filestream struct {
 }
 
 // filestreamInputManager wraps loginp.InputManager and releases the shared
-// directory reader when all inputs have stopped (on Close).
+// directory cache when all inputs have stopped (on Close).
 type filestreamInputManager struct {
 	*loginp.InputManager
 	releaseDirReader func()
-
-	deregMu    sync.Mutex
-	deregPaths []func() // per-path TTL deregister funcs, one per registered (dir, interval) pair
-}
-
-func (m *filestreamInputManager) trackDeregister(fn func()) {
-	m.deregMu.Lock()
-	m.deregPaths = append(m.deregPaths, fn)
-	m.deregMu.Unlock()
 }
 
 func (m *filestreamInputManager) Close() {
-	m.deregMu.Lock()
-	for _, fn := range m.deregPaths {
-		fn()
-	}
-	m.deregMu.Unlock()
 	m.InputManager.Close()
 	m.releaseDirReader()
 }
 
 // Plugin creates a new filestream input plugin for creating a stateful input.
 func Plugin(log *logp.Logger, store statestore.States) input.Plugin {
-	dr, releaseDR := acquireSharedDirReader()
+	dc, releaseDR := acquireSharedDirReader()
 	mgr := &filestreamInputManager{releaseDirReader: releaseDR}
 	mgr.InputManager = &loginp.InputManager{
 		Logger:              log,
 		StateStore:          store,
 		Type:                pluginName,
-		Configure:           makeConfigureFunc(dr, mgr),
+		Configure:           makeConfigureFunc(dc),
 		DefaultCleanTimeout: -1,
 	}
 	return input.Plugin{
@@ -142,11 +127,11 @@ func Plugin(log *logp.Logger, store statestore.States) input.Plugin {
 	}
 }
 
-// makeConfigureFunc returns a configure function that closes over dr and mgr so
-// the shared dir reader and per-path TTL tracking flow into every prospector.
-func makeConfigureFunc(dr dirReader, mgr *filestreamInputManager) func(*conf.C, *logp.Logger, *loginp.SourceIdentifier) (loginp.Prospector, loginp.Harvester, error) {
+// makeConfigureFunc returns a configure function that closes over dc so the
+// shared dir cache flows into every prospector created by this plugin instance.
+func makeConfigureFunc(dc *dirCache) func(*conf.C, *logp.Logger, *loginp.SourceIdentifier) (loginp.Prospector, loginp.Harvester, error) {
 	return func(cfg *conf.C, log *logp.Logger, src *loginp.SourceIdentifier) (loginp.Prospector, loginp.Harvester, error) {
-		return configure(cfg, log, src, dr, mgr.trackDeregister)
+		return configure(cfg, log, src, dc)
 	}
 }
 
@@ -154,8 +139,7 @@ func configure(
 	cfg *conf.C,
 	log *logp.Logger,
 	src *loginp.SourceIdentifier,
-	dr dirReader,
-	trackFn func(func())) (loginp.Prospector, loginp.Harvester, error) {
+	dc *dirCache) (loginp.Prospector, loginp.Harvester, error) {
 
 	c := defaultConfig()
 	if err := cfg.Unpack(&c); err != nil {
@@ -164,16 +148,6 @@ func configure(
 
 	if err := normalizeConfig(cfg, &c, log); err != nil {
 		return nil, nil, err
-	}
-
-	// Register each watched base directory with the shared cache so the
-	// per-path TTL reflects this input's check_interval. The deregister func
-	// is called on receiver shutdown so the TTL rises back when no fast
-	// watchers remain for a given directory.
-	if rd, ok := dr.(*cachedDirReader); ok && trackFn != nil {
-		for _, pattern := range c.Paths {
-			trackFn(rd.registerPath(globBase(pattern), c.FileWatcher.Interval))
-		}
 	}
 
 	// zero must also disable clean_inactive, see:
@@ -189,7 +163,7 @@ func configure(
 
 	c.TakeOver.LogWarnings(log)
 
-	prospector, err := newProspector(c, log, src, dr)
+	prospector, err := newProspector(c, log, src, dc)
 	if err != nil {
 		return nil, nil, fmt.Errorf("cannot create prospector: %w", err)
 	}

--- a/filebeat/input/filestream/input.go
+++ b/filebeat/input/filestream/input.go
@@ -117,10 +117,10 @@ func Plugin(log *logp.Logger, store statestore.States) input.Plugin {
 		Doc:        "The filestream input collects logs from the local filestream service",
 		Manager: &filestreamInputManager{
 			InputManager: &loginp.InputManager{
-				Logger:      log,
-				StateStore:  store,
-				Type:        pluginName,
-				Configure:   makeConfigureFunc(dr),
+				Logger:              log,
+				StateStore:          store,
+				Type:                pluginName,
+				Configure:           makeConfigureFunc(dr),
 				DefaultCleanTimeout: -1,
 			},
 			releaseDirReader: releaseDR,

--- a/filebeat/input/filestream/input.go
+++ b/filebeat/input/filestream/input.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sync"
 	"time"
 
 	"golang.org/x/text/transform"
@@ -99,9 +100,23 @@ type filestream struct {
 type filestreamInputManager struct {
 	*loginp.InputManager
 	releaseDirReader func()
+
+	deregMu    sync.Mutex
+	deregPaths []func() // per-path TTL deregister funcs, one per registered (dir, interval) pair
+}
+
+func (m *filestreamInputManager) trackDeregister(fn func()) {
+	m.deregMu.Lock()
+	m.deregPaths = append(m.deregPaths, fn)
+	m.deregMu.Unlock()
 }
 
 func (m *filestreamInputManager) Close() {
+	m.deregMu.Lock()
+	for _, fn := range m.deregPaths {
+		fn()
+	}
+	m.deregMu.Unlock()
 	m.InputManager.Close()
 	m.releaseDirReader()
 }
@@ -109,30 +124,29 @@ func (m *filestreamInputManager) Close() {
 // Plugin creates a new filestream input plugin for creating a stateful input.
 func Plugin(log *logp.Logger, store statestore.States) input.Plugin {
 	dr, releaseDR := acquireSharedDirReader()
+	mgr := &filestreamInputManager{releaseDirReader: releaseDR}
+	mgr.InputManager = &loginp.InputManager{
+		Logger:              log,
+		StateStore:          store,
+		Type:                pluginName,
+		Configure:           makeConfigureFunc(dr, mgr),
+		DefaultCleanTimeout: -1,
+	}
 	return input.Plugin{
 		Name:       pluginName,
 		Stability:  feature.Stable,
 		Deprecated: false,
 		Info:       "filestream input",
 		Doc:        "The filestream input collects logs from the local filestream service",
-		Manager: &filestreamInputManager{
-			InputManager: &loginp.InputManager{
-				Logger:              log,
-				StateStore:          store,
-				Type:                pluginName,
-				Configure:           makeConfigureFunc(dr),
-				DefaultCleanTimeout: -1,
-			},
-			releaseDirReader: releaseDR,
-		},
+		Manager:    mgr,
 	}
 }
 
-// makeConfigureFunc returns a configure function that closes over dr so the
-// shared dir reader flows into every prospector created by this plugin instance.
-func makeConfigureFunc(dr dirReader) func(*conf.C, *logp.Logger, *loginp.SourceIdentifier) (loginp.Prospector, loginp.Harvester, error) {
+// makeConfigureFunc returns a configure function that closes over dr and mgr so
+// the shared dir reader and per-path TTL tracking flow into every prospector.
+func makeConfigureFunc(dr dirReader, mgr *filestreamInputManager) func(*conf.C, *logp.Logger, *loginp.SourceIdentifier) (loginp.Prospector, loginp.Harvester, error) {
 	return func(cfg *conf.C, log *logp.Logger, src *loginp.SourceIdentifier) (loginp.Prospector, loginp.Harvester, error) {
-		return configure(cfg, log, src, dr)
+		return configure(cfg, log, src, dr, mgr.trackDeregister)
 	}
 }
 
@@ -140,7 +154,8 @@ func configure(
 	cfg *conf.C,
 	log *logp.Logger,
 	src *loginp.SourceIdentifier,
-	dr dirReader) (loginp.Prospector, loginp.Harvester, error) {
+	dr dirReader,
+	trackFn func(func())) (loginp.Prospector, loginp.Harvester, error) {
 
 	c := defaultConfig()
 	if err := cfg.Unpack(&c); err != nil {
@@ -151,11 +166,14 @@ func configure(
 		return nil, nil, err
 	}
 
-	// Lower the cache TTL if this input's check_interval is shorter, so the
-	// cache never serves listings stale beyond the fastest configured interval.
-	type ttlLowerer interface{ lowerTTL(time.Duration) }
-	if tl, ok := dr.(ttlLowerer); ok {
-		tl.lowerTTL(c.FileWatcher.Interval)
+	// Register each watched base directory with the shared cache so the
+	// per-path TTL reflects this input's check_interval. The deregister func
+	// is called on receiver shutdown so the TTL rises back when no fast
+	// watchers remain for a given directory.
+	if rd, ok := dr.(*cachedDirReader); ok && trackFn != nil {
+		for _, pattern := range c.Paths {
+			trackFn(rd.registerPath(globBase(pattern), c.FileWatcher.Interval))
+		}
 	}
 
 	// zero must also disable clean_inactive, see:

--- a/filebeat/input/filestream/input.go
+++ b/filebeat/input/filestream/input.go
@@ -151,6 +151,13 @@ func configure(
 		return nil, nil, err
 	}
 
+	// Lower the cache TTL if this input's check_interval is shorter, so the
+	// cache never serves listings stale beyond the fastest configured interval.
+	type ttlLowerer interface{ lowerTTL(time.Duration) }
+	if tl, ok := dr.(ttlLowerer); ok {
+		tl.lowerTTL(c.FileWatcher.Interval)
+	}
+
 	// zero must also disable clean_inactive, see:
 	// https://github.com/elastic/beats/issues/45601
 	// for more details. At the same time we need to allow

--- a/filebeat/input/filestream/input.go
+++ b/filebeat/input/filestream/input.go
@@ -94,28 +94,53 @@ type filestream struct {
 	statFn   func(string) (os.FileInfo, error)
 }
 
+// filestreamInputManager wraps loginp.InputManager and releases the shared
+// directory reader when all inputs have stopped (on Close).
+type filestreamInputManager struct {
+	*loginp.InputManager
+	releaseDirReader func()
+}
+
+func (m *filestreamInputManager) Close() {
+	m.InputManager.Close()
+	m.releaseDirReader()
+}
+
 // Plugin creates a new filestream input plugin for creating a stateful input.
 func Plugin(log *logp.Logger, store statestore.States) input.Plugin {
+	dr, releaseDR := acquireSharedDirReader()
 	return input.Plugin{
 		Name:       pluginName,
 		Stability:  feature.Stable,
 		Deprecated: false,
 		Info:       "filestream input",
 		Doc:        "The filestream input collects logs from the local filestream service",
-		Manager: &loginp.InputManager{
-			Logger:              log,
-			StateStore:          store,
-			Type:                pluginName,
-			Configure:           configure,
-			DefaultCleanTimeout: -1,
+		Manager: &filestreamInputManager{
+			InputManager: &loginp.InputManager{
+				Logger:      log,
+				StateStore:  store,
+				Type:        pluginName,
+				Configure:   makeConfigureFunc(dr),
+				DefaultCleanTimeout: -1,
+			},
+			releaseDirReader: releaseDR,
 		},
+	}
+}
+
+// makeConfigureFunc returns a configure function that closes over dr so the
+// shared dir reader flows into every prospector created by this plugin instance.
+func makeConfigureFunc(dr dirReader) func(*conf.C, *logp.Logger, *loginp.SourceIdentifier) (loginp.Prospector, loginp.Harvester, error) {
+	return func(cfg *conf.C, log *logp.Logger, src *loginp.SourceIdentifier) (loginp.Prospector, loginp.Harvester, error) {
+		return configure(cfg, log, src, dr)
 	}
 }
 
 func configure(
 	cfg *conf.C,
 	log *logp.Logger,
-	src *loginp.SourceIdentifier) (loginp.Prospector, loginp.Harvester, error) {
+	src *loginp.SourceIdentifier,
+	dr dirReader) (loginp.Prospector, loginp.Harvester, error) {
 
 	c := defaultConfig()
 	if err := cfg.Unpack(&c); err != nil {
@@ -139,7 +164,7 @@ func configure(
 
 	c.TakeOver.LogWarnings(log)
 
-	prospector, err := newProspector(c, log, src)
+	prospector, err := newProspector(c, log, src, dr)
 	if err != nil {
 		return nil, nil, fmt.Errorf("cannot create prospector: %w", err)
 	}

--- a/filebeat/input/filestream/input_test.go
+++ b/filebeat/input/filestream/input_test.go
@@ -449,7 +449,7 @@ paths:
   - /var/log/foo
 %s
 `, extra))
-		_, harvester, err := configure(cfg, logger, srcIdentifier)
+		_, harvester, err := configure(cfg, logger, srcIdentifier, osDirReader{})
 		require.NoError(t, err)
 		fs, ok := harvester.(*filestream)
 		require.True(t, ok)
@@ -668,7 +668,7 @@ func createFilestreamTestRunner(tb testing.TB, logger *logp.Logger, testID strin
 
 	p := Plugin(logger, createTestStore(tb))
 	//nolint:errcheck // It's a test, let it panic if the casting fails
-	tb.Cleanup(p.Manager.(*loginp.InputManager).Close)
+	tb.Cleanup(p.Manager.(*filestreamInputManager).Close)
 	input, err := p.Manager.Create(c)
 	require.NoError(tb, err)
 

--- a/filebeat/input/filestream/input_test.go
+++ b/filebeat/input/filestream/input_test.go
@@ -449,7 +449,7 @@ paths:
   - /var/log/foo
 %s
 `, extra))
-		_, harvester, err := configure(cfg, logger, srcIdentifier, osDirReader{})
+		_, harvester, err := configure(cfg, logger, srcIdentifier, osDirReader{}, nil)
 		require.NoError(t, err)
 		fs, ok := harvester.(*filestream)
 		require.True(t, ok)

--- a/filebeat/input/filestream/input_test.go
+++ b/filebeat/input/filestream/input_test.go
@@ -449,7 +449,7 @@ paths:
   - /var/log/foo
 %s
 `, extra))
-		_, harvester, err := configure(cfg, logger, srcIdentifier, osDirReader{}, nil)
+		_, harvester, err := configure(cfg, logger, srcIdentifier, nil)
 		require.NoError(t, err)
 		fs, ok := harvester.(*filestream)
 		require.True(t, ok)

--- a/filebeat/input/filestream/prospector_creator.go
+++ b/filebeat/input/filestream/prospector_creator.go
@@ -93,7 +93,7 @@ func newProspector(
 	config config,
 	log *logp.Logger,
 	srci *loginp.SourceIdentifier,
-	dr dirReader) (loginp.Prospector, error) {
+	dc *dirCache) (loginp.Prospector, error) {
 
 	logger := log.Named("filestream").With("id", config.ID)
 
@@ -114,7 +114,8 @@ func newProspector(
 		config.Delete.Enabled,
 		identifier,
 		srci,
-		dr,
+		dc,
+		min(config.FileWatcher.Interval, maxDirCacheAge),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("error while creating filewatcher %w", err)

--- a/filebeat/input/filestream/prospector_creator.go
+++ b/filebeat/input/filestream/prospector_creator.go
@@ -92,7 +92,8 @@ func logFileIdentifiers(logger *logp.Logger) map[string]file.StateIdentifier {
 func newProspector(
 	config config,
 	log *logp.Logger,
-	srci *loginp.SourceIdentifier) (loginp.Prospector, error) {
+	srci *loginp.SourceIdentifier,
+	dr dirReader) (loginp.Prospector, error) {
 
 	logger := log.Named("filestream").With("id", config.ID)
 
@@ -105,7 +106,7 @@ func newProspector(
 	}
 	logger.Debugf("file identity is set to %s", identifier.Name())
 
-	filewatcher, err := newFileWatcher(
+	filewatcher, err := newFileWatcherWithDirReader(
 		logger,
 		config.Paths,
 		config.FileWatcher,
@@ -113,6 +114,7 @@ func newProspector(
 		config.Delete.Enabled,
 		identifier,
 		srci,
+		dr,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("error while creating filewatcher %w", err)

--- a/filebeat/input/filestream/prospector_creator_test.go
+++ b/filebeat/input/filestream/prospector_creator_test.go
@@ -47,7 +47,7 @@ func TestCreateProspector(t *testing.T) {
 			t.Run(name, func(t *testing.T) {
 				c := defaultConfig()
 				c.IgnoreInactive = ignoreInactiveSettings[test.ignore_inactive_since]
-				p, err := newProspector(c, logptest.NewTestingLogger(t, ""), mustSourceIdentifier("foo-id"), osDirReader{})
+				p, err := newProspector(c, logptest.NewTestingLogger(t, ""), mustSourceIdentifier("foo-id"), nil)
 				require.NoError(t, err)
 				fileProspector := p.(*fileProspector) //nolint:errcheck // we know the type
 				assert.Equal(t, fileProspector.ignoreInactiveSince, ignoreInactiveSettings[test.ignore_inactive_since])
@@ -109,7 +109,7 @@ prospector.scanner.fingerprint.enabled: false
 				require.NoError(t, err)
 				require.NoError(t, normalizeConfig(c, &cfg, logger))
 
-				_, err = newProspector(cfg, logger, mustSourceIdentifier("foo-id"), osDirReader{})
+				_, err = newProspector(cfg, logger, mustSourceIdentifier("foo-id"), nil)
 				require.NoError(t, err)
 			})
 		}
@@ -150,7 +150,7 @@ rotation.external.strategy.copytruncate:
 				require.NoError(t, c.Unpack(&cfg), "test config must unpack into filestream config")
 				require.NoError(t, normalizeConfig(c, &cfg, logger), "normalizeConfig must succeed")
 
-				p, err := newProspector(cfg, logger, mustSourceIdentifier("foo-id"), osDirReader{})
+				p, err := newProspector(cfg, logger, mustSourceIdentifier("foo-id"), nil)
 				require.NoError(t, err, "creating the prospector must succeed")
 
 				if tc.wantCopyTruncate {

--- a/filebeat/input/filestream/prospector_creator_test.go
+++ b/filebeat/input/filestream/prospector_creator_test.go
@@ -47,7 +47,7 @@ func TestCreateProspector(t *testing.T) {
 			t.Run(name, func(t *testing.T) {
 				c := defaultConfig()
 				c.IgnoreInactive = ignoreInactiveSettings[test.ignore_inactive_since]
-				p, err := newProspector(c, logptest.NewTestingLogger(t, ""), mustSourceIdentifier("foo-id"))
+				p, err := newProspector(c, logptest.NewTestingLogger(t, ""), mustSourceIdentifier("foo-id"), osDirReader{})
 				require.NoError(t, err)
 				fileProspector := p.(*fileProspector) //nolint:errcheck // we know the type
 				assert.Equal(t, fileProspector.ignoreInactiveSince, ignoreInactiveSettings[test.ignore_inactive_since])
@@ -109,7 +109,7 @@ prospector.scanner.fingerprint.enabled: false
 				require.NoError(t, err)
 				require.NoError(t, normalizeConfig(c, &cfg, logger))
 
-				_, err = newProspector(cfg, logger, mustSourceIdentifier("foo-id"))
+				_, err = newProspector(cfg, logger, mustSourceIdentifier("foo-id"), osDirReader{})
 				require.NoError(t, err)
 			})
 		}
@@ -150,7 +150,7 @@ rotation.external.strategy.copytruncate:
 				require.NoError(t, c.Unpack(&cfg), "test config must unpack into filestream config")
 				require.NoError(t, normalizeConfig(c, &cfg, logger), "normalizeConfig must succeed")
 
-				p, err := newProspector(cfg, logger, mustSourceIdentifier("foo-id"))
+				p, err := newProspector(cfg, logger, mustSourceIdentifier("foo-id"), osDirReader{})
 				require.NoError(t, err, "creating the prospector must succeed")
 
 				if tc.wantCopyTruncate {


### PR DESCRIPTION
<!-- Enhancement -->

## Proposed commit message

On nodes running the Kubernetes integration, 1,600 filestream inputs each watch `/var/log/containers` independently. Every `check_interval` each input called `readdir`, generating 1,600 syscalls and ~800,000 `DirEntry` allocations per tick instead of 1.

Add a process-wide `cachedDirReader` (1 s TTL, background sweep goroutine) shared across all filestream `Plugin` instances via a ref-counted acquire/release singleton — the same pattern as `AcquireSystemBridge` in `x-pack/otel/telemetry`. N inputs watching the same directory make one `readdir` call per TTL window. The default code path (`newFileScanner` / `newFileWatcher`) keeps using `osDirReader` so existing tests are unaffected.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Related issues

- Closes #53130

## How to test this PR locally

```
go test ./filebeat/input/filestream/... -count=1 -timeout 120s
go test ./filebeat/input/filestream/... -bench=BenchmarkGetFilesSharedDir -benchtime=5s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)