### PR TITLE
ci: update Kerberos fixture with stack snapshots

### DIFF
--- a/.github/workflows/updatecli.d/bump-elastic-stack-snapshot.yml
+++ b/.github/workflows/updatecli.d/bump-elastic-stack-snapshot.yml
@@ -47,3 +47,13 @@ targets:
       file: testing/environments/snapshot.yml
       matchpattern: '(image: docker\.elastic\.co/.*):\d+.\d+.\d+-.*-SNAPSHOT'
       replacepattern: '$1:{{ source "latestVersion" }}-SNAPSHOT'
+
+  update-elasticsearch-kerberos:
+    name: "Update Elasticsearch Kerberos Dockerfile"
+    kind: file
+    sourceid: latestVersion
+    scmid: default
+    spec:
+      file: testing/environments/docker/elasticsearch_kerberos/Dockerfile
+      matchpattern: '(FROM docker\.elastic\.co/elasticsearch/elasticsearch):\d+.\d+.\d+-.*-SNAPSHOT'
+      replacepattern: '$1:{{ source "latestVersion" }}-SNAPSHOT'


### PR DESCRIPTION
## Proposed commit message

```
Configure the scheduled Updatecli snapshot bump to also update the\nElasticsearch image used by the Kerberos fixture. This keeps the fixture on\nthe same tested stack build as the rest of the integration environment.

Assisted-By: Cursor GPT-5.6-Terra
```

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.~~
- [ ] ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).~~

~~## Disruptive User Impact~~

## How to test this PR locally

Run the `bump-elastic-stack-snapshot` workflow and verify both `testing/environments/snapshot.yml` and `testing/environments/docker/elasticsearch_kerberos/Dockerfile` use its selected snapshot build.

## Related issues

- Closes https://github.com/elastic/beats/issues/53155


~~## Use cases~~
~~## Screenshots~~
~~## Logs~~
