### PR TITLE
feat(autoops_es): persist additional cluster settings in cluster_settings

### DIFF
--- a/changelog/fragments/1789012800-autoops-es-cluster-settings-schema.yaml
+++ b/changelog/fragments/1789012800-autoops-es-cluster-settings-schema.yaml
@@ -1,0 +1,3 @@
+kind: enhancement
+summary: Persist additional cluster settings in the autoops_es cluster_settings metricset
+component: metricbeat

--- a/x-pack/metricbeat/module/autoops_es/cluster_settings/_meta/test/cluster_settings.my-cluster.7.17.0.json
+++ b/x-pack/metricbeat/module/autoops_es/cluster_settings/_meta/test/cluster_settings.my-cluster.7.17.0.json
@@ -210,6 +210,13 @@
         "path": {
             "data": ["/app/data"]
         },
+        "gateway": {
+            "expected_nodes": "0",
+            "expected_data_nodes": "0",
+            "recover_after_nodes": "-1",
+            "recover_after_data_nodes": "-1",
+            "recover_after_time": "5m"
+        },
         "ccr": {
             "indices": {
                 "recovery": {

--- a/x-pack/metricbeat/module/autoops_es/cluster_settings/_meta/test/cluster_settings.my-cluster.8.15.3.json
+++ b/x-pack/metricbeat/module/autoops_es/cluster_settings/_meta/test/cluster_settings.my-cluster.8.15.3.json
@@ -204,6 +204,11 @@
         "path": {
             "data": ["/app/data"]
         },
+        "gateway": {
+            "expected_data_nodes": "0",
+            "recover_after_data_nodes": "-1",
+            "recover_after_time": "5m"
+        },
         "ccr": {
             "indices": {
                 "recovery": {

--- a/x-pack/metricbeat/module/autoops_es/cluster_settings/cluster_settings.go
+++ b/x-pack/metricbeat/module/autoops_es/cluster_settings/cluster_settings.go
@@ -8,7 +8,9 @@ import "github.com/elastic/beats/v7/x-pack/metricbeat/module/autoops_es/metricse
 
 const (
 	ClusterSettingsMetricSet = "cluster_settings"
-	ClusterSettingsPath      = "/_cluster/settings?include_defaults&filter_path=**.discovery,**.processors,**.cluster,**.repositories,**.bootstrap,**.search,**.indices,**.action,defaults.path.data"
+	// `gateway.*` settings are static and node-scoped, so they are requested by exact path under
+	// `defaults` only: `**.gateway` would pull in ~10 keys that the schema discards anyway.
+	ClusterSettingsPath = "/_cluster/settings?include_defaults&filter_path=**.discovery,**.processors,**.cluster,**.repositories,**.bootstrap,**.search,**.indices,**.action,defaults.path.data,defaults.gateway.expected_nodes,defaults.gateway.expected_data_nodes,defaults.gateway.recover_after_nodes,defaults.gateway.recover_after_data_nodes,defaults.gateway.recover_after_time"
 )
 
 // init registers the MetricSet with the central registry as soon as the program

--- a/x-pack/metricbeat/module/autoops_es/cluster_settings/data.go
+++ b/x-pack/metricbeat/module/autoops_es/cluster_settings/data.go
@@ -17,7 +17,49 @@ import (
 	"github.com/elastic/beats/v7/x-pack/metricbeat/module/autoops_es/utils"
 )
 
+// allocationFilterSchema builds the schema for one of the interchangeable
+// `cluster.routing.allocation.{exclude,include,require}` shard filter groups,
+// which all accept the same attributes.
+func allocationFilterSchema(key string) c.ConvMap {
+	return c.Dict(key, s.Schema{
+		"_ip":   c.Str("_ip", s.IgnoreAllErrors),
+		"_host": c.Str("_host", s.IgnoreAllErrors),
+		"_name": c.Str("_name", s.IgnoreAllErrors),
+		"_tier": c.Str("_tier", s.IgnoreAllErrors),
+	}, c.DictOptional)
+}
+
 var (
+	// `discovery.zen.*` is a 7.x-only namespace, removed in 8.0, so every key is optional.
+	discoverySchema = c.Dict("discovery", s.Schema{
+		"zen": c.Dict("zen", s.Schema{
+			"minimum_master_nodes": c.Str("minimum_master_nodes", s.IgnoreAllErrors),
+			"ping_timeout":         c.Str("ping_timeout", s.IgnoreAllErrors),
+			"join_timeout":         c.Str("join_timeout", s.IgnoreAllErrors),
+			"publish_timeout":      c.Str("publish_timeout", s.IgnoreAllErrors),
+			"hosts_provider":       c.Ifc("hosts_provider", s.Optional),
+			"fd": c.Dict("fd", s.Schema{
+				"ping_timeout": c.Str("ping_timeout", s.IgnoreAllErrors),
+			}, c.DictOptional),
+			"master_election": c.Dict("master_election", s.Schema{
+				"wait_for_joins_timeout": c.Str("wait_for_joins_timeout", s.IgnoreAllErrors),
+			}, c.DictOptional),
+			"ping": c.Dict("ping", s.Schema{
+				"unicast": c.Dict("unicast", s.Schema{
+					"hosts": c.Ifc("hosts", s.Optional),
+					// `hosts` is a list and `hosts.resolve_timeout` a literal dotted sibling key,
+					// so the two cannot share the `hosts` name in the event
+					"hosts_resolve_timeout": c.Str("hosts.resolve_timeout", s.IgnoreAllErrors),
+				}, c.DictOptional),
+			}, c.DictOptional),
+		}, c.DictOptional),
+	}, c.DictOptional)
+
+	actionSchema = c.Dict("action", s.Schema{
+		"destructive_requires_name": c.Str("destructive_requires_name", s.IgnoreAllErrors),
+		"auto_create_index":         c.Str("auto_create_index", s.IgnoreAllErrors),
+	}, c.DictOptional)
+
 	clusterSchema = c.Dict("cluster", s.Schema{
 		"metadata": c.Dict("metadata", s.Schema{
 			"display_name": c.Str("display_name", s.IgnoreAllErrors),
@@ -28,6 +70,7 @@ var (
 		"routing": c.Dict("routing", s.Schema{
 			"allocation": c.Dict("allocation", s.Schema{
 				"disk": c.Dict("disk", s.Schema{
+					"threshold_enabled": c.Str("threshold_enabled", s.IgnoreAllErrors),
 					"watermark": c.Dict("watermark", s.Schema{
 						"low":                c.Str("low", s.IgnoreAllErrors),
 						"high":               c.Str("high", s.IgnoreAllErrors),
@@ -35,20 +78,22 @@ var (
 						"flood_stage_frozen": c.Str("flood_stage.frozen", s.IgnoreAllErrors),
 					}, c.DictOptional),
 				}, c.DictOptional),
+				"enable":                              c.Str("enable", s.IgnoreAllErrors),
 				"node_concurrent_outgoing_recoveries": c.Str("node_concurrent_outgoing_recoveries", s.IgnoreAllErrors),
 				"cluster_concurrent_rebalance":        c.Str("cluster_concurrent_rebalance", s.IgnoreAllErrors),
 				"node_concurrent_recoveries":          c.Str("node_concurrent_recoveries", s.IgnoreAllErrors),
+				"node_initial_primaries_recoveries":   c.Str("node_initial_primaries_recoveries", s.IgnoreAllErrors),
 				"total_shards_per_node":               c.Str("total_shards_per_node", s.IgnoreAllErrors),
-				"exclude": c.Dict("exclude", s.Schema{
-					"_ip":   c.Str("_ip", s.IgnoreAllErrors),
-					"_host": c.Str("_host", s.IgnoreAllErrors),
-					"_name": c.Str("_name", s.IgnoreAllErrors),
+				"awareness": c.Dict("awareness", s.Schema{
+					// a list setting: ES returns an array, or a comma-separated string when set that way
+					"attributes": c.Ifc("attributes", s.Optional),
 				}, c.DictOptional),
-				"include": c.Dict("include", s.Schema{
-					"_ip":   c.Str("_ip", s.IgnoreAllErrors),
-					"_host": c.Str("_host", s.IgnoreAllErrors),
-					"_name": c.Str("_name", s.IgnoreAllErrors),
-				}, c.DictOptional),
+				"exclude": allocationFilterSchema("exclude"),
+				"include": allocationFilterSchema("include"),
+				"require": allocationFilterSchema("require"),
+			}, c.DictOptional),
+			"rebalance": c.Dict("rebalance", s.Schema{
+				"enable": c.Str("enable", s.IgnoreAllErrors),
 			}, c.DictOptional),
 		}, c.DictOptional),
 		"blocks": c.Dict("blocks", s.Schema{
@@ -70,13 +115,20 @@ var (
 					"search_power_min": c.Str("search_power_min", s.IgnoreAllErrors),
 				}, c.DictOptional),
 			}, c.DictOptional),
-			"discovery": c.Dict("discovery", s.Schema{
-				"zen": c.Dict("zen", s.Schema{
-					"minimum_master_nodes": c.Str("minimum_master_nodes", s.IgnoreAllErrors),
-				}, c.DictOptional),
-			}, c.DictOptional),
+			"discovery":  discoverySchema,
 			"processors": c.Str("processors", s.IgnoreAllErrors),
 			"cluster":    clusterSchema,
+			// `gateway.*` is static, node-scoped configuration: it can never be set as a persistent
+			// or transient cluster setting, so it is only mapped under `defaults`. Both generations
+			// are collected — `expected_nodes` and `recover_after_nodes` were removed in 8.0 in
+			// favour of the `*_data_nodes` variants — so every key is optional.
+			"gateway": c.Dict("gateway", s.Schema{
+				"expected_nodes":           c.Str("expected_nodes", s.IgnoreAllErrors),
+				"expected_data_nodes":      c.Str("expected_data_nodes", s.IgnoreAllErrors),
+				"recover_after_nodes":      c.Str("recover_after_nodes", s.IgnoreAllErrors),
+				"recover_after_data_nodes": c.Str("recover_after_data_nodes", s.IgnoreAllErrors),
+				"recover_after_time":       c.Str("recover_after_time", s.IgnoreAllErrors),
+			}, c.DictOptional),
 			"repositories": c.Dict("repositories", s.Schema{
 				"fs": c.Dict("fs", s.Schema{
 					"compress":   c.Str("compress", s.IgnoreAllErrors),
@@ -115,9 +167,7 @@ var (
 					}, c.DictOptional),
 				}, c.DictOptional),
 			}, c.DictOptional),
-			"action": c.Dict("action", s.Schema{
-				"destructive_requires_name": c.Str("destructive_requires_name", s.IgnoreAllErrors),
-			}, c.DictOptional),
+			"action": actionSchema,
 		}, c.DictRequired),
 		"persistent": c.Dict("persistent", s.Schema{
 			"serverless": c.Dict("serverless", s.Schema{
@@ -127,11 +177,7 @@ var (
 					"search_power_min": c.Str("search_power_min", s.IgnoreAllErrors),
 				}, c.DictOptional),
 			}, c.DictOptional),
-			"discovery": c.Dict("discovery", s.Schema{
-				"zen": c.Dict("zen", s.Schema{
-					"minimum_master_nodes": c.Str("minimum_master_nodes", s.IgnoreAllErrors),
-				}, c.DictOptional),
-			}, c.DictOptional),
+			"discovery":  discoverySchema,
 			"processors": c.Str("processors", s.IgnoreAllErrors),
 			"cluster":    clusterSchema,
 			"bootstrap": c.Dict("bootstrap", s.Schema{
@@ -162,9 +208,7 @@ var (
 					}, c.DictOptional),
 				}, c.DictOptional),
 			}, c.DictOptional),
-			"action": c.Dict("action", s.Schema{
-				"destructive_requires_name": c.Str("destructive_requires_name", s.IgnoreAllErrors),
-			}, c.DictOptional),
+			"action": actionSchema,
 		}, c.DictOptional),
 		"transient": c.Dict("transient", s.Schema{
 			"serverless": c.Dict("serverless", s.Schema{
@@ -174,11 +218,7 @@ var (
 					"search_power_min": c.Str("search_power_min", s.IgnoreAllErrors),
 				}, c.DictOptional),
 			}, c.DictOptional),
-			"discovery": c.Dict("discovery", s.Schema{
-				"zen": c.Dict("zen", s.Schema{
-					"minimum_master_nodes": c.Str("minimum_master_nodes", s.IgnoreAllErrors),
-				}, c.DictOptional),
-			}, c.DictOptional),
+			"discovery":  discoverySchema,
 			"processors": c.Str("processors", s.IgnoreAllErrors),
 			"cluster":    clusterSchema,
 			"bootstrap": c.Dict("bootstrap", s.Schema{
@@ -209,9 +249,7 @@ var (
 					}, c.DictOptional),
 				}, c.DictOptional),
 			}, c.DictOptional),
-			"action": c.Dict("action", s.Schema{
-				"destructive_requires_name": c.Str("destructive_requires_name", s.IgnoreAllErrors),
-			}, c.DictOptional),
+			"action": actionSchema,
 		}, c.DictOptional),
 	}
 )

--- a/x-pack/metricbeat/module/autoops_es/cluster_settings/data_test.go
+++ b/x-pack/metricbeat/module/autoops_es/cluster_settings/data_test.go
@@ -42,6 +42,58 @@ func expectValidParsedData(t *testing.T, data metricset.FetcherData[map[string]a
 	require.Equal(t, "95%", auto_ops_testing.GetObjectValue(event.MetricSetFields, "cluster.routing.allocation.disk.watermark.flood_stage"))
 	require.Equal(t, "95%", auto_ops_testing.GetObjectValue(event.MetricSetFields, "cluster.routing.allocation.disk.watermark.flood_stage_frozen"))
 
+	// allocation and rebalance settings present in every supported version
+	require.Equal(t, "all", auto_ops_testing.GetObjectValue(event.MetricSetFields, "cluster.routing.allocation.enable"))
+	require.Equal(t, "all", auto_ops_testing.GetObjectValue(event.MetricSetFields, "cluster.routing.rebalance.enable"))
+	require.Equal(t, "4", auto_ops_testing.GetObjectValue(event.MetricSetFields, "cluster.routing.allocation.node_initial_primaries_recoveries"))
+	require.Equal(t, "true", auto_ops_testing.GetObjectValue(event.MetricSetFields, "cluster.routing.allocation.disk.threshold_enabled"))
+
+	// awareness attributes are a list setting, so they survive as an array rather than a string
+	require.ElementsMatch(t, []string{"region", "logical_availability_zone"}, auto_ops_testing.GetObjectValue(event.MetricSetFields, "cluster.routing.allocation.awareness.attributes"))
+
+	// gateway.* is static node-scoped config, so it is only ever reported from defaults
+	require.Equal(t, "0", auto_ops_testing.GetObjectValue(event.MetricSetFields, "gateway.expected_data_nodes"))
+	require.Equal(t, "-1", auto_ops_testing.GetObjectValue(event.MetricSetFields, "gateway.recover_after_data_nodes"))
+	require.Equal(t, "5m", auto_ops_testing.GetObjectValue(event.MetricSetFields, "gateway.recover_after_time"))
+
+	// version-specific settings
+	if data.Version == "7.17.0" {
+		// the pre-8.0 gateway settings, removed in 8.0 in favour of the *_data_nodes variants
+		require.Equal(t, "0", auto_ops_testing.GetObjectValue(event.MetricSetFields, "gateway.expected_nodes"))
+		require.Equal(t, "-1", auto_ops_testing.GetObjectValue(event.MetricSetFields, "gateway.recover_after_nodes"))
+
+		// transient overrides persistent for auto_create_index
+		require.Equal(t, "false", auto_ops_testing.GetObjectValue(event.MetricSetFields, "action.auto_create_index"))
+
+		// the shard filter groups accept _tier alongside _ip/_host/_name
+		require.Equal(t, "", auto_ops_testing.GetObjectValue(event.MetricSetFields, "cluster.routing.allocation.exclude._tier"))
+		require.Equal(t, "", auto_ops_testing.GetObjectValue(event.MetricSetFields, "cluster.routing.allocation.include._tier"))
+		require.Equal(t, "", auto_ops_testing.GetObjectValue(event.MetricSetFields, "cluster.routing.allocation.require._tier"))
+
+		// discovery.zen.* is a 7.x-only namespace
+		require.Equal(t, "-1", auto_ops_testing.GetObjectValue(event.MetricSetFields, "discovery.zen.minimum_master_nodes"))
+		require.Equal(t, "3s", auto_ops_testing.GetObjectValue(event.MetricSetFields, "discovery.zen.ping_timeout"))
+		require.Equal(t, "60000ms", auto_ops_testing.GetObjectValue(event.MetricSetFields, "discovery.zen.join_timeout"))
+		require.Equal(t, "30s", auto_ops_testing.GetObjectValue(event.MetricSetFields, "discovery.zen.publish_timeout"))
+		require.Equal(t, "30s", auto_ops_testing.GetObjectValue(event.MetricSetFields, "discovery.zen.fd.ping_timeout"))
+		require.Equal(t, "30000ms", auto_ops_testing.GetObjectValue(event.MetricSetFields, "discovery.zen.master_election.wait_for_joins_timeout"))
+		// list settings are reported as empty arrays rather than dropped
+		require.Equal(t, []any{}, auto_ops_testing.GetObjectValue(event.MetricSetFields, "discovery.zen.hosts_provider"))
+
+		// `hosts` is a list and `hosts.resolve_timeout` a literal dotted sibling key: both are reported
+		require.Equal(t, []any{}, auto_ops_testing.GetObjectValue(event.MetricSetFields, "discovery.zen.ping.unicast.hosts"))
+		require.Equal(t, "5s", auto_ops_testing.GetObjectValue(event.MetricSetFields, "discovery.zen.ping.unicast.hosts_resolve_timeout"))
+	} else if data.Version == "8.15.3" {
+		require.Equal(t, ".ent-search-*-logs-*,-.ent-search-*,+*", auto_ops_testing.GetObjectValue(event.MetricSetFields, "action.auto_create_index"))
+
+		// discovery.zen.* was removed in 8.0, so nothing is reported for it
+		require.Nil(t, auto_ops_testing.GetObjectValue(event.MetricSetFields, "discovery.zen"))
+
+		// likewise the pre-8.0 gateway settings
+		require.Nil(t, auto_ops_testing.GetObjectValue(event.MetricSetFields, "gateway.expected_nodes"))
+		require.Nil(t, auto_ops_testing.GetObjectValue(event.MetricSetFields, "gateway.recover_after_nodes"))
+	}
+
 	// schema is expected to drop this field if it appears (it does in one file)
 	require.Nil(t, auto_ops_testing.GetObjectValue(event.MetricSetFields, "ignored_field"))
 }


### PR DESCRIPTION
Maps cluster settings that were already being fetched but silently dropped by the schema, and collects the `gateway.*` recovery settings that were not being requested at all.

**Already in the response, now mapped** (no `filter_path` change needed for these):

- `cluster.routing.allocation.{enable,node_initial_primaries_recoveries}`
- `cluster.routing.allocation.disk.threshold_enabled`
- `cluster.routing.allocation.awareness.attributes`
- `cluster.routing.rebalance.enable`
- `action.auto_create_index`
- a `discovery.zen.*` allowlist (7.x-only namespace, removed in 8.0)

`awareness.attributes` is a list setting — Elasticsearch returns an array, or a comma-separated string when set that way — so it uses `c.Ifc` rather than `c.Str`, which would have dropped it. Likewise `discovery.zen.ping.unicast` carries both a `hosts` list and a literal dotted `hosts.resolve_timeout` sibling key, so the latter is mapped to `hosts_resolve_timeout` to avoid colliding on `hosts`, mirroring the existing `flood_stage_frozen` treatment.

`_tier` was missing from the shard filter groups. Rather than add it to `exclude` and `include` while leaving a `require` group holding only `_tier`, the three interchangeable groups are now built from one helper so they all accept the same `_ip`/`_host`/`_name`/`_tier` attributes.

**Newly requested:**

- `gateway.{expected_nodes,recover_after_nodes}` (7.x)
- `gateway.{expected_data_nodes,recover_after_data_nodes,recover_after_time}`

These are static, node-scoped settings that can never be set as persistent or transient cluster settings, so they are mapped under `defaults` only. Both generations are collected because `expected_nodes` and `recover_after_nodes` were removed in 8.0 in favour of the `*_data_nodes` variants, so every key is optional. They are requested by exact path rather than `**.gateway`, which would transfer ~10 keys the schema discards — matching the allowlist approach used in #53049.

`discovery` and `action` were duplicated across all three scopes; they are now shared vars alongside the existing `clusterSchema`, so these additions are written once rather than three times.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments`

Note on the documentation checkbox: `_meta/fields.yml` and `docs/reference/metricbeat/exported-fields-autoops_es.md` are already stale for this metricset independently of this PR — they document `autoops_es.cluster_settings.defaults.*` even though `flattenSettings` strips those prefixes, and they are missing existing fields such as `flood_stage_frozen`, `serverless.*`, `path.data`, `processors` and `repositories`. Rather than half-correct that drift here, I have left it for a dedicated follow-up.

## Disruptive User Impact

None. This is purely additive: existing fields keep their names and values, and the only request change is five extra exact-path entries in `filter_path` under `defaults`. Every new key is optional at each level, so a cluster that reports none of them maps without error and emits no empty objects for them.

## How to test this PR locally

```
go test ./x-pack/metricbeat/module/autoops_es/cluster_settings/... -v
```

Both fixture versions run as subtests. The assertions are split by version so the 7.x-only surface (`discovery.zen.*`, `gateway.expected_nodes`, `gateway.recover_after_nodes`) is asserted present on `7.17.0` and explicitly asserted absent on `8.15.3`, pinning the version split in both directions.

## Related issues

- Relates #52654

The remaining item from that issue, `archived.*`, is deliberately not in this PR. It cannot be expressed in `libbeat/common/schema` (fixed-key only, no wildcards) and needs to be built as a post-processing step in `eventsMapping` instead — in particular because `flattenSettings` merges scopes with `mapstr.DeepUpdate`, which overwrites rather than merges arrays, so an `archived` list under both `persistent` and `transient` would silently lose the persistent entries. That is being tracked in the issue discussion and will follow separately.

## Use cases

AutoOps receives allocation, rebalance, recovery and gateway configuration that it previously could not see, so shard-allocation and upgrade/recovery analyses can reason about settings such as `cluster.routing.allocation.enable`, `awareness.attributes` and the gateway recovery thresholds.

## Author's Checklist

- [ ] `recover_after_time: "5m"` in the fixtures is taken from the Elasticsearch documentation rather than a live capture. ES may return `0ms` when no `expected_*` setting is configured. This is a cosmetic fixture value with no behavioural effect, but worth confirming against a real cluster.
