### PR TITLE
autoops_es/node_stats: derive os.cgroup.cpu.usage_percent from CFS quota counters

### DIFF
--- a/changelog/fragments/1757001600-autoops-es-cgroup-cpu-usage-percent.yaml
+++ b/changelog/fragments/1757001600-autoops-es-cgroup-cpu-usage-percent.yaml
@@ -1,0 +1,4 @@
+kind: enhancement
+summary: Add os.cgroup.cpu.usage_percent to autoops_es node_stats metricset
+component: metricbeat
+issue: https://github.com/elastic/beats/issues/52616

--- a/x-pack/metricbeat/module/autoops_es/node_stats/cache.go
+++ b/x-pack/metricbeat/module/autoops_es/node_stats/cache.go
@@ -109,7 +109,11 @@ func enrichCgroupCpuUsagePercent(node *mapstr.M, prevNode *mapstr.M) {
 	if usageDelta < 0 || periodsDelta <= 0 {
 		return
 	}
-	percent := float64(usageDelta) / (float64(periodsDelta) * float64(quotaMicros) * 1000) * 100
+	// Truncate to a whole-number percentage: process.cpu.percent is already an integer
+	// (the ES node stats API returns 0–100 as int), and the account index mapping for
+	// this field is `long`. Emitting an integer keeps the stored value identical to
+	// what the agent sends rather than relying on ES coercion to truncate a float.
+	percent := int64(float64(usageDelta) / (float64(periodsDelta) * float64(quotaMicros) * 1000) * 100)
 
 	// `setValue` writes a literal flat key; use `Put` so the value lands inside the
 	// nested `os.cgroup.cpu` object that the schema already produces.

--- a/x-pack/metricbeat/module/autoops_es/node_stats/cache.go
+++ b/x-pack/metricbeat/module/autoops_es/node_stats/cache.go
@@ -75,9 +75,51 @@ func createRate(rateKey string, key string) utils.EnrichedType[mapstr.M] {
 	}
 }
 
