### PR TITLE
statestore: scope the Elasticsearch state store by input id

### DIFF
--- a/changelog/fragments/1788817407-es-cursor-store-input-index.yaml
+++ b/changelog/fragments/1788817407-es-cursor-store-input-index.yaml
@@ -1,0 +1,9 @@
+kind: bug-fix
+
+summary: Fix agentless Elasticsearch state store writing to the wrong input index
+
+description: >
+  Inputs affected by the bug re-ingest once, from their configured initial
+  lookback, the first time they read their own index.
+
+component: filebeat

--- a/filebeat/beater/store.go
+++ b/filebeat/beater/store.go
@@ -158,17 +158,31 @@ func (s *filebeatStore) Close() {
 	}
 }
 
-// StoreFor returns the storage registry depending on the type. Default is the file store.
-func (s *filebeatStore) StoreFor(typ string) (*statestore.Store, error) {
-	if features.IsElasticsearchStateStoreEnabledForInput(typ) && s.shared.esRegistry != nil {
-		return s.shared.esRegistry.Get(s.storeName)
+// StoreFor returns the store for the input type and ID. It uses file storage by default.
+func (s *filebeatStore) StoreFor(typ, id string) (*statestore.Store, error) {
+	if s.usesES(typ) {
+		return s.shared.esRegistry.Get(s.esStoreName(id))
 	}
 	return s.shared.registry.Get(s.storeName)
 }
 
 // StoreKey returns the identifier of the shared persistent registry backend.
-func (s *filebeatStore) StoreKey() string {
+func (s *filebeatStore) StoreKey(typ, id string) string {
+	if s.usesES(typ) {
+		return s.storeKey + "::es::" + s.esStoreName(id)
+	}
 	return s.storeKey
+}
+
+func (s *filebeatStore) usesES(typ string) bool {
+	return features.IsElasticsearchStateStoreEnabledForInput(typ) && s.shared.esRegistry != nil
+}
+
+func (s *filebeatStore) esStoreName(id string) string {
+	if id == "" {
+		return s.storeName
+	}
+	return id
 }
 
 func (s *filebeatStore) CleanupInterval() time.Duration {

--- a/filebeat/beater/store_filestorage_test.go
+++ b/filebeat/beater/store_filestorage_test.go
@@ -44,7 +44,7 @@ func TestOpenStateStore_OtelFileStorageSetGet(t *testing.T) {
 	require.NoError(t, err)
 	defer fb.Close()
 
-	st, err := fb.StoreFor("filestream")
+	st, err := fb.StoreFor("filestream", "")
 	require.NoError(t, err)
 	defer st.Close()
 

--- a/filebeat/beater/store_test.go
+++ b/filebeat/beater/store_test.go
@@ -27,6 +27,8 @@ import (
 
 	"github.com/elastic/beats/v7/filebeat/config"
 	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/beats/v7/libbeat/features"
+	"github.com/elastic/beats/v7/libbeat/statestore/storetest"
 	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/paths"
 )
@@ -52,7 +54,7 @@ func TestOpenStateStore_SamePathSharesRegistry(t *testing.T) {
 	s2 := testOpenStore(t, dir)
 
 	assert.Same(t, s1.shared, s2.shared, "stores with the same path should share the same sharedRegistries")
-	assert.Equal(t, s1.StoreKey(), s2.StoreKey(), "stores with the same backend should have the same key")
+	assert.Equal(t, s1.StoreKey("", ""), s2.StoreKey("", ""), "stores with the same backend should have the same key")
 
 	globalMu.Lock()
 	assert.Equal(t, 2, s1.shared.refCount)
@@ -89,8 +91,53 @@ func TestFilebeatStore_StoreKeyMatchesBackendAndPath(t *testing.T) {
 	require.NoError(t, err)
 	defer second.Close()
 
-	assert.Equal(t, expected, first.StoreKey())
-	assert.Equal(t, expected, second.StoreKey())
+	assert.Equal(t, expected, first.StoreKey("", ""))
+	assert.Equal(t, expected, second.StoreKey("", ""))
+}
+
+// Elasticsearch inputs with different IDs must use separate stores.
+// Other input types must share the file store.
+func TestFilebeatStore_ElasticsearchStoreIsPerInputID(t *testing.T) {
+	// Restore the environment before reloading the feature flags during cleanup.
+	t.Cleanup(features.ReinitForTest)
+	t.Setenv("AGENTLESS_ELASTICSEARCH_STATE_STORE_INPUT_TYPES", "test")
+	features.ReinitForTest()
+
+	beatPaths := paths.New()
+	beatPaths.Data = t.TempDir()
+	cfg := config.Registry{
+		Path:               "registry",
+		Permissions:        0o600,
+		Backend:            "memlog",
+		ESStorageExtension: storetest.NewMemoryStoreBackend(),
+	}
+
+	s, err := openStateStore(
+		t.Context(),
+		beat.Info{Beat: "test", Paths: beatPaths},
+		logp.NewNopLogger(),
+		cfg,
+	)
+	require.NoError(t, err)
+	defer s.Close()
+
+	assert.NotEqual(t, s.StoreKey("test", "a"), s.StoreKey("test", "b"))
+
+	fileKey := storeKey(beatPaths.Resolve(paths.Data, cfg.Path), cfg.Backend)
+	assert.Equal(t, fileKey, s.StoreKey("other", "a"))
+	assert.Equal(t, fileKey, s.StoreKey("other", "b"))
+
+	storeA, err := s.StoreFor("test", "a")
+	require.NoError(t, err)
+	defer storeA.Close()
+	storeB, err := s.StoreFor("test", "b")
+	require.NoError(t, err)
+	defer storeB.Close()
+
+	require.NoError(t, storeA.Set("key", "value"))
+	has, err := storeB.Has("key")
+	require.NoError(t, err)
+	assert.False(t, has, "inputs with different ids must not share state")
 }
 
 func TestOpenStateStore_DifferentPathsGetDifferentRegistries(t *testing.T) {
@@ -101,7 +148,7 @@ func TestOpenStateStore_DifferentPathsGetDifferentRegistries(t *testing.T) {
 	s2 := testOpenStore(t, dir2)
 
 	assert.NotSame(t, s1.shared, s2.shared, "stores with different paths should not share registries")
-	assert.NotEqual(t, s1.StoreKey(), s2.StoreKey(), "stores with different backends should have different keys")
+	assert.NotEqual(t, s1.StoreKey("", ""), s2.StoreKey("", ""), "stores with different backends should have different keys")
 
 	s1.Close()
 	s2.Close()

--- a/filebeat/input/filestream/environment_test.go
+++ b/filebeat/input/filestream/environment_test.go
@@ -196,7 +196,7 @@ func (e *inputTestingEnvironment) abspath(filename string) string {
 }
 
 func (e *inputTestingEnvironment) requireRegistryEntryCount(expectedCount int) {
-	inputStore, _ := e.stateStore.StoreFor("")
+	inputStore, _ := e.stateStore.StoreFor("", "")
 	defer inputStore.Close()
 
 	actual := 0
@@ -327,7 +327,7 @@ func (e *inputTestingEnvironment) requireNoEntryInRegistry(filename, inputID str
 		e.t.Fatalf("cannot stat file when cheking for offset: %+v", err)
 	}
 
-	inputStore, _ := e.stateStore.StoreFor("")
+	inputStore, _ := e.stateStore.StoreFor("", "")
 	defer inputStore.Close()
 	id := getIDFromPath(filepath, inputID, fi)
 
@@ -349,7 +349,7 @@ func (e *inputTestingEnvironment) requireOffsetInRegistryByID(key string, expect
 }
 
 func (e *inputTestingEnvironment) getRegistryState(key string) (registryEntry, error) {
-	inputStore, _ := e.stateStore.StoreFor("")
+	inputStore, _ := e.stateStore.StoreFor("", "")
 	defer inputStore.Close()
 
 	var entry registryEntry
@@ -388,44 +388,6 @@ func (e *inputTestingEnvironment) waitUntilEventCount(count int) {
 		events := e.pipeline.GetAllEvents()
 		require.Len(t, events, count, "unexpected number of events")
 	}, 2*time.Minute, 10*time.Millisecond)
-}
-
-// waitUntilEventCountCtx calls waitUntilEventCount, but fails if ctx is cancelled.
-func (e *inputTestingEnvironment) waitUntilEventCountCtx(ctx context.Context, count int) {
-	e.t.Helper()
-	ch := make(chan struct{})
-
-	go func() {
-		e.waitUntilEventCount(count)
-		ch <- struct{}{}
-	}()
-
-	select {
-	case <-ctx.Done():
-		logLines := map[string][]string{}
-		for _, evt := range e.pipeline.GetAllEvents() {
-			flat := evt.Fields.Flatten()
-			pathi, _ := flat.GetValue("log.file.path")
-			path, ok := pathi.(string)
-			if !ok {
-				e.t.Fatalf("waitUntilEventCountCtx: path is not a string: %v", pathi)
-			}
-			msgi, _ := flat.GetValue("message")
-			msg, ok := msgi.(string)
-			if !ok {
-				e.t.Fatalf("waitUntilEventCountCtx: message is not a string: %v", msgi)
-			}
-			logLines[path] = append(logLines[path], msg)
-		}
-
-		e.t.Fatalf("waitUntilEventCountCtx: %v. Want %d events, got %d: %v",
-			ctx.Err(),
-			count,
-			len(e.pipeline.GetAllEvents()),
-			logLines)
-	case <-ch:
-		return
-	}
 }
 
 // waitUntilAtLeastEventCount waits until at least count events arrive to the client.
@@ -555,11 +517,11 @@ func (s *testInputStore) Close() {
 	s.registry.Close()
 }
 
-func (s *testInputStore) StoreFor(string) (*statestore.Store, error) {
+func (s *testInputStore) StoreFor(_, _ string) (*statestore.Store, error) {
 	return s.registry.Get("filebeat")
 }
 
-func (s *testInputStore) StoreKey() string {
+func (s *testInputStore) StoreKey(_, _ string) string {
 	return fmt.Sprintf("test:%p", s.registry)
 }
 

--- a/filebeat/input/filestream/input_test.go
+++ b/filebeat/input/filestream/input_test.go
@@ -730,11 +730,11 @@ func (s *testStore) Close() {
 	s.registry.Close()
 }
 
-func (s *testStore) StoreFor(string) (*statestore.Store, error) {
+func (s *testStore) StoreFor(_, _ string) (*statestore.Store, error) {
 	return s.registry.Get("filestream-benchmark")
 }
 
-func (s *testStore) StoreKey() string {
+func (s *testStore) StoreKey(_, _ string) string {
 	return fmt.Sprintf("test:%p", s.registry)
 }
 

--- a/filebeat/input/filestream/internal/input-logfile/manager.go
+++ b/filebeat/input/filestream/internal/input-logfile/manager.go
@@ -343,7 +343,7 @@ func (cim *InputManager) acquireLease() (func(), bool) {
 	if closed {
 		return func() {}, false
 	}
-	_, release, ok := globalCache.Lease(cim.StateStore.StoreKey())
+	_, release, ok := globalCache.Lease(cim.StateStore.StoreKey("", ""))
 	return release, ok
 }
 

--- a/filebeat/input/filestream/internal/input-logfile/store.go
+++ b/filebeat/input/filestream/internal/input-logfile/store.go
@@ -159,7 +159,8 @@ var closeStore = (*store).close
 func openStore(log *logp.Logger, statestore statestore.States, prefix string) (*store, error) {
 	ok := false
 
-	persistentStore, err := statestore.StoreFor("")
+	// Empty arguments select the shared file store for filestream.
+	persistentStore, err := statestore.StoreFor("", "")
 	if err != nil {
 		return nil, err
 	}

--- a/filebeat/input/filestream/internal/input-logfile/store_cache.go
+++ b/filebeat/input/filestream/internal/input-logfile/store_cache.go
@@ -49,7 +49,7 @@ var globalCache = statemanager.NewCache[*cacheEntry](func(e *cacheEntry) {
 // first access. The returned release function must be called exactly once when
 // the caller is done with the entry.
 func acquireStore(logger *logp.Logger, states statestore.States, prefix string) (*cacheEntry, func(), error) {
-	key := states.StoreKey()
+	key := states.StoreKey("", "")
 	log := logger.
 		Named("filestream.store_cache").
 		WithLazy(zap.String("filestream_store_key", key))

--- a/filebeat/input/filestream/internal/input-logfile/store_cache_test.go
+++ b/filebeat/input/filestream/internal/input-logfile/store_cache_test.go
@@ -387,9 +387,9 @@ func newCountingStateStoreWithRegistry(key string, registry *statestore.Registry
 	return &countingStateStore{registry: registry, key: key}
 }
 
-func (s *countingStateStore) StoreKey() string { return s.key }
+func (s *countingStateStore) StoreKey(_, _ string) string { return s.key }
 
-func (s *countingStateStore) StoreFor(name string) (*statestore.Store, error) {
+func (s *countingStateStore) StoreFor(name, _ string) (*statestore.Store, error) {
 	s.storeForCalls.Add(1)
 	return s.registry.Get(name)
 }
@@ -414,7 +414,7 @@ func newBlockingStateStore(key string, firstStoreForError error) *blockingStateS
 	}
 }
 
-func (s *blockingStateStore) StoreFor(name string) (*statestore.Store, error) {
+func (s *blockingStateStore) StoreFor(name, _ string) (*statestore.Store, error) {
 	if s.storeForCalls.Add(1) == 1 {
 		close(s.firstStoreForStarted)
 		<-s.releaseFirstStoreFor

--- a/filebeat/input/filestream/internal/input-logfile/store_test.go
+++ b/filebeat/input/filestream/internal/input-logfile/store_test.go
@@ -748,8 +748,8 @@ type testStateStore struct {
 
 func (ts testStateStore) WithGCPeriod(d time.Duration) testStateStore { ts.GCPeriod = d; return ts }
 func (ts testStateStore) CleanupInterval() time.Duration              { return ts.GCPeriod }
-func (ts testStateStore) StoreKey() string                            { return fmt.Sprintf("test:%p", ts.Store) }
-func (ts testStateStore) StoreFor(string) (*statestore.Store, error) {
+func (ts testStateStore) StoreKey(_, _ string) string                 { return fmt.Sprintf("test:%p", ts.Store) }
+func (ts testStateStore) StoreFor(_, _ string) (*statestore.Store, error) {
 	if ts.Store == nil {
 		return nil, errors.New("no store configured")
 	}

--- a/filebeat/input/journald/environment_test.go
+++ b/filebeat/input/journald/environment_test.go
@@ -178,23 +178,6 @@ func (e *inputTestingEnvironment) waitUntilEventCount(count int) {
 	}, 5*time.Second, 10*time.Millisecond, &msg)
 }
 
-// waitUntilEventCount waits until total count events arrive to the client.
-func (e *inputTestingEnvironment) waitUntilEventsPublished(published int) {
-	e.t.Helper()
-	msg := strings.Builder{}
-	require.Eventually(e.t, func() bool {
-		sum := len(e.pipeline.GetAllEvents())
-		if sum >= published {
-			return true
-		}
-
-		msg.Reset()
-		fmt.Fprintf(&msg, "too few events; expected: %d, actual: %d", published, sum)
-
-		return false
-	}, 5*time.Second, 10*time.Millisecond, &msg)
-}
-
 func (e *inputTestingEnvironment) RequireStatuses(expected []statusUpdate) {
 	t := e.t
 	t.Helper()
@@ -230,11 +213,11 @@ func (s *testInputStore) Close() {
 	s.registry.Close()
 }
 
-func (s *testInputStore) StoreFor(string) (*statestore.Store, error) {
+func (s *testInputStore) StoreFor(_, _ string) (*statestore.Store, error) {
 	return s.registry.Get("filebeat")
 }
 
-func (s *testInputStore) StoreKey() string {
+func (s *testInputStore) StoreKey(_, _ string) string {
 	return fmt.Sprintf("test:%p", s.registry)
 }
 

--- a/filebeat/input/journald/input_filtering_test.go
+++ b/filebeat/input/journald/input_filtering_test.go
@@ -256,7 +256,7 @@ func TestInputSeek(t *testing.T) {
 			env := newInputTestingEnvironment(t)
 
 			if testCase.cursor != "" {
-				store, err := env.stateStore.StoreFor("")
+				store, err := env.stateStore.StoreFor("", "")
 				if err != nil {
 					t.Fatalf("failed to open store: %v", err)
 				}

--- a/filebeat/input/logv2/convert_test.go
+++ b/filebeat/input/logv2/convert_test.go
@@ -506,11 +506,11 @@ func (s *testInputStore) Close() {
 	s.registry.Close()
 }
 
-func (s *testInputStore) StoreFor(string) (*statestore.Store, error) {
+func (s *testInputStore) StoreFor(_, _ string) (*statestore.Store, error) {
 	return s.registry.Get("filebeat")
 }
 
-func (s *testInputStore) StoreKey() string {
+func (s *testInputStore) StoreKey(_, _ string) string {
 	return fmt.Sprintf("test:%p", s.registry)
 }
 

--- a/filebeat/input/v2/input-cursor/input.go
+++ b/filebeat/input/v2/input-cursor/input.go
@@ -62,6 +62,7 @@ type Input interface {
 type managedInput struct {
 	manager      *InputManager
 	userID       string
+	cacheKey     string
 	sources      []Source
 	input        Input
 	cleanTimeout time.Duration
@@ -123,7 +124,7 @@ func (inp *managedInput) Run(
 	// Acquire a lease on the shared store. This increments the cache user
 	// count so the store cannot be drained by a concurrent Close() call
 	// until all source goroutines have finished and leaseRelease is called.
-	store, leaseRelease, ok := inp.manager.acquireLease()
+	store, leaseRelease, ok := inp.manager.acquireLease(inp.cacheKey)
 	if !ok {
 		return errors.New("input manager store is not available")
 	}
@@ -190,7 +191,7 @@ func (inp *managedInput) runSource(
 	defer client.Close()
 
 	resourceKey := inp.createSourceID(source)
-	resource, err := inp.manager.lock(ctx, resourceKey)
+	resource, err := lock(ctx, store, resourceKey)
 	if err != nil {
 		return err
 	}

--- a/filebeat/input/v2/input-cursor/manager.go
+++ b/filebeat/input/v2/input-cursor/manager.go
@@ -30,10 +30,9 @@ import (
 	"github.com/elastic/elastic-agent-libs/logp"
 )
 
-// globalCache is the process-wide singleton store for cursor inputs.
-// All InputManager instances that share a (backend, type) pair use one store
-// and one background cleaner goroutine. The store is closed only after the
-// last manager releases its reference.
+// globalCache shares cursor stores across the process.
+// Managers with the same cache key share one store and one background cleaner.
+// The cache closes the store after all managers and running inputs release it.
 var globalCache = statemanager.NewCache[*store](func(s *store) { s.Release() })
 
 // InputManager is used to create, manage, and coordinate stateful inputs and
@@ -67,13 +66,11 @@ type InputManager struct {
 	// that will be used to collect events from each source.
 	Configure func(cfg *conf.C, log *logp.Logger) ([]Source, Input, error)
 
-	// mu guards store, release, cacheKey, and closed. store, release, and
-	// cacheKey are set once on the first successful Create and store/release
-	// are cleared on Close.
+	// mu protects releases and closed from concurrent access.
+	// releases holds one globalCache release function for each store this manager uses.
+	// Close clears releases.
 	mu       sync.Mutex
-	store    *store
-	release  func()
-	cacheKey string
+	releases map[string]func()
 	closed   bool
 }
 
@@ -89,88 +86,80 @@ var (
 	errNoInputRunner      = errors.New("no input runner available")
 )
 
-// ensureSetup opens the shared store on first call. It must NOT be called
-// with cim.mu held: it releases and re-acquires the lock around the blocking
-// globalCache.Acquire call so that a concurrent Close() can always proceed.
-func (cim *InputManager) ensureSetup(inputID string) error {
+// cacheKey identifies the cursor store for this input type and ID.
+// The key includes the type because each cursor store loads state for one type.
+func (cim *InputManager) cacheKey(inputID string) string {
+	return cim.StateStore.StoreKey(cim.Type, inputID) + "::" + cim.Type
+}
+
+// ensureSetup opens or reuses the store for inputID and returns its cache key.
+// Call ensureSetup without holding cim.mu.
+// It unlocks cim.mu before globalCache.Acquire, so Close can proceed while Acquire waits.
+func (cim *InputManager) ensureSetup(inputID string) (string, error) {
 	cim.mu.Lock()
-	if cim.store != nil {
-		cim.mu.Unlock()
-		return nil
-	}
 	if cim.closed {
 		cim.mu.Unlock()
-		return errors.New("input manager is closed")
+		return "", errors.New("input manager is closed")
 	}
 	if cim.DefaultCleanTimeout <= 0 {
 		cim.DefaultCleanTimeout = 30 * time.Minute
 	}
+	key := cim.cacheKey(inputID)
+	if _, ok := cim.releases[key]; ok {
+		cim.mu.Unlock()
+		return key, nil
+	}
 	log := cim.Logger.With("input_type", cim.Type)
-	key := cim.StateStore.StoreKey() + "::" + cim.Type
-	cim.cacheKey = key
 	interval := cim.StateStore.CleanupInterval()
 	if interval <= 0 {
 		interval = 5 * time.Minute
 	}
 	cim.mu.Unlock()
 
-	var runFn func(context.Context, *store)
-	if interval > 0 {
-		runFn = func(ctx context.Context, s *store) {
-			runCleaner(ctx, log, s, interval)
-		}
-	}
-
-	// Acquire the store without holding cim.mu so that a concurrent Close()
-	// or another Create() can proceed while this potentially-slow call runs.
-	s, release, err := globalCache.Acquire(
+	_, release, err := globalCache.Acquire(
 		key,
 		func() (*store, error) {
 			return openStore(log, cim.StateStore, cim.Type, inputID, true)
 		},
-		runFn,
+		func(ctx context.Context, s *store) {
+			runCleaner(ctx, log, s, interval)
+		},
 		nil,
 		nil,
 	)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	cim.mu.Lock()
+	defer cim.mu.Unlock()
 	if cim.closed {
-		cim.mu.Unlock()
 		release()
-		return errors.New("input manager is closed")
+		return "", errors.New("input manager is closed")
 	}
-	if cim.store == nil {
-		s.Retain() // InputManager holds its own reference to keep the store alive.
-		cim.store = s
-		cim.release = release
-	} else {
-		// Another Create() won the race; release the redundant reference.
+	if _, ok := cim.releases[key]; ok {
+		// Another Create already added this key. Release the extra reference.
 		release()
+		return key, nil
 	}
-	cim.mu.Unlock()
-	return nil
+	if cim.releases == nil {
+		cim.releases = make(map[string]func())
+	}
+	cim.releases[key] = release
+	return key, nil
 }
 
-// Close releases the manager's reference to the shared store. When the last
-// manager sharing a (backend, type) key releases, the background cleaner is
-// stopped and the store is closed. Call after all inputs managed by this
-// manager have stopped.
+// Close releases all stores that this manager uses.
+// After the last user releases a store, the cache stops its cleaner and closes it.
+// Call Close after all inputs for this manager stop.
 func (cim *InputManager) Close() {
 	cim.mu.Lock()
 	cim.closed = true
-	s := cim.store
-	release := cim.release
-	cim.release = nil
-	cim.store = nil
+	releases := cim.releases
+	cim.releases = nil
 	cim.mu.Unlock()
-	if s != nil {
-		s.Release() // Drop the InputManager's own reference.
-	}
-	if release != nil {
-		release() // Drop the globalCache reference; closes the store when the last holder releases.
+	for _, release := range releases {
+		release()
 	}
 }
 
@@ -185,7 +174,8 @@ func (cim *InputManager) Create(config *conf.C) (v2.Input, error) {
 		return nil, err
 	}
 
-	if err := cim.ensureSetup(settings.ID); err != nil {
+	cacheKey, err := cim.ensureSetup(settings.ID)
+	if err != nil {
 		return nil, err
 	}
 
@@ -203,38 +193,29 @@ func (cim *InputManager) Create(config *conf.C) (v2.Input, error) {
 	return &managedInput{
 		manager:      cim,
 		userID:       settings.ID,
+		cacheKey:     cacheKey,
 		sources:      sources,
 		input:        inp,
 		cleanTimeout: settings.CleanInactive,
 	}, nil
 }
 
-// acquireLease increments the globalCache user count for this manager's key,
-// preventing the cache from draining the store while the caller is active.
-// Returns ok=false if the cache entry is not active (manager not yet set up or
-// already closed). The returned release function must be called exactly once.
-func (cim *InputManager) acquireLease() (*store, func(), bool) {
+// acquireLease keeps the store open while the caller uses it.
+// It returns ok=false if the manager is closed or the cache entry is inactive.
+// Call the returned release function exactly once.
+func (cim *InputManager) acquireLease(cacheKey string) (*store, func(), bool) {
 	cim.mu.Lock()
-	key := cim.cacheKey
 	closed := cim.closed
 	cim.mu.Unlock()
-	if key == "" || closed {
+	if closed {
 		return nil, func() {}, false
 	}
-	return globalCache.Lease(key)
+	return globalCache.Lease(cacheKey)
 }
 
-// lock locks a key for exclusive access and returns a resource that can be used to modify
-// the cursor state and unlock the key.
-// The store is guaranteed alive for the duration of this call because the InputManager holds
-// its own reference (acquired in ensureSetup, released in Close).
-func (cim *InputManager) lock(ctx v2.Context, key string) (*resource, error) {
-	cim.mu.Lock()
-	store := cim.store
-	cim.mu.Unlock()
-	if store == nil {
-		return nil, errors.New("input manager is closed")
-	}
+// lock gives the caller exclusive access to the cursor state for key.
+// The caller must hold a lease to keep store open until it releases the resource.
+func lock(ctx v2.Context, store *store, key string) (*resource, error) {
 	resource := store.Get(key)
 	err := lockResource(ctx.Logger, resource, ctx.Cancelation)
 	if err != nil {

--- a/filebeat/input/v2/input-cursor/manager_test.go
+++ b/filebeat/input/v2/input-cursor/manager_test.go
@@ -35,7 +35,6 @@ import (
 
 	input "github.com/elastic/beats/v7/filebeat/input/v2"
 	"github.com/elastic/beats/v7/libbeat/beat"
-	"github.com/elastic/beats/v7/libbeat/features"
 	pubtest "github.com/elastic/beats/v7/libbeat/publisher/testing"
 	"github.com/elastic/beats/v7/libbeat/statestore"
 	"github.com/elastic/beats/v7/libbeat/tests/resources"
@@ -63,13 +62,13 @@ func TestManager_Init(t *testing.T) {
 
 		manager := cleanerManager(t, createSampleStore(t, nil))
 
-		require.Nil(t, manager.store, "store must not be opened before Create")
+		require.Empty(t, manager.releases, "store must not be opened before Create")
 		_, err := goroutines.WaitUntilOriginalCount()
 		require.NoError(t, err, "no goroutine must be started before Create")
 
 		_, err = manager.Create(conf.MustNewConfigFrom(map[string]any{"id": "my-input-id"}))
 		require.NoError(t, err)
-		require.NotNil(t, manager.store, "Create must open the registry store")
+		require.Len(t, manager.releases, 1, "Create must open the registry store")
 	})
 
 	// The store is opened with the input ID, which is only known once a config
@@ -84,7 +83,7 @@ func TestManager_Init(t *testing.T) {
 		_, err := manager.Create(conf.MustNewConfigFrom(map[string]any{"id": "my-input-id"}))
 		require.NoError(t, err)
 
-		snap := storeMemorySnapshot(manager.store)
+		snap := storeMemorySnapshot(leasedStore(t, manager, "my-input-id"))
 		assert.Contains(t, snap, "test::mykey")
 		assert.Equal(t, "value1", snap["test::mykey"].Cursor)
 	})
@@ -123,9 +122,8 @@ func TestManager_Init(t *testing.T) {
 		}
 	})
 
-	// Two reload paths — static config, central management, autodiscovery — can
-	// create inputs of one type concurrently, and each of those is now what
-	// opens the store and starts the cleaner.
+	// Configuration reloads can create inputs of one type concurrently.
+	// With file storage, all input IDs use the same key and must share one store.
 	t.Run("concurrent Create opens one store and starts one cleaner", func(t *testing.T) {
 		manager := cleanerManager(t, createSampleStore(t, nil))
 
@@ -140,8 +138,18 @@ func TestManager_Init(t *testing.T) {
 		}
 		wg.Wait()
 
-		require.NotNil(t, manager.store)
+		require.Len(t, manager.releases, 1)
 	})
+}
+
+// leasedStore returns the store for inputID and keeps it open until the test ends.
+func leasedStore(t *testing.T, manager *InputManager, inputID string) *store {
+	t.Helper()
+
+	s, release, ok := globalCache.Lease(manager.cacheKey(inputID))
+	require.True(t, ok, "no active store for input id %q", inputID)
+	t.Cleanup(release)
+	return s
 }
 
 // cleanerManager builds an InputManager whose Create succeeds, with a clean
@@ -162,32 +170,53 @@ func cleanerManager(t *testing.T, store statestore.States) *InputManager {
 	return manager
 }
 
-// TestManager_InitDefersStoreForES covers the Elasticsearch-backed store, which
-// has always been opened from Create because it needs the input ID. All input
-// types now take that path; this pins that the ES-specific store still reaches
-// it, since SetID is a no-op for the file-backed backends and only matters here.
-func TestManager_InitDefersStoreForES(t *testing.T) {
-	t.Setenv("AGENTLESS_ELASTICSEARCH_STATE_STORE_INPUT_TYPES", "test")
-	features.ReinitForTest()
-	t.Cleanup(func() { features.ReinitForTest() }) // restore after test
+// Elasticsearch inputs with different IDs must use separate cursor stores,
+// even when they have the same input type.
+func TestManager_ESStorePerInputID(t *testing.T) {
+	t.Run("one manager keeps a store per input id", func(t *testing.T) {
+		stateStore := createESStore(t)
+		manager := cleanerManager(t, stateStore)
 
-	stateStore := createSampleStore(t, map[string]state{
-		"test::mykey": {Cursor: "value1"},
+		for _, id := range []string{"input-a", "input-b"} {
+			_, err := manager.Create(conf.MustNewConfigFrom(map[string]any{"id": id}))
+			require.NoError(t, err)
+		}
+		require.Len(t, manager.releases, 2)
+
+		// State written to one input's store must not appear in the other store.
+		storeA := leasedStore(t, manager, "input-a")
+		storeA.UpdateTTL(storeA.Get("test::input-a::mykey"), time.Minute)
+
+		assert.Contains(t, stateStore.snapshotFor(t, "input-a"), "test::input-a::mykey")
+		assert.Empty(t, stateStore.snapshotFor(t, "input-b"))
 	})
 
-	manager := cleanerManager(t, stateStore)
+	t.Run("managers sharing an input id share one store", func(t *testing.T) {
+		stateStore := createESStore(t)
+		first := cleanerManager(t, stateStore)
+		second := cleanerManager(t, stateStore)
 
-	require.Nil(t, manager.store, "store should be nil before Create()")
+		for _, manager := range []*InputManager{first, second} {
+			_, err := manager.Create(conf.MustNewConfigFrom(map[string]any{"id": "shared"}))
+			require.NoError(t, err)
+		}
 
-	_, err := manager.Create(conf.MustNewConfigFrom(map[string]any{
-		"id": "my-input-id",
-	}))
-	require.NoError(t, err)
-	require.NotNil(t, manager.store, "store should be created after Create()")
+		assert.Same(t, leasedStore(t, first, "shared"), leasedStore(t, second, "shared"))
+	})
 
-	snap := storeMemorySnapshot(manager.store)
-	assert.Contains(t, snap, "test::mykey")
-	assert.Equal(t, "value1", snap["test::mykey"].Cursor)
+	t.Run("Close releases every store the manager opened", func(t *testing.T) {
+		before := globalCache.Len()
+		manager := cleanerManager(t, createESStore(t))
+
+		for _, id := range []string{"input-a", "input-b"} {
+			_, err := manager.Create(conf.MustNewConfigFrom(map[string]any{"id": id}))
+			require.NoError(t, err)
+		}
+		require.Equal(t, before+2, globalCache.Len())
+
+		manager.Close()
+		assert.Equal(t, before, globalCache.Len())
+	})
 }
 
 func TestManager_Create(t *testing.T) {

--- a/filebeat/input/v2/input-cursor/store.go
+++ b/filebeat/input/v2/input-cursor/store.go
@@ -131,12 +131,11 @@ func openStore(log *logp.Logger, statestore statestore.States, prefix string, in
 	ok := false
 
 	log.Debugf("input-cursor::openStore: prefix: %v inputID: %s", prefix, inputID)
-	persistentStore, err := statestore.StoreFor(prefix)
+	persistentStore, err := statestore.StoreFor(prefix, inputID)
 	if err != nil {
 		return nil, err
 	}
 	defer cleanup.IfNot(&ok, func() { persistentStore.Close() })
-	persistentStore.SetID(inputID)
 
 	states, err := readStates(log, persistentStore, prefix, fullInit)
 	if err != nil {
@@ -151,7 +150,6 @@ func openStore(log *logp.Logger, statestore statestore.States, prefix string, in
 	}, nil
 }
 
-func (s *store) Retain() { s.refCount.Retain() }
 func (s *store) Release() {
 	if s.refCount.Release() {
 		closeStore(s)

--- a/filebeat/input/v2/input-cursor/store_test.go
+++ b/filebeat/input/v2/input-cursor/store_test.go
@@ -261,6 +261,39 @@ func createSampleStore(t *testing.T, data map[string]state) testStateStore {
 	}
 }
 
+var _ statestore.States = (*esStateStore)(nil)
+
+// esStateStore uses a separate store for each input ID, as Elasticsearch does.
+type esStateStore struct {
+	registry *statestore.Registry
+}
+
+func createESStore(t *testing.T) *esStateStore {
+	registry := statestore.NewRegistry(storetest.NewMemoryStoreBackend())
+	t.Cleanup(func() { registry.Close() })
+	return &esStateStore{registry: registry}
+}
+
+func (ts *esStateStore) CleanupInterval() time.Duration { return 0 }
+func (ts *esStateStore) StoreKey(_, id string) string {
+	return fmt.Sprintf("es:%p::%s", ts.registry, id)
+}
+
+func (ts *esStateStore) StoreFor(_, id string) (*statestore.Store, error) {
+	return ts.registry.Get(id)
+}
+
+// snapshotFor returns the saved state for the input ID.
+func (ts *esStateStore) snapshotFor(t *testing.T, id string) map[string]state {
+	t.Helper()
+
+	store, err := ts.StoreFor("", id)
+	require.NoError(t, err)
+	defer store.Close()
+
+	return testStateStore{Store: store}.snapshot()
+}
+
 var _ statestore.States = testStateStore{}
 
 type testStateStore struct {
@@ -270,8 +303,8 @@ type testStateStore struct {
 
 func (ts testStateStore) WithGCPeriod(d time.Duration) testStateStore { ts.GCPeriod = d; return ts }
 func (ts testStateStore) CleanupInterval() time.Duration              { return ts.GCPeriod }
-func (ts testStateStore) StoreKey() string                            { return fmt.Sprintf("test:%p", ts.Store) }
-func (ts testStateStore) StoreFor(string) (*statestore.Store, error) {
+func (ts testStateStore) StoreKey(_, _ string) string                 { return fmt.Sprintf("test:%p", ts.Store) }
+func (ts testStateStore) StoreFor(_, _ string) (*statestore.Store, error) {
 	if ts.Store == nil {
 		return nil, errors.New("no store configured")
 	}

--- a/filebeat/registrar/registrar.go
+++ b/filebeat/registrar/registrar.go
@@ -68,7 +68,7 @@ const fileStatePrefix = "filebeat::logs::"
 // New creates a new Registrar instance, updating the registry file on
 // `file.State` updates. New fails if the file can not be opened or created.
 func New(stateStore statestore.States, out successLogger, flushTimeout time.Duration, logger *logp.Logger) (*Registrar, error) {
-	store, err := stateStore.StoreFor("")
+	store, err := stateStore.StoreFor("", "")
 	if err != nil {
 		return nil, err
 	}

--- a/filebeat/registrar/registrar_test.go
+++ b/filebeat/registrar/registrar_test.go
@@ -43,11 +43,11 @@ type testStateStore struct {
 	registry *statestore.Registry
 }
 
-func (s *testStateStore) StoreFor(string) (*statestore.Store, error) {
+func (s *testStateStore) StoreFor(_, _ string) (*statestore.Store, error) {
 	return s.registry.Get(testStoreName)
 }
 
-func (s *testStateStore) StoreKey() string {
+func (s *testStateStore) StoreKey(_, _ string) string {
 	return fmt.Sprintf("test:%p", s.registry)
 }
 

--- a/libbeat/statestore/backend/backend.go
+++ b/libbeat/statestore/backend/backend.go
@@ -68,10 +68,6 @@ type Store interface {
 	// is assumed to be invalidated once fn returns
 	// The loop shall return if fn returns an error or false.
 	Each(fn func(string, ValueDecoder) (bool, error)) error
-
-	// SetID Sets the store ID when the full input configuration is acquired.
-	// This is needed in order to support Elasticsearch state store naming convention based on the input ID.
-	SetID(id string)
 }
 
 type WithESStateStoreExtension interface {

--- a/libbeat/statestore/backend/es/base.go
+++ b/libbeat/statestore/backend/es/base.go
@@ -181,17 +181,6 @@ func (b *baseStore) Close() error {
 	return nil
 }
 
-func (b *baseStore) SetID(id string) {
-	if b == nil {
-		return
-	}
-
-	if id == "" {
-		return
-	}
-	b.index = renderIndexName(id)
-}
-
 type queryResult struct {
 	Found  bool `json:"found"`
 	Source struct {

--- a/libbeat/statestore/backend/es/store.go
+++ b/libbeat/statestore/backend/es/store.go
@@ -51,7 +51,6 @@ type store struct {
 	mx     sync.Mutex
 	cli    *eslegclient.Connection
 	cliErr error
-	id     string
 
 	base *baseStore
 }
@@ -89,20 +88,6 @@ func (s *store) waitReady() error {
 	case <-s.chReady:
 		return s.cliErr
 	}
-}
-
-func (s *store) SetID(id string) {
-	s.mx.Lock()
-	s.id = id
-	s.mx.Unlock()
-
-	if err := s.waitReady(); err != nil {
-		return
-	}
-	s.mx.Lock()
-	defer s.mx.Unlock()
-
-	s.base.SetID(s.id)
 }
 
 func (s *store) Close() error {
@@ -188,9 +173,6 @@ func (s *store) configure(ctx context.Context, c *conf.C) {
 		s.cliErr = err
 	} else {
 		s.base = NewStore(ctx, s.log, cli, s.name)
-		if s.id != "" {
-			s.base.SetID(s.id)
-		}
 		s.cli = cli
 	}
 

--- a/libbeat/statestore/backend/memlog/store.go
+++ b/libbeat/statestore/backend/memlog/store.go
@@ -285,10 +285,6 @@ func (m *memstore) Remove(key string) bool {
 	return true
 }
 
-func (s *store) SetID(_ string) {
-	// NOOP
-}
-
 func (e entry) Decode(to any) error {
 	return typeconv.Convert(to, e.value)
 }

--- a/libbeat/statestore/backend/otelstorage/store_from_client.go
+++ b/libbeat/statestore/backend/otelstorage/store_from_client.go
@@ -111,10 +111,6 @@ func (s *storeFromClient) Each(fn func(string, backend.ValueDecoder) (bool, erro
 	})
 }
 
-func (s *storeFromClient) SetID(_ string) {
-	// NOOP
-}
-
 type jsonValueDecoder struct {
 	raw json.RawMessage
 }

--- a/libbeat/statestore/mock_test.go
+++ b/libbeat/statestore/mock_test.go
@@ -93,6 +93,3 @@ func (m *mockStore) Each(fn func(string, backend.ValueDecoder) (bool, error)) er
 	args := m.Called(fn)
 	return args.Error(0)
 }
-
-func (m *mockStore) SetID(_ string) {
-}

--- a/libbeat/statestore/store.go
+++ b/libbeat/statestore/store.go
@@ -26,18 +26,17 @@ import (
 )
 
 // States is a collection of states backed by one or more persistent stores
-// that may be differentiated by input type.
+// that may be differentiated by input type and ID.
 type States interface {
 	// StoreKey returns a process-wide identifier for the persistent backend
 	// selected by StoreFor. Equal keys identify the same backend.
-	StoreKey() string
+	StoreKey(typ, id string) string
 
-	// StoreFor returns the storage registry for the given type.
-	// The value of typ is expected to have been obtained from
-	// cursor.InputManager.Type and represents the input type.
-	// Whether the receiver considers the value of typ is
+	// StoreFor returns the store for the input type and ID.
+	// Implementations can ignore typ or id if they share a store across inputs.
+	// Whether the receiver considers the value of typ and ID is
 	// implementation dependent.
-	StoreFor(typ string) (*Store, error)
+	StoreFor(typ, id string) (*Store, error)
 
 	// CleanupInterval returns the time between garbage collection
 	// runs for the stores owned by the States.
@@ -79,10 +78,6 @@ func newStore(shared *sharedStore) *Store {
 	return &Store{
 		shared: shared,
 	}
-}
-
-func (s *Store) SetID(id string) {
-	s.shared.backend.SetID(id)
 }
 
 // Close deactivates the current store. No new transacation can be generated.

--- a/libbeat/statestore/storetest/storetest.go
+++ b/libbeat/statestore/storetest/storetest.go
@@ -213,7 +213,3 @@ func (s *MapStore) Each(fn func(string, backend.ValueDecoder) (bool, error)) err
 func (d valueUnpacker) Decode(to any) error {
 	return typeconv.Convert(to, d.from)
 }
-
-func (s *MapStore) SetID(_ string) {
-	// NOOP
-}

--- a/x-pack/filebeat/input/awscloudwatch/state_handler.go
+++ b/x-pack/filebeat/input/awscloudwatch/state_handler.go
@@ -49,7 +49,7 @@ func newStateHandler(log *logp.Logger, cfg config, store statestore.States) (*st
 	if err != nil {
 		return nil, err
 	}
-	st, err := store.StoreFor("")
+	st, err := store.StoreFor("", "")
 	if err != nil {
 		return nil, fmt.Errorf("error accessing persistence store: %w", err)
 	}

--- a/x-pack/filebeat/input/awscloudwatch/state_handler_test.go
+++ b/x-pack/filebeat/input/awscloudwatch/state_handler_test.go
@@ -214,11 +214,11 @@ type testInputStore struct {
 	registry *statestore.Registry
 }
 
-func (s *testInputStore) StoreFor(typ string) (*statestore.Store, error) {
+func (s *testInputStore) StoreFor(typ, _ string) (*statestore.Store, error) {
 	return s.registry.Get(typ)
 }
 
-func (s *testInputStore) StoreKey() string {
+func (s *testInputStore) StoreKey(_, _ string) string {
 	return fmt.Sprintf("test:%p", s.registry)
 }
 

--- a/x-pack/filebeat/input/awss3/states.go
+++ b/x-pack/filebeat/input/awss3/states.go
@@ -61,7 +61,7 @@ func newStateRegistry(log *logp.Logger, stateStore statestore.States, bucket str
 	if lexicographicalOrdering {
 		storeKey = inputName
 	}
-	store, err := stateStore.StoreFor(storeKey)
+	store, err := stateStore.StoreFor(storeKey, "")
 	if err != nil {
 		return nil, fmt.Errorf("can't access persistent store: %w", err)
 	}

--- a/x-pack/filebeat/input/awss3/states_bucket_scoping_test.go
+++ b/x-pack/filebeat/input/awss3/states_bucket_scoping_test.go
@@ -24,8 +24,10 @@ type diskBackedStatestore struct {
 	registry *statestore.Registry
 }
 
-func (s *diskBackedStatestore) StoreKey() string { return fmt.Sprintf("disk:%p", s.registry) }
-func (s *diskBackedStatestore) StoreFor(string) (*statestore.Store, error) {
+func (s *diskBackedStatestore) StoreKey(_, _ string) string {
+	return fmt.Sprintf("disk:%p", s.registry)
+}
+func (s *diskBackedStatestore) StoreFor(_, _ string) (*statestore.Store, error) {
 	return s.registry.Get("filebeat")
 }
 func (s *diskBackedStatestore) CleanupInterval() time.Duration { return 24 * time.Hour }

--- a/x-pack/filebeat/input/awss3/states_test.go
+++ b/x-pack/filebeat/input/awss3/states_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/elastic/beats/v7/libbeat/statestore"
 	"github.com/elastic/beats/v7/libbeat/statestore/storetest"
-	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/logp/logptest"
 
 	"github.com/stretchr/testify/assert"
@@ -398,7 +397,7 @@ func TestLexicographicalStateRegistry_TailTracking(t *testing.T) {
 }
 
 func TestLexicographicalStateRegistry_CleanUp(t *testing.T) {
-	logger := logp.NewLogger("lexicographical-registry-test")
+	logger := logptest.NewTestingLogger(t, "lexicographical-registry-test")
 
 	t.Run("CleanUp preserves newest state", func(t *testing.T) {
 		store := openTestStatestore()
@@ -456,12 +455,12 @@ func TestLexicographicalStateRegistry_CleanUp(t *testing.T) {
 		require.True(t, registry.IsProcessed(stateA.IDWithLexicographicalOrdering()))
 		require.False(t, registry.IsProcessed(stateB.IDWithLexicographicalOrdering()))
 		require.False(t, registry.IsProcessed(stateC.IDWithLexicographicalOrdering()))
-		require.Equal(t, 1, len(lexicoRegistry.states))
+		require.Len(t, lexicoRegistry.states, 1)
 	})
 }
 
 func TestLexicographicalStateRegistry_TrimsOnLoad(t *testing.T) {
-	logger := logp.NewLogger("lexicographical-registry-test")
+	logger := logptest.NewTestingLogger(t, "lexicographical-registry-test")
 	store := openTestStatestore()
 
 	registry1, err := newStateRegistry(logger, store, "", "", false, 0)
@@ -496,7 +495,7 @@ func TestLexicographicalStateRegistry_TrimsOnLoad(t *testing.T) {
 	lexicoRegistry2 := registry2.(*lexicographicalStateRegistry) //nolint:errcheck // type assertion is safe in test
 
 	// Should only have the 2 newest (lexicographically greatest) states: c and d
-	require.Equal(t, capacity, len(lexicoRegistry2.states))
+	require.Len(t, lexicoRegistry2.states, capacity)
 	require.False(t, registry2.IsProcessed(stateA.IDWithLexicographicalOrdering()))
 	require.False(t, registry2.IsProcessed(stateB.IDWithLexicographicalOrdering()))
 	require.True(t, registry2.IsProcessed(stateC.IDWithLexicographicalOrdering()))
@@ -512,7 +511,7 @@ func TestLexicographicalStateRegistry_TrimsOnLoad(t *testing.T) {
 }
 
 func TestLexicographicalStateRegistry_HeapOrder(t *testing.T) {
-	logger := logp.NewLogger("lexicographical-registry-test")
+	logger := logptest.NewTestingLogger(t, "lexicographical-registry-test")
 	store := openTestStatestore()
 	registry, err := newStateRegistry(logger, store, "", "", true, 10)
 	require.NoError(t, err)
@@ -568,7 +567,7 @@ func TestNewStateRegistry(t *testing.T) {
 // ============================================================================
 
 func TestStateRegistryBehaviorDifferences(t *testing.T) {
-	logger := logp.NewLogger("state-registry-diff-test")
+	logger := logptest.NewTestingLogger(t, "state-registry-diff-test")
 
 	t.Run("ID format differs between implementations", func(t *testing.T) {
 		normalStore := openTestStatestore()
@@ -655,7 +654,7 @@ func TestStateRegistryBehaviorDifferences(t *testing.T) {
 }
 
 func TestStatesStoreForRouting(t *testing.T) {
-	logger := logp.NewLogger("states-store-routing-test")
+	logger := logptest.NewTestingLogger(t, "states-store-routing-test")
 
 	t.Run("lexicographical ordering passes aws-s3 to StoreFor", func(t *testing.T) {
 		store := &trackingInputStore{
@@ -680,7 +679,7 @@ func TestStatesStoreForRouting(t *testing.T) {
 		_, err := newStateRegistry(logger, store, "", "", false, 0)
 		require.NoError(t, err)
 
-		require.Equal(t, "", store.lastStoreForType, "StoreFor should be called with empty string when lexicographical ordering is disabled")
+		require.Empty(t, store.lastStoreForType, "StoreFor should be called with empty string when lexicographical ordering is disabled")
 	})
 }
 
@@ -696,9 +695,9 @@ type trackingInputStore struct {
 	lastStoreForType string
 }
 
-func (s *trackingInputStore) StoreFor(typ string) (*statestore.Store, error) {
+func (s *trackingInputStore) StoreFor(typ, id string) (*statestore.Store, error) {
 	s.lastStoreForType = typ
-	return s.testInputStore.StoreFor(typ)
+	return s.testInputStore.StoreFor(typ, id)
 }
 
 func openTestStatestore() statestore.States {
@@ -711,11 +710,11 @@ func (s *testInputStore) Close() {
 	_ = s.registry.Close()
 }
 
-func (s *testInputStore) StoreFor(string) (*statestore.Store, error) {
+func (s *testInputStore) StoreFor(_, _ string) (*statestore.Store, error) {
 	return s.registry.Get("filebeat")
 }
 
-func (s *testInputStore) StoreKey() string {
+func (s *testInputStore) StoreKey(_, _ string) string {
 	return fmt.Sprintf("test:%p", s.registry)
 }
 

--- a/x-pack/filebeat/input/entityanalytics/es_integration_test.go
+++ b/x-pack/filebeat/input/entityanalytics/es_integration_test.go
@@ -244,7 +244,6 @@ func newESStore(t *testing.T) (*statestore.Store, *eslegclient.Connection, strin
 	if err != nil {
 		t.Fatalf("registry Get: %v", err)
 	}
-	s.SetID(inputID)
 	t.Cleanup(func() {
 		s.Close()
 		// Clean up the test index.

--- a/x-pack/filebeat/input/entityanalytics/internal/kvstore/statestoreadapter.go
+++ b/x-pack/filebeat/input/entityanalytics/internal/kvstore/statestoreadapter.go
@@ -19,9 +19,6 @@ var _ entcollect.Store = (*StateStoreAdapter)(nil)
 // StateStoreAdapter wraps a *statestore.Store to satisfy the
 // entcollect.Store interface. It is used when the ES-backed state
 // store is enabled for agentless deployments.
-//
-// Callers must call store.SetID before constructing the adapter to
-// ensure per-input isolation in the ES backend.
 type StateStoreAdapter struct {
 	store *statestore.Store
 }
@@ -91,8 +88,7 @@ func (a *StateStoreAdapter) Each(fn func(key string, decode func(any) error) (bo
 // propagates a formatted error containing "404 Not Found" (see
 // libbeat/statestore/backend/es/base.go Remove). We match both.
 func isKeyUnknown(err error) bool {
-	var opErr *statestore.ErrorOperation
-	if errors.As(err, &opErr) {
+	if opErr, ok := errors.AsType[*statestore.ErrorOperation](err); ok {
 		cause := opErr.Unwrap()
 		if cause == nil {
 			return false

--- a/x-pack/filebeat/input/entityanalytics/internal/kvstore/statestoreadapter_test.go
+++ b/x-pack/filebeat/input/entityanalytics/internal/kvstore/statestoreadapter_test.go
@@ -218,8 +218,6 @@ func (s *testBackendStore) Each(fn func(string, backend.ValueDecoder) (bool, err
 	return nil
 }
 
-func (s *testBackendStore) SetID(_ string) {}
-
 type jsonDecoder struct {
 	raw []byte
 }

--- a/x-pack/filebeat/input/entityanalytics/minimal.go
+++ b/x-pack/filebeat/input/entityanalytics/minimal.go
@@ -215,12 +215,11 @@ type esSyncer struct {
 }
 
 func (n *minimalStateInput) newESSyncer(runCtx v2.Context, log *logp.Logger) (*esSyncer, error) {
-	s, err := n.store.StoreFor(Name)
+	s, err := n.store.StoreFor(Name, runCtx.ID)
 	if err != nil {
 		return nil, fmt.Errorf("unable to open ES state store: %w", err)
 	}
-	s.SetID(runCtx.ID)
-	log.Infof("Using Elasticsearch-backed state store (index: agentless-state-%s)", runCtx.ID)
+	log.Info("Using Elasticsearch-backed state store")
 	return &esSyncer{store: s}, nil
 }
 

--- a/x-pack/filebeat/input/httpjson/redirect.go
+++ b/x-pack/filebeat/input/httpjson/redirect.go
@@ -57,13 +57,12 @@ func (m InputManager) migrateCursor(src, dst *conf.C) {
 	if err != nil {
 		return
 	}
-	store, err := m.cursor.StateStore.StoreFor("httpjson")
+	store, err := m.cursor.StateStore.StoreFor("httpjson", id)
 	if err != nil {
 		m.cursor.Logger.Warnw("cursor migration: cannot open store", "error", err)
 		return
 	}
 	defer store.Close()
-	store.SetID(id)
 
 	key := cursorKey("httpjson", id, u.String())
 	var entry map[string]any

--- a/x-pack/filebeat/input/httpjson/redirect_test.go
+++ b/x-pack/filebeat/input/httpjson/redirect_test.go
@@ -5,9 +5,7 @@
 package httpjson
 
 import (
-	"encoding/json"
 	"fmt"
-	"sync"
 	"testing"
 	"time"
 
@@ -16,7 +14,6 @@ import (
 	v2 "github.com/elastic/beats/v7/filebeat/input/v2"
 	"github.com/elastic/beats/v7/libbeat/feature"
 	"github.com/elastic/beats/v7/libbeat/statestore"
-	"github.com/elastic/beats/v7/libbeat/statestore/backend"
 	"github.com/elastic/beats/v7/libbeat/statestore/storetest"
 	"github.com/elastic/beats/v7/x-pack/filebeat/input/cel"
 	conf "github.com/elastic/elastic-agent-libs/config"
@@ -441,7 +438,7 @@ func TestConvertHttpjsonToCel(t *testing.T) {
 	})
 
 	t.Run("realistic_full_config", func(t *testing.T) {
-		cfg := conf.MustNewConfigFrom(map[string]any{
+		cfg := conf.MustNewConfigFrom(map[string]any{ //nolint:gosec // dummy credentials in a test fixture
 			"type":        "httpjson",
 			"id":          "okta-system-log",
 			"interval":    "120s",
@@ -576,7 +573,7 @@ state.url.with({
 func TestMigrateCursor(t *testing.T) {
 	t.Run("injects_stored_cursor", func(t *testing.T) {
 		store := newTestStore()
-		s, err := store.StoreFor("httpjson")
+		s, err := store.StoreFor("httpjson", "")
 		require.NoError(t, err)
 		err = s.Set("httpjson::my-input::https://api.example.com/events", map[string]any{
 			"ttl":     0,
@@ -628,7 +625,7 @@ func TestMigrateCursor(t *testing.T) {
 
 	t.Run("no_id", func(t *testing.T) {
 		store := newTestStore()
-		s, err := store.StoreFor("httpjson")
+		s, err := store.StoreFor("httpjson", "")
 		require.NoError(t, err)
 		err = s.Set("httpjson::https://api.example.com/events", map[string]any{
 			"ttl":     0,
@@ -658,7 +655,7 @@ func TestMigrateCursor(t *testing.T) {
 
 	t.Run("no_state_in_config", func(t *testing.T) {
 		store := newTestStore()
-		s, err := store.StoreFor("httpjson")
+		s, err := store.StoreFor("httpjson", "")
 		require.NoError(t, err)
 		err = s.Set("httpjson::no-state::https://api.example.com/events", map[string]any{
 			"ttl":     0,
@@ -688,7 +685,7 @@ func TestMigrateCursor(t *testing.T) {
 
 	t.Run("idempotent", func(t *testing.T) {
 		store := newTestStore()
-		s, err := store.StoreFor("httpjson")
+		s, err := store.StoreFor("httpjson", "")
 		require.NoError(t, err)
 		err = s.Set("httpjson::idem::https://api.example.com/events", map[string]any{
 			"ttl":     0,
@@ -722,20 +719,20 @@ func TestMigrateCursor(t *testing.T) {
 		require.Equal(t, v1, v2)
 	})
 
-	t.Run("set_id_scoped_store", func(t *testing.T) {
-		// Simulate an Elasticsearch-backed store where SetID routes to a different
-		// index. The cursor was previously written under the "my-input" namespace;
-		// migrateCursor must call SetID so it reads from the right partition.
-		b := newNamespacedMemBackend()
-		b.partitions["my-input"] = map[string]any{
-			"httpjson::my-input::https://api.example.com/events": map[string]any{
-				"ttl":     0,
-				"updated": time.Now(),
-				"cursor":  map[string]any{"timestamp": "2025-06-15T10:30:00Z"},
-			},
-		}
-
-		store := newNamespacedTestStore(b)
+	t.Run("id_scoped_store", func(t *testing.T) {
+		// Elasticsearch uses one index per input ID.
+		// migrateCursor must select the store for "my-input" to find its cursor.
+		store := &namespacedTestStore{testStore: newTestStore()}
+		t.Cleanup(store.Close)
+		s, err := store.StoreFor("httpjson", "my-input")
+		require.NoError(t, err, "open the store for my-input")
+		defer s.Close()
+		err = s.Set("httpjson::my-input::https://api.example.com/events", map[string]any{
+			"ttl":     0,
+			"updated": time.Now(),
+			"cursor":  map[string]any{"timestamp": "2025-06-15T10:30:00Z"},
+		})
+		require.NoError(t, err, "save the cursor for my-input")
 		mgr := NewInputManager(logp.NewNopLogger(), store)
 		cfg := conf.MustNewConfigFrom(map[string]any{
 			"type":        "httpjson",
@@ -748,11 +745,11 @@ func TestMigrateCursor(t *testing.T) {
 		})
 
 		_, newCfg, err := mgr.Redirect(cfg)
-		require.NoError(t, err)
+		require.NoError(t, err, "redirect httpjson to CEL")
 
 		v, err := newCfg.String("state.cursor.timestamp", -1)
-		require.NoError(t, err)
-		require.Equal(t, "2025-06-15T10:30:00Z", v)
+		require.NoError(t, err, "read the migrated cursor")
+		require.Equal(t, "2025-06-15T10:30:00Z", v, "use the cursor from the store for my-input")
 	})
 }
 
@@ -774,149 +771,25 @@ func newTestStore() *testStore {
 	}
 }
 
-func (s *testStore) Close()                                     { s.registry.Close() }
-func (s *testStore) StoreFor(string) (*statestore.Store, error) { return s.registry.Get("filebeat") }
-func (s *testStore) StoreKey() string                           { return fmt.Sprintf("test:%p", s.registry) }
-func (s *testStore) CleanupInterval() time.Duration             { return 0 }
-
-// namespacedMemBackend is a backend.Registry whose stores partition keys by
-// namespace, simulating the Elasticsearch state store where SetID routes
-// operations to a different index.
-type namespacedMemBackend struct {
-	mu         sync.Mutex
-	partitions map[string]map[string]any
+func (s *testStore) Close() { s.registry.Close() }
+func (s *testStore) StoreFor(_, _ string) (*statestore.Store, error) {
+	return s.registry.Get("filebeat")
 }
-
-// newNamespacedMemBackend returns an empty namespacedMemBackend.
-func newNamespacedMemBackend() *namespacedMemBackend {
-	return &namespacedMemBackend{partitions: make(map[string]map[string]any)}
-}
-
-// Access returns a new namespacedMemStore sharing the back end's partition map.
-// The store family name is ignored; it selects which backing store to open,
-// but we are a singleton in this setting.
-func (b *namespacedMemBackend) Access(string) (backend.Store, error) {
-	return &namespacedMemStore{b: b}, nil
-}
-
-// Close is a no-op.
-func (b *namespacedMemBackend) Close() error { return nil }
-
-// namespacedMemStore is a backend.Store that routes all key operations to the
-// partition currently selected by SetID. The default namespace (before any
-// SetID call) is the empty string. ns is protected by b.mu.
-type namespacedMemStore struct {
-	b  *namespacedMemBackend
-	ns string
-}
-
-// SetID sets the active namespace; all subsequent key operations target that
-// partition, mirroring how the Elasticsearch back end switches index on SetID.
-func (s *namespacedMemStore) SetID(id string) {
-	s.b.mu.Lock()
-	s.ns = id
-	s.b.mu.Unlock()
-}
-
-// Has reports whether key exists in the current namespace's partition.
-func (s *namespacedMemStore) Has(key string) (bool, error) {
-	s.b.mu.Lock()
-	_, ok := s.b.partitions[s.ns][key]
-	s.b.mu.Unlock()
-	return ok, nil
-}
-
-// Get decodes the value stored under key in the current namespace into value
-// via a JSON round-trip.
-func (s *namespacedMemStore) Get(key string, val any) error {
-	s.b.mu.Lock()
-	v, ok := s.b.partitions[s.ns][key]
-	s.b.mu.Unlock()
-	if !ok {
-		return fmt.Errorf("key not found: %s", key)
-	}
-	buf, err := json.Marshal(v)
-	if err != nil {
-		return err
-	}
-	return json.Unmarshal(buf, val)
-}
-
-// Set stores value under key in the current namespace's partition, creating
-// the partition if it does not yet exist.
-func (s *namespacedMemStore) Set(key string, val any) error {
-	s.b.mu.Lock()
-	if s.b.partitions[s.ns] == nil {
-		s.b.partitions[s.ns] = make(map[string]any)
-	}
-	s.b.partitions[s.ns][key] = val
-	s.b.mu.Unlock()
-	return nil
-}
-
-// Remove deletes key from the current namespace's partition.
-func (s *namespacedMemStore) Remove(key string) error {
-	s.b.mu.Lock()
-	delete(s.b.partitions[s.ns], key)
-	s.b.mu.Unlock()
-	return nil
-}
-
-// Each snapshots the current namespace's partition under the lock, then
-// iterates over the snapshot without holding the lock, calling fn for each
-// key-value pair. Iteration stops when fn returns false or a non-nil error.
-func (s *namespacedMemStore) Each(fn func(string, backend.ValueDecoder) (bool, error)) error {
-	s.b.mu.Lock()
-	p := s.b.partitions[s.ns]
-	keys := make([]string, 0, len(p))
-	vals := make([]any, 0, len(p))
-	for k, v := range p {
-		keys = append(keys, k)
-		vals = append(vals, v)
-	}
-	s.b.mu.Unlock()
-	for i, k := range keys {
-		cont, err := fn(k, jsonValueDecoder{vals[i]})
-		if err != nil || !cont {
-			return err
-		}
-	}
-	return nil
-}
-
-// Close is a no-op; the store holds no resources beyond the shared backend.
-func (s *namespacedMemStore) Close() error { return nil }
-
-// jsonValueDecoder implements backend.ValueDecoder via a JSON round-trip,
-// allowing arbitrary in-memory values to be decoded into typed targets.
-type jsonValueDecoder struct{ v any }
-
-// Decode marshals the held value to JSON and unmarshals it into to.
-func (d jsonValueDecoder) Decode(dst any) error {
-	buf, err := json.Marshal(d.v)
-	if err != nil {
-		return err
-	}
-	return json.Unmarshal(buf, dst)
-}
+func (s *testStore) StoreKey(_, _ string) string    { return fmt.Sprintf("test:%p", s.registry) }
+func (s *testStore) CleanupInterval() time.Duration { return 0 }
 
 var _ statestore.States = (*namespacedTestStore)(nil)
 
-// namespacedTestStore implements statestore.States backed by a
-// namespacedMemBackend, for use in tests that require SetID-aware storage.
+// namespacedTestStore uses a separate store for each input ID.
 type namespacedTestStore struct {
-	registry *statestore.Registry
+	*testStore
 }
 
-// newNamespacedTestStore returns a namespacedTestStore backed by b.
-func newNamespacedTestStore(b *namespacedMemBackend) *namespacedTestStore {
-	return &namespacedTestStore{registry: statestore.NewRegistry(b)}
+// StoreFor returns the store for the input ID.
+func (s *namespacedTestStore) StoreFor(_, id string) (*statestore.Store, error) {
+	return s.registry.Get(id)
 }
 
-// StoreFor returns the shared "filebeat" store from the underlying registry.
-func (s *namespacedTestStore) StoreFor(_ string) (*statestore.Store, error) {
-	return s.registry.Get("filebeat")
+func (s *namespacedTestStore) StoreKey(_, id string) string {
+	return fmt.Sprintf("namespaced:%p::%s", s.registry, id)
 }
-
-func (s *namespacedTestStore) StoreKey() string               { return fmt.Sprintf("namespaced:%p", s.registry) }
-func (s *namespacedTestStore) CleanupInterval() time.Duration { return 0 }

--- a/x-pack/filebeat/input/salesforce/input_manager_test.go
+++ b/x-pack/filebeat/input/salesforce/input_manager_test.go
@@ -36,10 +36,10 @@ var _ statestore.States = stateStore{}
 
 type stateStore struct{}
 
-func (stateStore) StoreFor(string) (*statestore.Store, error) {
+func (stateStore) StoreFor(_, _ string) (*statestore.Store, error) {
 	return makeTestStore(map[string]any{"hello": "world"}), nil
 }
-func (stateStore) StoreKey() string               { return "salesforce-test-store" }
+func (stateStore) StoreKey(_, _ string) string    { return "salesforce-test-store" }
 func (stateStore) CleanupInterval() time.Duration { return time.Duration(0) }
 
 func TestInputManager(t *testing.T) {

--- a/x-pack/filebeat/tests/integration/otel_test.go
+++ b/x-pack/filebeat/tests/integration/otel_test.go
@@ -1572,73 +1572,68 @@ service:
 		"receivers must have different diskqueue paths")
 }
 
-func TestFilebeatOTelHTTPJSONInputWithElasticStateStore(t *testing.T) {
+func TestFilebeatOTelHTTPJSONStateStoreIsPerInputID(t *testing.T) {
 	integration.EnsureESIsRunning(t)
 
-	// Enable ES state store for httpjson and cel input types.
-	// Reload must be called to apply the change since the features package
-	// reads the env var only once at init() time.
-	t.Cleanup(func() { features.ReinitForTest() }) // restore after test. We call cleanup before setting env because cleanups are called in last added first called order.
+	// Register the cleanup before Setenv so the flags are reloaded after the
+	// env var is restored.
+	t.Cleanup(func() { features.ReinitForTest() })
 	t.Setenv("AGENTLESS_ELASTICSEARCH_STATE_STORE_INPUT_TYPES", "httpjson,cel")
 	features.ReinitForTest()
 
-	// Mock HTTP server for httpjson input: tracks request count and returns
-	// a JSON response with a published timestamp that the cursor tracks.
-	var requestCount atomic.Int64
-	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		requestCount.Add(1)
+	// Fixed publication time, so a poll reveals where the input started.
+	const cursorTime = "2026-01-01T00:00:00Z"
 
-		published := parseParams(t, r.RequestURI)
+	// Each input polls its own path so requests can be attributed to it.
+	var mu sync.Mutex
+	sinceByInput := map[string][]string{}
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		id := strings.TrimPrefix(r.URL.Path, "/")
+		sinceByInput[id] = append(sinceByInput[id], parseParams(t, r.RequestURI).Format(time.RFC3339))
+		mu.Unlock()
+
 		w.Header().Set("Content-Type", "application/json")
-		err := json.NewEncoder(w).Encode(response{
-			Message:   "Hello",
-			Published: published.Format(time.RFC3339),
-		})
+		err := json.NewEncoder(w).Encode(response{Message: "Hello", Published: cursorTime})
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
 	}))
 	defer testServer.Close()
 
-	host := integration.GetESURL(t, "http")
-	user := host.User.Username()
-	password, _ := host.User.Password()
-	esURL := fmt.Sprintf("%s://%s", host.Scheme, host.Host)
-
-	namespace := strings.ReplaceAll(uuid.Must(uuid.NewV4()).String(), "-", "")
-	dataIndex := "logs-integration-" + namespace
-	inputID := "httpjson-otel-esstore-" + strings.ReplaceAll(uuid.Must(uuid.NewV4()).String(), "-", "")
-	pathHome := t.TempDir()
-
-	type configParams struct {
-		ESURL     string
-		Username  string
-		Password  string
-		DataIndex string
-		InputURL  string
-		InputID   string
-		PathHome  string
+	sinceValues := func(id string) []string {
+		mu.Lock()
+		defer mu.Unlock()
+		return slices.Clone(sinceByInput[id])
 	}
 
-	params := configParams{
-		ESURL:     esURL,
-		Username:  user,
-		Password:  password,
-		DataIndex: dataIndex,
-		InputURL:  testServer.URL,
-		InputID:   inputID,
-		PathHome:  pathHome,
+	host := integration.GetESURL(t, "http")
+	password, _ := host.User.Password()
+	suffix := strings.ReplaceAll(uuid.Must(uuid.NewV4()).String(), "-", "")
+
+	params := struct {
+		ESURL, Username, Password, InputURL, PathHome string
+		InputIDs                                      []string
+	}{
+		ESURL:    fmt.Sprintf("%s://%s", host.Scheme, host.Host),
+		Username: host.User.Username(),
+		Password: password,
+		InputURL: testServer.URL,
+		// One path.home, so both receivers resolve to the same shared registry.
+		PathHome: t.TempDir(),
+		InputIDs: []string{"httpjson-a-" + suffix, "httpjson-b-" + suffix},
 	}
 
 	configTemplate := `receivers:
-  filebeatreceiver:
+{{- range $id := .InputIDs }}
+  filebeatreceiver/{{ $id }}:
     filebeat:
       inputs:
         - type: httpjson
-          id: {{ .InputID }}
+          id: {{ $id }}
           enabled: true
-          interval: 5s
-          request.url: {{ .InputURL }}
+          interval: 1s
+          request.url: {{ $.InputURL }}/{{ $id }}
           request.method: GET
           request.transforms:
             - set:
@@ -1651,7 +1646,8 @@ func TestFilebeatOTelHTTPJSONInputWithElasticStateStore(t *testing.T) {
     queue.mem.flush.timeout: 0s
     setup.template.enabled: false
     storage: elasticsearch_storage
-    path.home: {{ .PathHome }}
+    path.home: {{ $.PathHome }}
+{{- end }}
 extensions:
   elasticsearch_storage:
     hosts:
@@ -1659,98 +1655,107 @@ extensions:
     username: {{ .Username }}
     password: {{ .Password }}
 exporters:
-  elasticsearch/log:
-    endpoints:
-      - {{ .ESURL }}
-    compression: none
-    user: {{ .Username }}
-    password: {{ .Password }}
-    logs_index: {{ .DataIndex }}
-    sending_queue:
-      enabled: true
-      batch:
-        flush_timeout: 1s
+  debug:
 service:
   extensions:
     - elasticsearch_storage
   pipelines:
     logs:
       receivers:
-        - filebeatreceiver
+{{- range $id := .InputIDs }}
+        - filebeatreceiver/{{ $id }}
+{{- end }}
       exporters:
-        - elasticsearch/log
+        - debug
   telemetry:
     logs:
       level: DEBUG
 `
 
-	var configBuffer bytes.Buffer
-	require.NoError(t, template.Must(template.New("config").Parse(configTemplate)).Execute(&configBuffer, params))
-	configStr := configBuffer.String()
+	configStr := renderOtelConfig(t, configTemplate, params)
+	es := esapi.New(integration.GetESClient(t, "http"))
 
-	t.Cleanup(func() {
-		if t.Failed() {
-			t.Logf("Config:\n%s", configStr)
+	// Each input's index must hold its own cursor, at the published time the
+	// server reports, and nothing else. Wait for the value as the key appears
+	// at input start before any event is acknowledged and the cursor saved.
+	wantCursors := map[string]map[string]string{}
+	for _, id := range params.InputIDs {
+		wantCursors[id] = map[string]string{
+			"httpjson::" + id + "::" + params.InputURL + "/" + id: cursorTime,
 		}
-	})
+	}
+	requireOwnCursorOnly := func() {
+		t.Helper()
+		require.EventuallyWithT(t, func(ct *assert.CollectT) {
+			for _, id := range params.InputIDs {
+				assert.Equalf(ct, wantCursors[id],
+					stateStoreCursors(t.Context(), ct, es, "agentless-state-"+id),
+					"agentless-state-%s must hold exactly its own input's cursor", id)
+			}
+		}, time.Minute, time.Second)
+	}
 
-	// Start first collector
 	collector := oteltestcol.New(t, configStr)
+	requireOwnCursorOnly()
 
-	es := integration.GetESClient(t, "http")
-
-	// Wait for data to arrive in ES
-	require.EventuallyWithTf(t,
-		func(ct *assert.CollectT) {
-			findCtx, findCancel := context.WithTimeout(context.Background(), 10*time.Second)
-			defer findCancel()
-
-			docs, err := estools.GetAllLogsForIndexWithContext(findCtx, es, ".ds-"+dataIndex+"*")
-			assert.NoError(ct, err)
-			assert.GreaterOrEqual(ct, docs.Hits.Total.Value, 1, "expected at least 1 event, got %d", docs.Hits.Total.Value)
-		},
-		2*time.Minute, 1*time.Second, "expected at least 1 event in data index")
-
-	// Verify openStore was called for httpjson input
-	require.Eventually(t, func() bool {
-		return collector.ObservedLogs().FilterMessageSnippet(
-			"input-cursor::openStore: prefix: httpjson inputID: "+inputID,
-		).Len() >= 1
-	}, 30*time.Second, 100*time.Millisecond, "expected openStore log for httpjson input")
-
-	// Verify initial store read found 0 keys (first run, no previous state in ES)
-	require.Eventually(t, func() bool {
-		return collector.ObservedLogs().FilterMessageSnippet(
-			"input-cursor store read 0 keys",
-		).Len() >= 1
-	}, 30*time.Second, 100*time.Millisecond, "expected initial store read with 0 keys")
-
-	// Wait for at least 2 polling cycles to ensure cursor is persisted to ES
-	require.Eventually(t, func() bool {
-		return requestCount.Load() >= 2
-	}, 60*time.Second, 1*time.Second, "expected at least 2 httpjson poll cycles before restart")
-
-	// Shut down first collector
+	pollsBeforeRestart := map[string]int{}
+	for _, id := range params.InputIDs {
+		pollsBeforeRestart[id] = len(sinceValues(id))
+	}
 	collector.Shutdown()
 
-	// Verify data continues to arrive after restart
-	requestCountBeforeRestart := requestCount.Load()
+	oteltestcol.New(t, configStr)
 
-	// Start second collector with the same config
-	collector2 := oteltestcol.New(t, configStr)
-	t.Cleanup(collector2.Shutdown)
+	// Every input must resume from its own stored cursor.
+	for _, id := range params.InputIDs {
+		require.EventuallyWithTf(t, func(ct *assert.CollectT) {
+			since := sinceValues(id)
+			if !assert.Greater(ct, len(since), pollsBeforeRestart[id]) {
+				return
+			}
+			assert.Equal(ct, cursorTime, since[pollsBeforeRestart[id]])
+		}, time.Minute, time.Second, "input %s must resume from its stored cursor after the restart", id)
+	}
+	requireOwnCursorOnly()
+}
 
-	// Verify cursor was restored from ES: the store should now read 1 key
-	require.Eventually(t, func() bool {
-		return collector2.ObservedLogs().FilterMessageSnippet(
-			"input-cursor store read 1 keys",
-		).Len() >= 1
-	}, 60*time.Second, 100*time.Millisecond,
-		"expected store to read 1 key after restart, proving cursor was restored from ES")
+// stateStoreCursors maps each document id in an agentless state index to the
+// publication time stored in its cursor.
+func stateStoreCursors(ctx context.Context, ct *assert.CollectT, es *esapi.API, index string) map[string]string {
+	res, err := es.Search(
+		es.Search.WithIndex(index),
+		es.Search.WithSize(100),
+		es.Search.WithContext(ctx),
+	)
+	if !assert.NoError(ct, err) {
+		return nil
+	}
+	defer res.Body.Close()
+	if !assert.Falsef(ct, res.IsError(), "search %s: %s", index, res.Status()) {
+		return nil
+	}
 
-	require.Eventually(t, func() bool {
-		return requestCount.Load() > requestCountBeforeRestart
-	}, 60*time.Second, 1*time.Second, "expected httpjson to continue polling after restart")
+	var result struct {
+		Hits struct {
+			Hits []struct {
+				ID     string `json:"_id"`
+				Source struct {
+					V struct {
+						Cursor struct {
+							Published string `json:"published"`
+						} `json:"cursor"`
+					} `json:"v"`
+				} `json:"_source"`
+			} `json:"hits"`
+		} `json:"hits"`
+	}
+	assert.NoError(ct, json.NewDecoder(res.Body).Decode(&result))
+
+	cursors := make(map[string]string, len(result.Hits.Hits))
+	for _, h := range result.Hits.Hits {
+		cursors[h.ID] = h.Source.V.Cursor.Published
+	}
+	return cursors
 }
 
 func BenchmarkFilebeatOTelCollector(b *testing.B) {

--- a/x-pack/otel/extension/elasticsearchstorage/extension.go
+++ b/x-pack/otel/extension/elasticsearchstorage/extension.go
@@ -118,9 +118,3 @@ func (s *lockedStore) Each(fn func(string, backend.ValueDecoder) (bool, error)) 
 	defer s.mu.Unlock()
 	return s.inner.Each(fn)
 }
-
-func (s *lockedStore) SetID(id string) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.inner.SetID(id)
-}


### PR DESCRIPTION
## Proposed commit message

```
statestore: scope the Elasticsearch state store by input id

The Elasticsearch state store can send several inputs to the same index.
When inputs share the wrong index, a restart can cause them to read an
old cursor or find no cursor and collect old data again.

The first input that opens the store selects its index through
Store.SetID. Later inputs reuse that store, even when their IDs differ.
InputManager keeps one store for all Create calls.

Use the input ID as the Elasticsearch store name. The backend already
uses this name to select agentless-state-<input id>. InputManager keeps
a reference to each store that its inputs use.

Index names and document keys stay the same. After the upgrade, an input
whose state is in another input's index can collect old data once more.
Later restarts use its own index.
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

The index name remains `agentless-state-<input id>`, and the document key remains `<type>::<input id>::<source>`. The change determines which inputs use each index. Inputs without an `id` continue to use `agentless-state-<beat>`.

| Before the upgrade | Location of the saved cursor | After the upgrade |
| --- | --- | --- |
| One input per type per Beat or receiver, with a separate `path.data` | Its own index | The input resumes from the same cursor. |
| An input without an `id` | `agentless-state-<beat>` | The input uses the same index. |
| Several inputs of one type, with this input opening the store first | Its own index | The input resumes from the same cursor. |
| Several inputs of one type, with another input opening the store first | The first input's index, under `<type>::<own id>::…` | The input opens its own index, which can contain an old cursor or no cursor. Leads to re-ingestion. |
| Inputs that use memlog or otel file storage | `<path.data>/registry/filebeat` | Unafected. |

This change does not move cursors between indices. An affected input cannot locate its previous cursor without a search across `agentless-state-*`. That requires migration code specific to Elasticsearch. Before this fix, a change in startup order can cause the same problem on each restart.

Receivers that share `path.data` now use one store and one cleanup goroutine per input ID, rather than one for all of them. The `elasticsearch_storage` extension still shares a single connection across stores, so agentless opens no extra connections.

## How to test this PR locally

`TestFilebeatOTelHTTPJSONStateStoreIsPerInputID` runs two receivers that share one `path.data`, each with one `httpjson` input, and asserts that each input's index holds only its own cursor.

```sh
# needs a local Elasticsearch on localhost:9200
go test -tags integration -count=1 ./x-pack/filebeat/tests/integration/ \
  -run TestFilebeatOTelHTTPJSONStateStoreIsPerInputID
```

On `main` it fails because both cursors land in the index of whichever input opened the store first:

```
expected: ["httpjson::httpjson-a-<suffix>::<url>"]
actual  : ["httpjson::httpjson-a-<suffix>::<url>", "httpjson::httpjson-b-<suffix>::<url>"]
```

Unit tests:

```sh
go test -race -count=1 ./filebeat/input/v2/input-cursor/... ./filebeat/beater/... ./libbeat/statestore/... \
  ./filebeat/input/filestream/internal/input-logfile/... ./x-pack/filebeat/input/httpjson/... \
  ./x-pack/filebeat/input/entityanalytics/... ./filebeat/registrar/... ./x-pack/otel/extension/elasticsearchstorage/...
```

## Related issues

- Closes #53034
