### PR TITLE
filebeat,winlogbeat: fix wording defects in user-facing error messages

### DIFF
--- a/changelog/fragments/1789059985-fix-user-facing-error-text-wording.yaml
+++ b/changelog/fragments/1789059985-fix-user-facing-error-text-wording.yaml
@@ -1,0 +1,14 @@
+kind: bug-fix
+
+summary: Fix duplicated and grammatically incorrect wording in user-facing error messages
+
+description: >
+  Three user-visible error messages contained wording defects that made log
+  output confusing: the GCS input repeated "job with job id", the Winlogbeat
+  event log metadata store contained the duplicated word "for for event ID",
+  and the Filestream input used the wrong article in "a os.File". The messages
+  now read "job with ID", "for event ID", and "an os.File" respectively.
+
+component: filebeat, winlogbeat
+
+issue: https://github.com/elastic/beats/issues/52807

--- a/filebeat/input/filestream/input.go
+++ b/filebeat/input/filestream/input.go
@@ -524,7 +524,7 @@ func (inp *filestream) openFile(
 	f, err := inp.newFile(rawFile)
 	if err != nil {
 		return nil, nil, false,
-			fmt.Errorf("failed to create a File from a os.File: %w", err)
+			fmt.Errorf("failed to create a File from an os.File: %w", err)
 	}
 
 	ok := false

--- a/winlogbeat/sys/wineventlog/metadata_store.go
+++ b/winlogbeat/sys/wineventlog/metadata_store.go
@@ -487,7 +487,7 @@ func (em *EventMetadata) initEventMessage(itr *EventMetadataIterator, publisher 
 
 	msg, err := getMessageString(publisher, NilHandle, messageID, templateInserts.Slice())
 	if err != nil {
-		return fmt.Errorf("failed to get message string using message ID %v for for event ID %v: %w", messageID, em.EventID, err)
+		return fmt.Errorf("failed to get message string using message ID %v for event ID %v: %w", messageID, em.EventID, err)
 	}
 
 	return em.setMessage(msg)

--- a/x-pack/filebeat/input/gcs/job.go
+++ b/x-pack/filebeat/input/gcs/job.go
@@ -348,7 +348,7 @@ func (j *job) splitEventList(key string, raw json.RawMessage, offset int64, id s
 	var eventsPerObject int
 	if err := json.Unmarshal(raw, &jsonObject); err != nil {
 		j.status.UpdateStatus(status.Degraded, "failed to unmarshal JSON: "+err.Error())
-		return eventsPerObject, fmt.Errorf("job with job id %s encountered an unmarshaling error: %w", id, err)
+		return eventsPerObject, fmt.Errorf("job with ID %s encountered an unmarshaling error: %w", id, err)
 	}
 
 	raw, found := jsonObject[key]
@@ -386,7 +386,7 @@ func (j *job) splitEventList(key string, raw json.RawMessage, offset int64, id s
 		data, err := item.MarshalJSON()
 		if err != nil {
 			j.status.UpdateStatus(status.Degraded, "failed to re-marshal JSON: "+err.Error())
-			return eventsPerObject, fmt.Errorf("job with job id %s encountered a marshaling error: %w", id, err)
+			return eventsPerObject, fmt.Errorf("job with ID %s encountered a marshaling error: %w", id, err)
 		}
 		evt := j.createEvent(data, nil, offset+arrayOffset)
 


### PR DESCRIPTION
## Proposed commit message

fix wording defects in user-facing error messages

**WHAT:** Corrected three string literals that are emitted in user-visible runtime error messages.

- `x-pack/filebeat/input/gcs/job.go` — `job with job id %s` → `job with ID %s` (redundant wording, two occurrences)
- `winlogbeat/sys/wineventlog/metadata_store.go` — `for for event ID %v` → `for event ID %v` (duplicated word)
- `filebeat/input/filestream/input.go` — `a os.File` → `an os.File` (wrong indefinite article)

**WHY:** These strings are written when a failure occurs, so the wording defects land directly in logs and on the console and make diagnostic output harder to read. The change touches string literals only — no behaviour, control flow or types are affected.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~ (N/A — string literals only)
- [ ] ~~I have made corresponding changes to the documentation~~ (N/A)
- [ ] ~~I have made corresponding change to the default configuration files~~ (N/A)
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~ (N/A — no behaviour change; no test asserts these strings, see below)
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md)

## Disruptive User Impact

None. Only the wording of three error/log messages changes; there is no functional, configuration or API impact.

## How to test this PR locally

```sh
# 1. Formatting is clean (gofmt -l prints nothing)
gofmt -l x-pack/filebeat/input/gcs/job.go \
         winlogbeat/sys/wineventlog/metadata_store.go \
         filebeat/input/filestream/input.go

# 2. Old wording is gone from the three changed files, new wording is in place
grep -n "job with job id\|for for event ID\|a os.File" \
  x-pack/filebeat/input/gcs/job.go \
  winlogbeat/sys/wineventlog/metadata_store.go \
  filebeat/input/filestream/input.go            # no matches expected

grep -n "job with ID\|for event ID\|an os.File" \
  x-pack/filebeat/input/gcs/job.go \
  winlogbeat/sys/wineventlog/metadata_store.go \
  filebeat/input/filestream/input.go            # the three updated sites

# 3. No test in the affected packages depends on the previous strings
grep -rn "job with job id\|for for event ID\|a os.File" --include=*_test.go \
  x-pack/filebeat/input/gcs winlogbeat/sys/wineventlog filebeat/input/filestream
```

A repository-wide search for the three previous strings returns only the three files changed here, so no test or other caller depends on them. CI covers compilation of the affected packages (`winlogbeat` is Windows-only and is built by the corresponding CI job).

## Scope note

The only other occurrence of `a os.File` in the repository is a code comment in `auditbeat/module/file_integrity/event.go` (`... based on data from a os.FileInfo`). It is not a runtime message and is intentionally left out of scope for this change.

Closes #52807