+const (
+	cgroupUsageNanosKey  = "os.cgroup.cpuacct.usage_nanos"
+	cgroupPeriodsKey     = "os.cgroup.cpu.stat.number_of_elapsed_periods"
+	cgroupQuotaMicrosKey = "os.cgroup.cpu.cfs_quota_micros"
+	cgroupCpuPercentKey  = "os.cgroup.cpu.usage_percent"
+)
+
+// Derive the percentage of the configured CFS quota that the process cgroup consumed
+// between two consecutive samples:
+//
+//	(Δusage_nanos / (Δnumber_of_elapsed_periods × cfs_quota_micros × 1000)) × 100
+//
+// This is emitted *alongside* `process.cpu.percent`, never in place of it: the latter
+// reports host-level CPU usage, which is misleading when a CFS quota caps the process,
+// while this field is relative to that quota. Keeping both means consumers can compare
+// the two views instead of guessing which one a sample represents.
+//
+// The value is deliberately not clamped to 100: a cgroup can burst above its quota
+// within a sampling window, and that is meaningful signal rather than an error.
+func enrichCgroupCpuUsagePercent(node *mapstr.M, prevNode *mapstr.M) {
+	if !hasKey(node, cgroupUsageNanosKey) || !hasKey(prevNode, cgroupUsageNanosKey) ||
+		!hasKey(node, cgroupPeriodsKey) || !hasKey(prevNode, cgroupPeriodsKey) ||
+		!hasKey(node, cgroupQuotaMicrosKey) {
+		return
+	}
+	quotaMicros := getValue(node, cgroupQuotaMicrosKey)
+	if quotaMicros <= 0 {
+		return
+	}
+	usageDelta := getValue(node, cgroupUsageNanosKey) - getValue(prevNode, cgroupUsageNanosKey)
+	periodsDelta := getValue(node, cgroupPeriodsKey) - getValue(prevNode, cgroupPeriodsKey)
+	if usageDelta < 0 || periodsDelta <= 0 {
+		return
+	}
+	percent := float64(usageDelta) / (float64(periodsDelta) * float64(quotaMicros) * 1000) * 100
+
+	// `setValue` writes a literal flat key; use `Put` so the value lands inside the
+	// nested `os.cgroup.cpu` object that the schema already produces.
+	_, _ = node.Put(cgroupCpuPercentKey, percent)
+}
+
 func enrichNodeStats(id string, nodeStats *mapstr.M, timestampDiff int64) {
 	if prevNodeStats, exists := cache.PreviousCache[id]; exists {
 		utils.EnrichObject(nodeStats, &prevNodeStats, cache)
+		enrichCgroupCpuUsagePercent(nodeStats, &prevNodeStats)
 
 		setValue(nodeStats, "timestampDiff", timestampDiff)
 	}

--- a/x-pack/metricbeat/module/autoops_es/node_stats/cache_test.go
+++ b/x-pack/metricbeat/module/autoops_es/node_stats/cache_test.go
@@ -7,7 +7,6 @@
 package node_stats
 
 import (
-	"math"
 	"testing"
 	"testing/quick"
 	"time"
@@ -346,27 +345,27 @@ func TestEnrichNodeStatsCgroupCpuUsagePercent(t *testing.T) {
 		prev          mapstr.M // if nil, cache is cleared (first sample)
 		curr          mapstr.M
 		expectPresent bool
-		expected      float64
+		expected      int64
 	}{
 		"happy path 50%": {
 			// Δusage=500_000_000 ns, Δperiods=10, quota=100_000 µs → 50%
 			prev:          makeCgroupNodeStats(1_000_000_000, 90, 100_000),
 			curr:          makeCgroupNodeStats(1_500_000_000, 100, 100_000),
 			expectPresent: true,
-			expected:      50.0,
+			expected:      50,
 		},
 		"burst above quota emits >100%": {
 			// Δusage=3_000_000_000 ns, Δperiods=10, quota=100_000 µs → 300%
 			prev:          makeCgroupNodeStats(1_000_000_000, 90, 100_000),
 			curr:          makeCgroupNodeStats(4_000_000_000, 100, 100_000),
 			expectPresent: true,
-			expected:      300.0,
+			expected:      300,
 		},
 		"zero usage delta emits 0%": {
 			prev:          makeCgroupNodeStats(1_000_000_000, 90, 100_000),
 			curr:          makeCgroupNodeStats(1_000_000_000, 100, 100_000),
 			expectPresent: true,
-			expected:      0.0,
+			expected:      0,
 		},
 		"quota changed uses current quota": {
 			// Even if prev had a different quota, current sample's quota is authoritative.
@@ -374,7 +373,7 @@ func TestEnrichNodeStatsCgroupCpuUsagePercent(t *testing.T) {
 			prev:          makeCgroupNodeStats(1_000_000_000, 90, 100_000),
 			curr:          makeCgroupNodeStats(1_500_000_000, 100, 200_000),
 			expectPresent: true,
-			expected:      25.0,
+			expected:      25,
 		},
 		"unlimited quota (-1)": {
 			prev:          makeCgroupNodeStats(1_000_000_000, 90, -1),
@@ -447,7 +446,7 @@ func TestEnrichNodeStatsCgroupCpuUsagePercent(t *testing.T) {
 			if tt.expectPresent {
 				v, err := curr.GetValue(cgroupCpuPercentKey)
 				require.NoError(t, err, "expected %s to be set", cgroupCpuPercentKey)
-				require.InDelta(t, tt.expected, v.(float64), 0.001)
+				require.Equal(t, tt.expected, v.(int64))
 			} else {
 				ok, _ := curr.HasKey(cgroupCpuPercentKey)
 				require.False(t, ok, "expected %s to be absent", cgroupCpuPercentKey)
@@ -475,11 +474,11 @@ func TestEnrichNodeStatsCgroupCpuUsagePercentQuickCheck(t *testing.T) {
 		if err != nil {
 			return false
 		}
-		v, ok := raw.(float64)
+		v, ok := raw.(int64)
 		if !ok {
 			return false
 		}
-		return v >= 0 && !math.IsNaN(v) && !math.IsInf(v, 0)
+		return v >= 0
 	}
 	require.NoError(t, quick.Check(property, nil))
 }

--- a/x-pack/metricbeat/module/autoops_es/node_stats/cache_test.go
+++ b/x-pack/metricbeat/module/autoops_es/node_stats/cache_test.go
@@ -7,7 +7,9 @@
 package node_stats
 
 import (
+	"math"
 	"testing"
+	"testing/quick"
 	"time"
 
 	"github.com/stretchr/testify/require"
@@ -52,6 +54,21 @@ func getNodeStatsForNode(nodeIndex int64) mapstr.M {
 			"bulk": mapstr.M{
 				"total_size_in_bytes": 300 + nodeIndex,
 				"total_operations":    400 + nodeIndex,
+			},
+		},
+		// Cgroup counters at zero so that fixture-driven cache tests produce a positive
+		// delta (curr_fixture_value − 0). The enricher only reads prev usage_nanos and
+		// prev number_of_elapsed_periods; quota is always taken from the current sample.
+		"os": mapstr.M{
+			"cgroup": mapstr.M{
+				"cpuacct": mapstr.M{
+					"usage_nanos": int64(0),
+				},
+				"cpu": mapstr.M{
+					"stat": mapstr.M{
+						"number_of_elapsed_periods": int64(0),
+					},
+				},
 			},
 		},
 	}
@@ -297,6 +314,174 @@ func TestEnrichNodeStatsWithCachedValuesWithHoles(t *testing.T) {
 		require.EqualValues(t, 1, nodeStats["merge_latency_in_millis"])
 		require.EqualValues(t, 2, nodeStats["search_latency_in_millis"])
 	}
+}
+
+func makeCgroupNodeStats(usageNanos, periods, quotaMicros int64) mapstr.M {
+	return mapstr.M{
+		"os": mapstr.M{
+			"cgroup": mapstr.M{
+				"cpuacct": mapstr.M{
+					"usage_nanos": usageNanos,
+				},
+				"cpu": mapstr.M{
+					"cfs_quota_micros": quotaMicros,
+					"stat": mapstr.M{
+						"number_of_elapsed_periods": periods,
+					},
+				},
+			},
+		},
+	}
+}
+
+// makeCgroupWithout returns a cgroup mapstr.M with the given key path deleted.
+func makeCgroupWithout(usageNanos, periods, quotaMicros int64, deletePath string) mapstr.M {
+	m := makeCgroupNodeStats(usageNanos, periods, quotaMicros)
+	_ = m.Delete(deletePath)
+	return m
+}
+
+func TestEnrichNodeStatsCgroupCpuUsagePercent(t *testing.T) {
+	tests := map[string]struct {
+		prev          mapstr.M // if nil, cache is cleared (first sample)
+		curr          mapstr.M
+		expectPresent bool
+		expected      float64
+	}{
+		"happy path 50%": {
+			// Δusage=500_000_000 ns, Δperiods=10, quota=100_000 µs → 50%
+			prev:          makeCgroupNodeStats(1_000_000_000, 90, 100_000),
+			curr:          makeCgroupNodeStats(1_500_000_000, 100, 100_000),
+			expectPresent: true,
+			expected:      50.0,
+		},
+		"burst above quota emits >100%": {
+			// Δusage=3_000_000_000 ns, Δperiods=10, quota=100_000 µs → 300%
+			prev:          makeCgroupNodeStats(1_000_000_000, 90, 100_000),
+			curr:          makeCgroupNodeStats(4_000_000_000, 100, 100_000),
+			expectPresent: true,
+			expected:      300.0,
+		},
+		"zero usage delta emits 0%": {
+			prev:          makeCgroupNodeStats(1_000_000_000, 90, 100_000),
+			curr:          makeCgroupNodeStats(1_000_000_000, 100, 100_000),
+			expectPresent: true,
+			expected:      0.0,
+		},
+		"quota changed uses current quota": {
+			// Even if prev had a different quota, current sample's quota is authoritative.
+			// Δusage=500_000_000, Δperiods=10, current quota=200_000 → 25%
+			prev:          makeCgroupNodeStats(1_000_000_000, 90, 100_000),
+			curr:          makeCgroupNodeStats(1_500_000_000, 100, 200_000),
+			expectPresent: true,
+			expected:      25.0,
+		},
+		"unlimited quota (-1)": {
+			prev:          makeCgroupNodeStats(1_000_000_000, 90, -1),
+			curr:          makeCgroupNodeStats(1_500_000_000, 100, -1),
+			expectPresent: false,
+		},
+		"zero quota": {
+			prev:          makeCgroupNodeStats(1_000_000_000, 90, 0),
+			curr:          makeCgroupNodeStats(1_500_000_000, 100, 0),
+			expectPresent: false,
+		},
+		"first sample no previous": {
+			prev:          nil,
+			curr:          makeCgroupNodeStats(1_500_000_000, 100, 100_000),
+			expectPresent: false,
+		},
+		"zero periods delta": {
+			prev:          makeCgroupNodeStats(1_000_000_000, 100, 100_000),
+			curr:          makeCgroupNodeStats(1_500_000_000, 100, 100_000),
+			expectPresent: false,
+		},
+		"usage counter reset (negative delta)": {
+			prev:          makeCgroupNodeStats(2_000_000_000, 90, 100_000),
+			curr:          makeCgroupNodeStats(500_000_000, 100, 100_000),
+			expectPresent: false,
+		},
+		"periods counter reset (negative delta)": {
+			prev:          makeCgroupNodeStats(1_000_000_000, 100, 100_000),
+			curr:          makeCgroupNodeStats(1_500_000_000, 50, 100_000),
+			expectPresent: false,
+		},
+		"missing usage_nanos on previous": {
+			prev:          makeCgroupWithout(1_000_000_000, 90, 100_000, "os.cgroup.cpuacct.usage_nanos"),
+			curr:          makeCgroupNodeStats(1_500_000_000, 100, 100_000),
+			expectPresent: false,
+		},
+		"missing usage_nanos on current": {
+			prev:          makeCgroupNodeStats(1_000_000_000, 90, 100_000),
+			curr:          makeCgroupWithout(1_500_000_000, 100, 100_000, "os.cgroup.cpuacct.usage_nanos"),
+			expectPresent: false,
+		},
+		"missing periods on previous": {
+			prev:          makeCgroupWithout(1_000_000_000, 90, 100_000, "os.cgroup.cpu.stat.number_of_elapsed_periods"),
+			curr:          makeCgroupNodeStats(1_500_000_000, 100, 100_000),
+			expectPresent: false,
+		},
+		"missing periods on current": {
+			prev:          makeCgroupNodeStats(1_000_000_000, 90, 100_000),
+			curr:          makeCgroupWithout(1_500_000_000, 100, 100_000, "os.cgroup.cpu.stat.number_of_elapsed_periods"),
+			expectPresent: false,
+		},
+		"missing cfs_quota_micros on current": {
+			prev:          makeCgroupNodeStats(1_000_000_000, 90, 100_000),
+			curr:          makeCgroupWithout(1_500_000_000, 100, 100_000, "os.cgroup.cpu.cfs_quota_micros"),
+			expectPresent: false,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			if tt.prev != nil {
+				initCache(map[string]mapstr.M{"n1": tt.prev}, 10)
+			} else {
+				clearCache()
+			}
+			curr := tt.curr
+
+			enrichNodeStats("n1", &curr, 10_000)
+
+			if tt.expectPresent {
+				v, err := curr.GetValue(cgroupCpuPercentKey)
+				require.NoError(t, err, "expected %s to be set", cgroupCpuPercentKey)
+				require.InDelta(t, tt.expected, v.(float64), 0.001)
+			} else {
+				ok, _ := curr.HasKey(cgroupCpuPercentKey)
+				require.False(t, ok, "expected %s to be absent", cgroupCpuPercentKey)
+			}
+		})
+	}
+}
+
+// TestEnrichNodeStatsCgroupCpuUsagePercentQuickCheck fuzzes the enricher with
+// randomly-generated positive counter deltas and quota. For any valid input
+// the emitted percent must be finite and non-negative.
+func TestEnrichNodeStatsCgroupCpuUsagePercentQuickCheck(t *testing.T) {
+	property := func(prevUsage uint32, usageDelta uint32, prevPeriods uint16, periodsDelta uint16, quotaMicros uint32) bool {
+		// Guarantee the two counter deltas and quota are strictly positive so
+		// the enricher can compute a value. Otherwise we assert only the skip.
+		periodsDelta = (periodsDelta % 1000) + 1 // 1..1000
+		quotaMicros = (quotaMicros % 500_000) + 1
+		prev := makeCgroupNodeStats(int64(prevUsage), int64(prevPeriods), int64(quotaMicros))
+		curr := makeCgroupNodeStats(int64(prevUsage)+int64(usageDelta), int64(prevPeriods)+int64(periodsDelta), int64(quotaMicros))
+		initCache(map[string]mapstr.M{"n1": prev}, 10)
+
+		enrichNodeStats("n1", &curr, 10_000)
+
+		raw, err := curr.GetValue(cgroupCpuPercentKey)
+		if err != nil {
+			return false
+		}
+		v, ok := raw.(float64)
+		if !ok {
+			return false
+		}
+		return v >= 0 && !math.IsNaN(v) && !math.IsInf(v, 0)
+	}
+	require.NoError(t, quick.Check(property, nil))
 }
 
 func TestEnrichNodeStatsGaugeDecreaseWritesNilIngestRate(t *testing.T) {

--- a/x-pack/metricbeat/module/autoops_es/node_stats/data_test.go
+++ b/x-pack/metricbeat/module/autoops_es/node_stats/data_test.go
@@ -169,6 +169,8 @@ func expectValidParsedDetailedWithNoCache(t *testing.T, data metricset.FetcherDa
 	require.Nil(t, node1MetricSet["index_latency_in_millis"])
 	require.Nil(t, node1MetricSet["merge_latency_in_millis"])
 	require.Nil(t, node1MetricSet["search_latency_in_millis"])
+	// no previous sample → cgroup CPU percent must be absent
+	require.Nil(t, auto_ops_testing.GetObjectValue(node1MetricSet, "os.cgroup.cpu.usage_percent"))
 }
 
 func expectValidParsedDetailedWithCache(t *testing.T, data metricset.FetcherData[NodesStats]) {
@@ -198,6 +200,12 @@ func expectValidParsedDetailedWithCache(t *testing.T, data metricset.FetcherData
 		require.NotNil(t, node1MetricSet["bulk_bytes_per_second"])
 		require.NotNil(t, node1MetricSet["bulk_operations_per_second"])
 	}
+	// all three fixture versions carry cgroup counters with a positive quota; the cache
+	// is seeded with zero prev-counters (getNodeStatsForNode), so the delta equals the
+	// fixture value and the enricher always emits a positive percentage.
+	cgroupCpuPct := auto_ops_testing.GetObjectValue(node1MetricSet, "os.cgroup.cpu.usage_percent")
+	require.NotNil(t, cgroupCpuPct, "expected os.cgroup.cpu.usage_percent to be set")
+	require.Greater(t, cgroupCpuPct.(float64), 0.0)
 }
 
 // Expect a valid response from Elasticsearch to create N events

--- a/x-pack/metricbeat/module/autoops_es/node_stats/data_test.go
+++ b/x-pack/metricbeat/module/autoops_es/node_stats/data_test.go
@@ -205,7 +205,7 @@ func expectValidParsedDetailedWithCache(t *testing.T, data metricset.FetcherData
 	// fixture value and the enricher always emits a positive percentage.
 	cgroupCpuPct := auto_ops_testing.GetObjectValue(node1MetricSet, "os.cgroup.cpu.usage_percent")
 	require.NotNil(t, cgroupCpuPct, "expected os.cgroup.cpu.usage_percent to be set")
-	require.Greater(t, cgroupCpuPct.(float64), 0.0)
+	require.Greater(t, cgroupCpuPct.(int64), int64(0))
 }
 
 // Expect a valid response from Elasticsearch to create N events


### PR DESCRIPTION
## Summary

Re-lands #53020 (reverted by #53095) with targeted adjustments.

Implements #52616. Adds `enrichCgroupCpuUsagePercent` to the `autoops_es` `node_stats` metricset, computing the percentage of the configured CFS quota consumed by the Elasticsearch cgroup between consecutive samples:

```
os.cgroup.cpu.usage_percent =
  (Δusage_nanos / (Δnumber_of_elapsed_periods × cfs_quota_micros × 1000)) × 100
```

This matches the Kibana `QuotaMetric` / container CPU utilization formula.

## Changes vs. #53020 (the reverted PR)

Two intentional differences from the original:

**1. Field name: `os.cgroup.cpu.usage_percent` (was: `cgroup_cpu_usage_percent`)**

The original PR emitted a flat top-level key. The field is now written into the existing nested `os.cgroup.cpu` dict via `mapstr.Put`, matching:
- The issue spec: _`os.cgroup.cpu.usage_percent`_
- The agreed consumer query: `COALESCE(os.cgroup.cpu.usage_percent, process.cpu.percent)`

`process.cpu.percent` is left completely untouched — the new field is purely additive.

**2. No `fields.yml` / `fields.go` change**

The existing `node_stats/_meta/fields.yml` is vestigial: its root group is `node.stats` while the metricset emits under `node_stats`, and none of the module's other derived fields (`index_rate_per_second`, `merge_latency_in_millis`, `timestampDiff`, …) appear there. Declaring the new field would document path `autoops_es.node.stats.os.cgroup.cpu.usage_percent`, which is never emitted. Skipping this change also keeps the base64 blob in `fields.go` out of the diff, which caused the `8.19` backport conflict in #53020. Consumer-side mapping is handled in the AutoOps index templates (the rollout order: add template mapping → wait for index rollover → merge the query change).

## Skip conditions (field is omitted when)

- No previous sample for the node (first poll / new node)
- `cfs_quota_micros` missing or `≤ 0` (includes the `-1` "no quota" sentinel)
- Any required counter (`usage_nanos`, `number_of_elapsed_periods`) missing on either sample
- `Δusage_nanos < 0` (counter reset)
- `Δnumber_of_elapsed_periods ≤ 0` (no new periods)

No clamping at 100% — a burst above quota is real signal.

## Test plan

- [x] 15-subtest table test covering all skip conditions and happy-path variants (50%, burst >100%, 0% usage, quota change, missing fields)
- [x] Property-based fuzz test (`testing/quick`) asserting result is always `≥ 0` and finite
- [x] All pre-existing fixture-driven tests (`TestProperlyHandlesResponseWithDetails`, `TestProperlyHandlesResponseWithDetailsWithCache`, `TestSuccessfulFetch`) pass against 7.17.0 / 8.15.3 / 9.2.0 fixtures

## Backport

Labels: `backport-9.1`, `backport-9.2`, `backport-9.3`, `backport-9.4`, `backport-9.5`

**No `backport-9.0`**: the `autoops_es` module does not exist on the `9.0` branch (only the generated docs reference file is there).

Note: `cache_test.go` differs between `main` and some 9.x branches, so some backport PRs may need manual conflict resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)